### PR TITLE
fix: enforce safe buffered response body defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ async with foghttp.AsyncClient() as client:
 - async request cancellation that aborts the in-flight Rust request
 - global and per-origin request backpressure, basic stats, and HTTP/1.1 over
   HTTP/HTTPS
-- optional buffered response body size limit for memory safety
+- default buffered response body size limit for memory safety
 - advanced per-client Tokio runtime worker tuning
 - grouped HTTP status constants and reusable HTTP method constants
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - documented buffered timeout model with pool and total deadline behavior
 - global active request limits, per-origin active request limits, pending
   acquire limits, and basic stats
-- optional buffered response body size limit
+- default buffered response body size limit
 - grouped HTTP status constants and reusable HTTP method constants
 
 ## Not Yet

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -29,7 +29,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - async request cancellation that aborts the in-flight Rust request
 - global active request limit, per-origin active request limit, pending acquire
   limit, and basic request stats
-- optional `max_response_body_size` limit for buffered response memory safety
+- default `max_response_body_size` limit for buffered response memory safety
 - explicit `close()`/`aclose()` lifecycle for Rust runtime and pool resources;
   sync `close()` waits for in-flight sync requests, while async `aclose()`
   cancels in-flight async requests; see [Client lifecycle](./lifecycle.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -352,10 +352,11 @@ base `TimeoutError` when it expires.
 `Limits.max_active_requests_per_origin` defaults to `None`; set it to cap active
 buffered requests for one normalized origin. `Limits.max_pending_requests` caps
 requests waiting for a free acquire permit. `Limits.max_response_body_size`
-defaults to `None`; set it to fail safely when a buffered response body grows
-beyond the configured byte limit. `Limits.max_idle_connections_per_host` controls
-idle keep-alive pool capacity; it is not an active request limit and is separate
-from per-origin request backpressure.
+defaults to `10 * 1024 * 1024` bytes. Set a smaller or larger explicit limit for
+your workload, or pass `None` only when unbounded buffered response bodies are an
+intentional opt-in. `Limits.max_idle_connections_per_host` controls idle
+keep-alive pool capacity; it is not an active request limit and is separate from
+per-origin request backpressure.
 
 `Timeouts.connect` is client-level connector configuration. Per-request
 `timeout=` currently affects `pool` and `total`, not `connect`, `read`, or

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -119,10 +119,13 @@ request path. Today it wraps:
 
 - waiting for the acquire gate, together with `pool`
 - waiting for response headers for the current hop
+- collecting the buffered response body for the current hop
 - redirect hops as one shared budget
 
 If `total` expires while the request is waiting for a pool slot, `total` wins
-and FogHTTP raises the base `TimeoutError`, not `PoolTimeout`.
+and FogHTTP raises the base `TimeoutError`, not `PoolTimeout`. The same base
+`TimeoutError` is raised when the shared total budget expires while reading the
+buffered response body.
 
 ```python
 with foghttp.Client(timeouts=foghttp.Timeouts(pool=1.0, total=0.05)) as client:
@@ -132,11 +135,10 @@ with foghttp.Client(timeouts=foghttp.Timeouts(pool=1.0, total=0.05)) as client:
         pass
 ```
 
-`total` is not a mature response body read timeout yet. The current buffered
-client still lacks separate read and write timeout semantics, so do not use
-`total` as a strict wall-clock guarantee for slow response bodies. For async
-callers that need a hard application-level budget today, wrap the call in
-`asyncio.timeout()`; cancellation aborts the in-flight Rust request.
+`total` is a shared wall-clock budget, not a separate per-chunk read timeout.
+For async callers that need an additional application-level budget, wrapping the
+call in `asyncio.timeout()` is still fine; cancellation aborts the in-flight Rust
+request.
 
 ```python
 import asyncio
@@ -186,8 +188,27 @@ They do not yet provide:
 - dedicated `ReadTimeout` or write-specific exceptions
 
 These fields will become meaningful with the streaming response/upload work.
-Until then, use `Limits.max_response_body_size` to bound buffered response
-memory and application-level cancellation for async deadlines.
+Until then, use `Timeouts.total` as the shared buffered request deadline and
+`Limits.max_response_body_size` to bound buffered response memory.
+
+## Buffered Body Limit
+
+FogHTTP is buffered today, so responses are collected into memory before the
+`Response` object is returned. To keep that safe by default,
+`Limits.max_response_body_size` defaults to `10 * 1024 * 1024` bytes.
+
+```python
+limits = foghttp.Limits(max_response_body_size=2 * 1024 * 1024)
+```
+
+Passing `None` is an explicit opt-in to unbounded buffering:
+
+```python
+limits = foghttp.Limits(max_response_body_size=None)
+```
+
+Use that only for controlled endpoints where another layer already enforces a
+safe body size. Large downloads should wait for streaming responses.
 
 ## Practical Defaults
 
@@ -207,4 +228,4 @@ Tune from there:
 - raise `pool` when short bursts should wait for capacity
 - keep `total` larger than the expected upstream response time
 - use a separate client when an upstream needs a different `connect` timeout
-- avoid large or unknown response bodies until streaming/read timeouts land
+- keep `max_response_body_size` finite unless unbounded buffering is deliberate

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -219,8 +219,8 @@ except foghttp.HTTPStatusError as exc:
 | Proxy and `trust_env` | Not implemented |
 | HTTP/2 | Not implemented |
 | Cookie jar and auth helper integration | Not implemented; cross-origin redirects still strip sensitive headers and drop body replay |
-| Unbounded large downloads | Use `max_response_body_size` for buffered fail-fast protection; streaming downloads are not implemented |
+| Unbounded large downloads | `max_response_body_size` defaults to 10 MiB for buffered fail-fast protection; streaming downloads are not implemented |
 
 FogHTTP is best today in controlled environments where request and response
-bodies are expected to fit in memory or where `max_response_body_size` can
-bound buffered response memory usage.
+bodies are expected to fit in memory. Keep `max_response_body_size` finite unless
+unbounded buffering is a deliberate opt-in for a trusted endpoint.

--- a/foghttp/limits.py
+++ b/foghttp/limits.py
@@ -1,4 +1,4 @@
-__all__ = ("Limits",)
+__all__ = ("DEFAULT_MAX_RESPONSE_BODY_SIZE", "Limits")
 
 from dataclasses import dataclass
 
@@ -9,12 +9,15 @@ from ._validation.numeric import (
 )
 
 
+DEFAULT_MAX_RESPONSE_BODY_SIZE = 10 * 1024 * 1024
+
+
 @dataclass(frozen=True, slots=True)
 class Limits:
     max_active_requests: int = 100
     max_active_requests_per_origin: int | None = None
     max_pending_requests: int = 1000
-    max_response_body_size: int | None = None
+    max_response_body_size: int | None = DEFAULT_MAX_RESPONSE_BODY_SIZE
     max_idle_connections_per_host: int = 20
     idle_timeout: float = 30.0
     keepalive: bool = True

--- a/src/py/client/transport.rs
+++ b/src/py/client/transport.rs
@@ -62,6 +62,7 @@ pub async fn send_request(
                 response,
                 request_info,
                 started,
+                state.total_timeout,
                 state.max_response_body_size,
             )
             .await?
@@ -167,12 +168,18 @@ async fn raw_response(
     response: Response<Incoming>,
     request: RawRequestInfo,
     started: Instant,
+    total_timeout: f64,
     max_response_body_size: Option<usize>,
 ) -> PyResult<RawResponse> {
     let status_code = response.status().as_u16();
     let http_version = format!("{:?}", response.version());
     let headers = response_headers(response.headers());
-    let content = collect_body(response.into_body(), max_response_body_size).await?;
+    let content = tokio::time::timeout(
+        remaining_duration(total_timeout, started)?,
+        collect_body(response.into_body(), max_response_body_size),
+    )
+    .await
+    .map_err(|_| FogHttpTimeoutError::new_err(REQUEST_TOTAL_TIMEOUT))??;
     let url = request.url.clone();
 
     Ok(RawResponse {

--- a/tests/client_options/test_numeric_validation.py
+++ b/tests/client_options/test_numeric_validation.py
@@ -3,6 +3,7 @@ import math
 import pytest
 
 import foghttp
+from foghttp.limits import DEFAULT_MAX_RESPONSE_BODY_SIZE
 
 
 MAX_INVALID_NUMERIC_OPTION = 2**31
@@ -15,6 +16,10 @@ INTEGER_LIMIT_FIELDS = (
     "max_response_body_size",
     "max_idle_connections_per_host",
 )
+
+
+def test_limits_use_safe_default_response_body_size() -> None:
+    assert foghttp.Limits().max_response_body_size == DEFAULT_MAX_RESPONSE_BODY_SIZE
 
 
 @pytest.mark.parametrize("field_name", TIMEOUT_FIELDS)

--- a/tests/client_resources/test_async_response_body_limits.py
+++ b/tests/client_resources/test_async_response_body_limits.py
@@ -2,6 +2,11 @@ import pytest
 
 import foghttp
 from foghttp.status_codes.success import OK
+from tests.http_body_scenarios import (
+    INCOMPLETE_CHUNKED_BODY_PATH,
+    SLOW_BODY_PATH,
+    TOO_LARGE_SIZE_HINT_PATH,
+)
 
 from .constants import (
     BODY_BELOW_LIMIT_SIZE,
@@ -66,6 +71,58 @@ async def test_async_buffered_response_body_limit_error_releases_request_slot(
     assert final_stats.failed_requests == 1
     assert final_stats.active_requests == 0
     assert final_stats.pending_requests == 0
+
+
+async def test_async_default_response_body_limit_rejects_large_size_hint(
+    http_server: str,
+) -> None:
+    async with foghttp.AsyncClient() as client:
+        with pytest.raises(
+            foghttp.ResponseBodyTooLargeError,
+            match="response body exceeded max_response_body_size",
+        ):
+            await client.get(f"{http_server}{TOO_LARGE_SIZE_HINT_PATH}")
+
+        stats_after_error = client.stats()
+
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0
+
+
+async def test_async_total_timeout_applies_to_slow_response_body(
+    http_server: str,
+) -> None:
+    timeouts = foghttp.Timeouts(total=0.05)
+
+    async with foghttp.AsyncClient(timeouts=timeouts) as client:
+        with pytest.raises(foghttp.TimeoutError, match="request total timeout expired"):
+            await client.get(f"{http_server}{SLOW_BODY_PATH}")
+
+        stats_after_error = client.stats()
+
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0
+
+
+async def test_async_total_timeout_applies_to_incomplete_chunked_response_body(
+    http_server: str,
+) -> None:
+    timeouts = foghttp.Timeouts(total=0.05)
+
+    async with foghttp.AsyncClient(timeouts=timeouts) as client:
+        with pytest.raises(foghttp.TimeoutError, match="request total timeout expired"):
+            await client.get(f"{http_server}{INCOMPLETE_CHUNKED_BODY_PATH}")
+
+        stats_after_error = client.stats()
+
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0
 
 
 async def test_async_buffered_response_body_limit_error_without_known_size_releases_request_slot(

--- a/tests/client_resources/test_sync_response_body_limits.py
+++ b/tests/client_resources/test_sync_response_body_limits.py
@@ -2,6 +2,11 @@ import pytest
 
 import foghttp
 from foghttp.status_codes.success import OK
+from tests.http_body_scenarios import (
+    INCOMPLETE_CHUNKED_BODY_PATH,
+    SLOW_BODY_PATH,
+    TOO_LARGE_SIZE_HINT_PATH,
+)
 
 from .constants import (
     BODY_BELOW_LIMIT_SIZE,
@@ -66,6 +71,58 @@ def test_sync_buffered_response_body_limit_error_releases_request_slot(
     assert final_stats.failed_requests == 1
     assert final_stats.active_requests == 0
     assert final_stats.pending_requests == 0
+
+
+def test_sync_default_response_body_limit_rejects_large_size_hint(
+    sync_http_server: str,
+) -> None:
+    with foghttp.Client() as client:
+        with pytest.raises(
+            foghttp.ResponseBodyTooLargeError,
+            match="response body exceeded max_response_body_size",
+        ):
+            client.get(f"{sync_http_server}{TOO_LARGE_SIZE_HINT_PATH}")
+
+        stats_after_error = client.stats()
+
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0
+
+
+def test_sync_total_timeout_applies_to_slow_response_body(
+    sync_http_server: str,
+) -> None:
+    timeouts = foghttp.Timeouts(total=0.05)
+
+    with foghttp.Client(timeouts=timeouts) as client:
+        with pytest.raises(foghttp.TimeoutError, match="request total timeout expired"):
+            client.get(f"{sync_http_server}{SLOW_BODY_PATH}")
+
+        stats_after_error = client.stats()
+
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0
+
+
+def test_sync_total_timeout_applies_to_incomplete_chunked_response_body(
+    sync_http_server: str,
+) -> None:
+    timeouts = foghttp.Timeouts(total=0.05)
+
+    with foghttp.Client(timeouts=timeouts) as client:
+        with pytest.raises(foghttp.TimeoutError, match="request total timeout expired"):
+            client.get(f"{sync_http_server}{INCOMPLETE_CHUNKED_BODY_PATH}")
+
+        stats_after_error = client.stats()
+
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0
 
 
 def test_sync_buffered_response_body_limit_error_without_known_size_releases_request_slot(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import AsyncIterator, Iterator
+from contextlib import suppress
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
@@ -12,6 +13,11 @@ import pytest
 from foghttp.methods import HEAD
 from foghttp.status_codes.redirect import FOUND
 from foghttp.status_codes.success import OK
+from tests.http_body_scenarios import (
+    raw_too_large_size_hint_response,
+    write_async_body_safety_response,
+    write_sync_body_safety_response,
+)
 
 
 REDIRECT_PATH_PARTS = 2
@@ -327,6 +333,7 @@ def _raw_http_server_response(headers: str, body: bytes) -> bytes:
         or _raw_redirect_to_status_response(path)
         or _raw_redirect_response(path)
         or _raw_status_response(path)
+        or raw_too_large_size_hint_response(path)
         or _raw_bytes_response(path)
         or _raw_unknown_size_bytes_response(path)
         or _raw_text_response(path)
@@ -339,11 +346,19 @@ def _raw_http_server_response(headers: str, body: bytes) -> bytes:
 
 async def _start_async_http_server() -> tuple[Any, str]:
     async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        headers, body = await _read_request(reader)
-        writer.write(_raw_http_server_response(headers, body))
-        await writer.drain()
-        writer.close()
-        await writer.wait_closed()
+        try:
+            headers, body = await _read_request(reader)
+            _method, target, _version = headers.splitlines()[0].split()
+            path = urlsplit(target).path
+            if not await write_async_body_safety_response(path, writer):
+                writer.write(_raw_http_server_response(headers, body))
+                await writer.drain()
+        except OSError:
+            return
+        finally:
+            writer.close()
+            with suppress(asyncio.CancelledError, OSError):
+                await writer.wait_closed()
 
     server = await asyncio.start_server(handle, "127.0.0.1", 0)
     host, port = server.sockets[0].getsockname()
@@ -406,6 +421,7 @@ class SyncHTTPHandler(BaseHTTPRequestHandler):
                 lambda: self._write_redirect_to_status(path),
                 lambda: self._write_redirect(path),
                 lambda: self._write_status(path),
+                lambda: write_sync_body_safety_response(self, path),
                 lambda: self._write_bytes(path),
                 lambda: self._write_unknown_size_bytes(path),
                 lambda: self._write_text(path),

--- a/tests/http_body_scenarios.py
+++ b/tests/http_body_scenarios.py
@@ -1,0 +1,140 @@
+__all__ = (
+    "INCOMPLETE_CHUNKED_BODY_PATH",
+    "SLOW_BODY_PATH",
+    "TOO_LARGE_SIZE_HINT_PATH",
+    "raw_too_large_size_hint_response",
+    "write_async_body_safety_response",
+    "write_sync_body_safety_response",
+)
+
+import asyncio
+from contextlib import suppress
+from http.server import BaseHTTPRequestHandler
+import time
+
+from foghttp.limits import DEFAULT_MAX_RESPONSE_BODY_SIZE
+from foghttp.status_codes.success import OK
+
+
+BODY_RESPONSE_DELAY = 0.25
+INCOMPLETE_CHUNKED_BODY_PATH = "/incomplete-chunked-body"
+SLOW_BODY_PATH = "/slow-body"
+TOO_LARGE_SIZE_HINT_PATH = "/too-large-size-hint"
+
+
+def raw_too_large_size_hint_response(path: str) -> bytes | None:
+    if path != TOO_LARGE_SIZE_HINT_PATH:
+        return None
+
+    return _raw_response(
+        [
+            ("content-type", "application/octet-stream"),
+            ("content-length", str(DEFAULT_MAX_RESPONSE_BODY_SIZE + 1)),
+            ("connection", "close"),
+        ],
+    )
+
+
+async def write_async_body_safety_response(
+    path: str,
+    writer: asyncio.StreamWriter,
+) -> bool:
+    if path == SLOW_BODY_PATH:
+        writer.write(
+            _raw_response(
+                [
+                    ("content-type", "application/octet-stream"),
+                    ("content-length", "1"),
+                    ("connection", "close"),
+                ],
+            ),
+        )
+        await writer.drain()
+        await asyncio.sleep(BODY_RESPONSE_DELAY)
+        writer.write(b"x")
+        await writer.drain()
+        return True
+
+    if path == INCOMPLETE_CHUNKED_BODY_PATH:
+        writer.write(
+            _raw_response(
+                [
+                    ("content-type", "application/octet-stream"),
+                    ("transfer-encoding", "chunked"),
+                    ("connection", "close"),
+                ],
+                b"1\r\nx\r\n",
+            ),
+        )
+        await writer.drain()
+        await asyncio.sleep(BODY_RESPONSE_DELAY)
+        return True
+
+    return False
+
+
+def write_sync_body_safety_response(
+    handler: BaseHTTPRequestHandler,
+    path: str,
+) -> bool:
+    return (
+        _write_sync_too_large_size_hint(handler, path)
+        or _write_sync_slow_body(handler, path)
+        or _write_sync_incomplete_chunked_body(handler, path)
+    )
+
+
+def _raw_response(headers: list[tuple[str, str]], content: bytes = b"") -> bytes:
+    header_lines = "".join(f"{name}: {value}\r\n" for name, value in headers)
+    return f"HTTP/1.1 {OK} OK\r\n{header_lines}\r\n".encode() + content
+
+
+def _write_sync_too_large_size_hint(
+    handler: BaseHTTPRequestHandler,
+    path: str,
+) -> bool:
+    if path != TOO_LARGE_SIZE_HINT_PATH:
+        return False
+
+    handler.send_response(OK)
+    handler.send_header("content-type", "application/octet-stream")
+    handler.send_header("content-length", str(DEFAULT_MAX_RESPONSE_BODY_SIZE + 1))
+    handler.send_header("connection", "close")
+    handler.end_headers()
+    return True
+
+
+def _write_sync_slow_body(handler: BaseHTTPRequestHandler, path: str) -> bool:
+    if path != SLOW_BODY_PATH:
+        return False
+
+    handler.send_response(OK)
+    handler.send_header("content-type", "application/octet-stream")
+    handler.send_header("content-length", "1")
+    handler.send_header("connection", "close")
+    handler.end_headers()
+    handler.wfile.flush()
+    time.sleep(BODY_RESPONSE_DELAY)
+    with suppress(OSError):
+        handler.wfile.write(b"x")
+    return True
+
+
+def _write_sync_incomplete_chunked_body(
+    handler: BaseHTTPRequestHandler,
+    path: str,
+) -> bool:
+    if path != INCOMPLETE_CHUNKED_BODY_PATH:
+        return False
+
+    handler.close_connection = True
+    handler.send_response(OK)
+    handler.send_header("content-type", "application/octet-stream")
+    handler.send_header("transfer-encoding", "chunked")
+    handler.send_header("connection", "close")
+    handler.end_headers()
+    with suppress(OSError):
+        handler.wfile.write(b"1\r\nx\r\n")
+        handler.wfile.flush()
+    time.sleep(BODY_RESPONSE_DELAY)
+    return True


### PR DESCRIPTION
- add default max_response_body_size limit
- apply total timeout while collecting buffered bodies
- cover sync and async body limit and timeout scenarios
- document bounded buffering and explicit unbounded opt-in