### PR TITLE
fix: harden redirect body replay policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ async with foghttp.AsyncClient() as client:
 - prepared `Request` objects with `build_request()` and `send()`
 - case-insensitive `Headers` with repeated values
 - normalized `URL` model with origin comparison and relative joins
-- GET/HEAD/POST redirects with final URL and history
+- GET/HEAD/POST redirects with final URL, history, and conservative replay policy
 - HTTPS with default WebPKI roots and explicit custom CA certificates
 - graceful sync `close()` that waits for in-flight sync requests
 - async request cancellation that aborts the in-flight Rust request

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - prepared `Request` objects with `build_request()` and `send()`
 - case-insensitive `Headers` with repeated value support
 - normalized `URL` model with origin comparison and relative joins
-- GET/HEAD/POST redirects with final URL and history
+- GET/HEAD/POST redirects with final URL, history, and conservative replay policy
 - HTTPS with default WebPKI roots and explicit custom CA certificates
 - documented lazy transport creation, graceful sync close, async request
   cancellation, and explicit client lifecycle

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -74,8 +74,8 @@ FogHTTP follows common browser-compatible POST redirect behavior:
 | `301` | `POST` becomes `GET`; body is dropped |
 | `302` | `POST` becomes `GET`; body is dropped |
 | `303` | `POST` becomes `GET`; body is dropped |
-| `307` | `POST` is preserved; body is resent |
-| `308` | `POST` is preserved; body is resent |
+| `307` | `POST` is preserved only for same-origin redirects; cross-origin body replay is dropped |
+| `308` | `POST` is preserved only for same-origin redirects; cross-origin body replay is dropped |
 
 ::: code-group
 
@@ -130,8 +130,18 @@ strips body-specific headers:
 - `Content-Type`
 - `Transfer-Encoding`
 
-For `307` and `308`, FogHTTP preserves the method and resends the current
-buffered body. Future streaming bodies will use a stricter replay policy because
+For same-origin `307` and `308`, FogHTTP preserves the method and resends the
+current buffered body. For cross-origin `307` and `308`, FogHTTP preserves the
+method but drops the body and body-specific headers before the next request.
+This prevents JSON payloads, tokens, form data, and other request bodies from
+being forwarded to a different origin by a redirect response.
+
+FogHTTP also blocks `https -> http` redirects. Scheme downgrade redirects are
+too easy to misuse once credentials, cookies, body replay, or future auth helpers
+are involved, so the safe default is to fail the request instead of silently
+following the downgrade.
+
+Future streaming bodies will use an explicit replayability model because
 non-replayable streams must not be resent automatically.
 
 ## Redirect Limit

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -115,7 +115,7 @@ def send_event(payload: dict) -> None:
 ### Redirect-Aware APIs
 
 FogHTTP can follow GET, HEAD, and POST redirects, preserve redirect history, and
-apply conservative header stripping for cross-origin redirects.
+apply conservative cross-origin header stripping and body replay protection.
 
 ```python
 import foghttp
@@ -218,7 +218,7 @@ except foghttp.HTTPStatusError as exc:
 | Cookies/session jar | Not implemented |
 | Proxy and `trust_env` | Not implemented |
 | HTTP/2 | Not implemented |
-| Cookie jar and auth helper integration | Not implemented; cross-origin redirects still strip sensitive headers |
+| Cookie jar and auth helper integration | Not implemented; cross-origin redirects still strip sensitive headers and drop body replay |
 | Unbounded large downloads | Use `max_response_body_size` for buffered fail-fast protection; streaming downloads are not implemented |
 
 FogHTTP is best today in controlled environments where request and response

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,6 +1,8 @@
 pub const POOL_ACQUIRE_QUEUE_FULL: &str = "request acquire queue is full";
 pub const POOL_ACQUIRE_TIMEOUT: &str = "request acquire timeout expired";
 pub const REQUEST_TOTAL_TIMEOUT: &str = "request total timeout expired";
+pub const HTTPS_TO_HTTP_REDIRECT_BLOCKED: &str =
+    "https-to-http redirect blocked by redirect security policy";
 pub const TRUST_ENV_UNSUPPORTED: &str = "trust_env/proxy support is planned after the MVP";
 
 pub fn response_body_too_large(limit: usize) -> String {

--- a/src/py/client/redirects/action.rs
+++ b/src/py/client/redirects/action.rs
@@ -1,7 +1,13 @@
 use super::method::redirect_method;
+use super::policy::redirect_security_policy;
 use super::status::redirect_status_code;
 use super::utils::header_value;
 use crate::core::url::HttpUrl;
+
+pub enum RedirectDecision {
+    Block(&'static str),
+    Follow(RedirectAction),
+}
 
 pub struct RedirectAction {
     pub method: String,
@@ -10,22 +16,27 @@ pub struct RedirectAction {
     pub url: String,
 }
 
-pub fn redirect_action(
+pub fn redirect_decision(
     method: &str,
     url: &str,
     status_code: u16,
     headers: &[(String, String)],
-) -> Option<RedirectAction> {
+) -> Option<RedirectDecision> {
     let status_code = redirect_status_code(status_code)?;
     let location = header_value(headers, "location")?;
     let (next_method, preserve_body) = redirect_method(method, status_code)?;
     let current_url = HttpUrl::parse(url).ok()?;
     let next_url = current_url.join(location).ok()?;
+    let policy = redirect_security_policy(&current_url, &next_url, next_method, preserve_body);
 
-    Some(RedirectAction {
+    if let Some(reason) = policy.block_reason {
+        return Some(RedirectDecision::Block(reason));
+    }
+
+    Some(RedirectDecision::Follow(RedirectAction {
         method: next_method.to_owned(),
-        preserve_body,
-        remove_sensitive_headers: !current_url.is_same_origin(&next_url),
+        preserve_body: policy.preserve_body,
+        remove_sensitive_headers: policy.remove_sensitive_headers,
         url: next_url.as_str().to_owned(),
-    })
+    }))
 }

--- a/src/py/client/redirects/mod.rs
+++ b/src/py/client/redirects/mod.rs
@@ -1,10 +1,11 @@
 mod action;
 mod headers;
 mod method;
+mod policy;
 mod status;
 mod utils;
 
-pub use action::{redirect_action, RedirectAction};
+pub use action::{redirect_decision, RedirectAction, RedirectDecision};
 pub use headers::{redirect_headers, RedirectHeaderPolicy};
 
 #[cfg(test)]

--- a/src/py/client/redirects/policy.rs
+++ b/src/py/client/redirects/policy.rs
@@ -1,0 +1,42 @@
+use crate::core::method::{GET, HEAD};
+use crate::core::url::HttpUrl;
+use crate::messages::HTTPS_TO_HTTP_REDIRECT_BLOCKED;
+
+const HTTPS_SCHEME: &str = "https";
+const HTTP_SCHEME: &str = "http";
+
+pub struct RedirectSecurityPolicy {
+    pub block_reason: Option<&'static str>,
+    pub preserve_body: bool,
+    pub remove_sensitive_headers: bool,
+}
+
+pub fn redirect_security_policy(
+    current_url: &HttpUrl,
+    next_url: &HttpUrl,
+    method: &str,
+    preserve_body: bool,
+) -> RedirectSecurityPolicy {
+    let remove_sensitive_headers = !current_url.is_same_origin(next_url);
+    let block_reason = if is_https_to_http_redirect(current_url, next_url) {
+        Some(HTTPS_TO_HTTP_REDIRECT_BLOCKED)
+    } else {
+        None
+    };
+    let preserve_body =
+        preserve_body && !(remove_sensitive_headers && can_replay_request_body(method));
+
+    RedirectSecurityPolicy {
+        block_reason,
+        preserve_body,
+        remove_sensitive_headers,
+    }
+}
+
+fn is_https_to_http_redirect(current_url: &HttpUrl, next_url: &HttpUrl) -> bool {
+    current_url.scheme() == HTTPS_SCHEME && next_url.scheme() == HTTP_SCHEME
+}
+
+fn can_replay_request_body(method: &str) -> bool {
+    method != GET && method != HEAD
+}

--- a/src/py/client/redirects/tests.rs
+++ b/src/py/client/redirects/tests.rs
@@ -1,6 +1,9 @@
-use super::{redirect_action, redirect_headers, RedirectHeaderPolicy};
+use super::{
+    redirect_decision, redirect_headers, RedirectAction, RedirectDecision, RedirectHeaderPolicy,
+};
 use crate::core::headers::HeaderPairs;
 use crate::core::method::{GET, POST};
+use crate::messages::HTTPS_TO_HTTP_REDIRECT_BLOCKED;
 use hyper::StatusCode;
 
 fn header_names(headers: &HeaderPairs) -> Vec<String> {
@@ -10,15 +13,21 @@ fn header_names(headers: &HeaderPairs) -> Vec<String> {
         .collect()
 }
 
+fn follow_action(decision: Option<RedirectDecision>) -> RedirectAction {
+    match decision.expect("redirect decision") {
+        RedirectDecision::Follow(action) => action,
+        RedirectDecision::Block(reason) => panic!("unexpected blocked redirect: {reason}"),
+    }
+}
+
 #[test]
 fn same_origin_redirect_keeps_sensitive_headers() {
-    let action = redirect_action(
+    let action = follow_action(redirect_decision(
         GET,
         "https://example.com/users",
         StatusCode::FOUND.as_u16(),
         &[("location".to_owned(), "/accounts".to_owned())],
-    )
-    .expect("redirect action");
+    ));
 
     let headers = redirect_headers(
         vec![
@@ -42,7 +51,7 @@ fn same_origin_redirect_keeps_sensitive_headers() {
 
 #[test]
 fn cross_origin_redirect_strips_sensitive_headers() {
-    let action = redirect_action(
+    let action = follow_action(redirect_decision(
         GET,
         "https://example.com/users",
         StatusCode::FOUND.as_u16(),
@@ -50,8 +59,7 @@ fn cross_origin_redirect_strips_sensitive_headers() {
             "location".to_owned(),
             "https://api.example.org/final".to_owned(),
         )],
-    )
-    .expect("redirect action");
+    ));
 
     let headers = redirect_headers(
         vec![
@@ -74,13 +82,12 @@ fn cross_origin_redirect_strips_sensitive_headers() {
 
 #[test]
 fn method_rewrite_strips_body_headers() {
-    let action = redirect_action(
+    let action = follow_action(redirect_decision(
         POST,
         "https://example.com/users",
         StatusCode::SEE_OTHER.as_u16(),
         &[("location".to_owned(), "/final".to_owned())],
-    )
-    .expect("redirect action");
+    ));
 
     let headers = redirect_headers(
         vec![
@@ -102,13 +109,12 @@ fn method_rewrite_strips_body_headers() {
 
 #[test]
 fn method_preserving_redirect_keeps_body_headers() {
-    let action = redirect_action(
+    let action = follow_action(redirect_decision(
         POST,
         "https://example.com/users",
         StatusCode::TEMPORARY_REDIRECT.as_u16(),
         &[("location".to_owned(), "/final".to_owned())],
-    )
-    .expect("redirect action");
+    ));
 
     let headers = redirect_headers(
         vec![
@@ -126,4 +132,51 @@ fn method_preserving_redirect_keeps_body_headers() {
         header_names(&headers),
         vec!["Content-Type", "Content-Length"]
     );
+}
+
+#[test]
+fn cross_origin_method_preserving_redirect_strips_body_headers() {
+    let action = follow_action(redirect_decision(
+        POST,
+        "https://example.com/users",
+        StatusCode::TEMPORARY_REDIRECT.as_u16(),
+        &[(
+            "location".to_owned(),
+            "https://api.example.org/final".to_owned(),
+        )],
+    ));
+
+    let headers = redirect_headers(
+        vec![
+            ("Content-Type".to_owned(), "application/json".to_owned()),
+            ("Content-Length".to_owned(), "12".to_owned()),
+            ("Transfer-Encoding".to_owned(), "chunked".to_owned()),
+            ("Authorization".to_owned(), "Bearer token".to_owned()),
+            ("Accept".to_owned(), "application/json".to_owned()),
+        ],
+        RedirectHeaderPolicy {
+            preserve_body: action.preserve_body,
+            remove_sensitive_headers: action.remove_sensitive_headers,
+        },
+    );
+
+    assert_eq!(action.method, POST);
+    assert!(!action.preserve_body);
+    assert_eq!(header_names(&headers), vec!["Accept"]);
+}
+
+#[test]
+fn https_to_http_redirect_is_blocked() {
+    let decision = redirect_decision(
+        POST,
+        "https://example.com/users",
+        StatusCode::TEMPORARY_REDIRECT.as_u16(),
+        &[("location".to_owned(), "http://example.com/final".to_owned())],
+    )
+    .expect("redirect decision");
+
+    match decision {
+        RedirectDecision::Block(reason) => assert_eq!(reason, HTTPS_TO_HTTP_REDIRECT_BLOCKED),
+        RedirectDecision::Follow(_) => panic!("expected blocked redirect"),
+    }
 }

--- a/src/py/client/transport.rs
+++ b/src/py/client/transport.rs
@@ -8,7 +8,7 @@ use crate::errors::{FogHttpError, FogHttpTimeoutError};
 use crate::messages::{redirect_limit_exceeded, REQUEST_TOTAL_TIMEOUT};
 use crate::py::client::acquire::AcquireGate;
 use crate::py::client::redirects::{
-    redirect_action, redirect_headers, RedirectAction, RedirectHeaderPolicy,
+    redirect_decision, redirect_headers, RedirectAction, RedirectDecision, RedirectHeaderPolicy,
 };
 use crate::py::response::{RawRequestInfo, RawResponse};
 use hyper::body::Incoming;
@@ -69,7 +69,7 @@ pub async fn send_request(
 
         let response_url = raw.request.url.clone();
         let redirect = if state.follow_redirects {
-            redirect_action(&state.method, &response_url, raw.status_code, &raw.headers)
+            redirect_decision(&state.method, &response_url, raw.status_code, &raw.headers)
         } else {
             None
         };
@@ -84,9 +84,13 @@ pub async fn send_request(
                 &response_url,
             )));
         }
-
-        history.push(raw);
-        state.apply_redirect(redirect);
+        match redirect {
+            RedirectDecision::Block(reason) => return Err(FogHttpError::new_err(reason)),
+            RedirectDecision::Follow(action) => {
+                history.push(raw);
+                state.apply_redirect(action);
+            }
+        }
     }
 }
 

--- a/tests/client_tls/server.py
+++ b/tests/client_tls/server.py
@@ -4,7 +4,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import ssl
 import threading
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import parse_qs, urlsplit
 
 from foghttp.status_codes.client_error import NOT_FOUND
 from foghttp.status_codes.success import OK
@@ -14,6 +14,7 @@ from .constants import TLS_OK_BODY, TLS_PATH
 from .models import TLSServer
 
 
+REDIRECT_TO_LOCATION_PATH = "/redirect-to-location"
 SERVER_HOST = "127.0.0.1"
 
 
@@ -34,6 +35,9 @@ class TLSHTTPHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def do_GET(self) -> None:
+        if self._write_redirect_to_location():
+            return
+
         if urlsplit(self.path).path != TLS_PATH:
             self.send_response(NOT_FOUND)
             self.send_header("content-length", "0")
@@ -48,5 +52,35 @@ class TLSHTTPHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(TLS_OK_BODY)
 
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length", "0"))
+        if length:
+            self.rfile.read(length)
+        if self._write_redirect_to_location():
+            return
+
+        self.send_response(NOT_FOUND)
+        self.send_header("content-length", "0")
+        self.send_header("connection", "close")
+        self.end_headers()
+
     def log_message(self, _format: str, *_args: Any) -> None:
         return
+
+    def _write_redirect_to_location(self) -> bool:
+        target = urlsplit(self.path)
+        if target.path != REDIRECT_TO_LOCATION_PATH:
+            return False
+
+        params = parse_qs(target.query, keep_blank_values=True)
+        status_values = params.get("status", [])
+        location_values = params.get("location", [])
+        if not status_values or not location_values:
+            return False
+
+        self.send_response(int(status_values[0]))
+        self.send_header("location", location_values[0])
+        self.send_header("content-length", "0")
+        self.send_header("connection", "close")
+        self.end_headers()
+        return True

--- a/tests/client_tls/test_async_tls_redirects.py
+++ b/tests/client_tls/test_async_tls_redirects.py
@@ -1,0 +1,44 @@
+from faker import Faker
+import pytest
+
+import foghttp
+from foghttp.status_codes.redirect import PERMANENT_REDIRECT, TEMPORARY_REDIRECT
+from tests.redirect_helpers import SECURITY_HEADERS_PATH, redirect_to_location_url
+
+from .certificates import TLSCertificateBundle
+from .models import TLSServer
+
+
+@pytest.mark.parametrize("status_code", (TEMPORARY_REDIRECT, PERMANENT_REDIRECT))
+async def test_async_https_to_http_redirect_with_body_is_blocked(
+    tls_certificates: TLSCertificateBundle,
+    tls_http_server: TLSServer,
+    http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    tls = foghttp.TLSConfig(ca_certificates=(tls_certificates.ca_path,))
+    location = f"{http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(
+        tls_http_server.url,
+        status_code=status_code,
+        location=location,
+    )
+
+    async with foghttp.AsyncClient(follow_redirects=True, tls=tls) as client:
+        with pytest.raises(
+            foghttp.RequestError,
+            match="https-to-http redirect blocked",
+        ):
+            await client.post(
+                url,
+                headers={"authorization": "Bearer secret"},
+                content=faker.sentence(),
+            )
+
+        stats_after_error = client.stats()
+
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0

--- a/tests/client_tls/test_sync_tls_redirects.py
+++ b/tests/client_tls/test_sync_tls_redirects.py
@@ -1,0 +1,44 @@
+from faker import Faker
+import pytest
+
+import foghttp
+from foghttp.status_codes.redirect import PERMANENT_REDIRECT, TEMPORARY_REDIRECT
+from tests.redirect_helpers import SECURITY_HEADERS_PATH, redirect_to_location_url
+
+from .certificates import TLSCertificateBundle
+from .models import TLSServer
+
+
+@pytest.mark.parametrize("status_code", (TEMPORARY_REDIRECT, PERMANENT_REDIRECT))
+def test_sync_https_to_http_redirect_with_body_is_blocked(
+    tls_certificates: TLSCertificateBundle,
+    tls_http_server: TLSServer,
+    sync_http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    tls = foghttp.TLSConfig(ca_certificates=(tls_certificates.ca_path,))
+    location = f"{sync_http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(
+        tls_http_server.url,
+        status_code=status_code,
+        location=location,
+    )
+
+    with foghttp.Client(follow_redirects=True, tls=tls) as client:
+        with pytest.raises(
+            foghttp.RequestError,
+            match="https-to-http redirect blocked",
+        ):
+            client.post(
+                url,
+                headers={"authorization": "Bearer secret"},
+                content=faker.sentence(),
+            )
+
+        stats_after_error = client.stats()
+
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0

--- a/tests/test_async_redirects.py
+++ b/tests/test_async_redirects.py
@@ -188,3 +188,43 @@ async def test_post_redirect_preserving_method_keeps_body_headers(http_server: s
     assert payload["request_line"] == f"POST {SECURITY_HEADERS_PATH} HTTP/1.1"
     assert payload["body"] == post_body
     assert header_values(payload, "content-type") == ["text/plain"]
+
+
+@pytest.mark.parametrize("status_code", POST_REDIRECTS_PRESERVE_METHOD_STATUS_CODES)
+async def test_cross_origin_post_redirect_drops_body_replay(
+    http_server: str,
+    secondary_http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    location = f"{secondary_http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(
+        http_server,
+        status_code=status_code,
+        location=location,
+    )
+    post_body = faker.sentence()
+
+    async with foghttp.AsyncClient(follow_redirects=True) as client:
+        response = await client.post(
+            url,
+            headers={
+                **REDIRECT_SECURITY_HEADERS,
+                "content-encoding": "identity",
+                "content-type": "text/plain",
+            },
+            content=post_body,
+        )
+
+    payload = response.json()
+    assert payload["request_line"] == f"POST {SECURITY_HEADERS_PATH} HTTP/1.1"
+    assert payload["body"] == ""
+    assert header_values(payload, "accept") == ["application/json"]
+    assert header_values(payload, "authorization") == []
+    assert header_values(payload, "content-encoding") == []
+    assert header_values(payload, "content-type") == []
+    assert header_values(payload, "cookie") == []
+    assert header_values(payload, "host") == [urlsplit(secondary_http_server).netloc]
+    assert header_values(payload, "origin") == []
+    assert header_values(payload, "proxy-authorization") == []
+    assert header_values(payload, "referer") == []

--- a/tests/test_sync_redirects.py
+++ b/tests/test_sync_redirects.py
@@ -181,3 +181,43 @@ def test_post_redirect_preserving_method_keeps_body_headers(sync_http_server: st
     assert payload["request_line"] == f"POST {SECURITY_HEADERS_PATH} HTTP/1.1"
     assert payload["body"] == post_body
     assert header_values(payload, "content-type") == ["text/plain"]
+
+
+@pytest.mark.parametrize("status_code", POST_REDIRECTS_PRESERVE_METHOD_STATUS_CODES)
+def test_cross_origin_post_redirect_drops_body_replay(
+    sync_http_server: str,
+    secondary_sync_http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    location = f"{secondary_sync_http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(
+        sync_http_server,
+        status_code=status_code,
+        location=location,
+    )
+    post_body = faker.sentence()
+
+    with foghttp.Client(follow_redirects=True) as client:
+        response = client.post(
+            url,
+            headers={
+                **REDIRECT_SECURITY_HEADERS,
+                "content-encoding": "identity",
+                "content-type": "text/plain",
+            },
+            content=post_body,
+        )
+
+    payload = response.json()
+    assert payload["request_line"] == f"POST {SECURITY_HEADERS_PATH} HTTP/1.1"
+    assert payload["body"] == ""
+    assert header_values(payload, "accept") == ["application/json"]
+    assert header_values(payload, "authorization") == []
+    assert header_values(payload, "content-encoding") == []
+    assert header_values(payload, "content-type") == []
+    assert header_values(payload, "cookie") == []
+    assert header_values(payload, "host") == [urlsplit(secondary_sync_http_server).netloc]
+    assert header_values(payload, "origin") == []
+    assert header_values(payload, "proxy-authorization") == []
+    assert header_values(payload, "referer") == []


### PR DESCRIPTION
- drop cross-origin 307/308 request body replay by default
- block https-to-http redirects through redirect security policy
- cover sync and async redirect replay security scenarios
- document conservative redirect replay behavior