### PR TITLE
fix: reject transport-managed request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ async with foghttp.AsyncClient() as client:
   `raise_for_status()`, and request metadata
 - prepared `Request` objects with `build_request()` and `send()`
 - case-insensitive `Headers` with repeated values
+- safe policy for transport-managed request headers
 - normalized `URL` model with origin comparison and relative joins
 - GET/HEAD/POST redirects with final URL, history, and conservative replay policy
 - HTTPS with default WebPKI roots and explicit custom CA certificates

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - response status flags for success, redirects, and client/server errors
 - prepared `Request` objects with `build_request()` and `send()`
 - case-insensitive `Headers` with repeated value support
+- safe policy for transport-managed request headers
 - normalized `URL` model with origin comparison and relative joins
 - GET/HEAD/POST redirects with final URL, history, and conservative replay policy
 - HTTPS with default WebPKI roots and explicit custom CA certificates

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -57,6 +57,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | Compression decoding | Not available |
 | `base_url` | Not available |
 | default client headers | Not available |
+| transport-managed request headers | Safe API rejects manual `Host`, `Content-Length`, `Transfer-Encoding`, `TE`, `Trailer`, `Connection`, `Upgrade`, `Keep-Alive`, and `Proxy-Connection` |
 | true active connection-level limits | `max_active_requests_per_origin` limits buffered request slots; physical TCP connection-level accounting is not exposed yet |
 | per-request connect timeout changes | `Timeouts.connect` configures the Rust connector from client-level settings when transport state is created; per-request `timeout.connect` does not reconfigure the connector |
 | separate read/write timeout semantics | `Timeouts.read` and `Timeouts.write` exist, but separate body read/write deadlines are reserved for later streaming/body work |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -275,6 +275,12 @@ with foghttp.Client() as client:
     response = client.get("https://httpbin.org/headers", headers=headers)
 ```
 
+FogHTTP treats authority, framing, and hop-by-hop request headers as
+transport-managed. The safe API rejects manual `Host`, `Content-Length`,
+`Transfer-Encoding`, `TE`, `Trailer`, `Connection`, `Upgrade`, `Keep-Alive`,
+and `Proxy-Connection` headers. Use semantic headers such as `Accept`,
+`Authorization`, `Content-Type`, and application-specific `X-*` headers.
+
 ## Custom CA Certificates
 
 FogHTTP uses WebPKI roots by default for HTTPS. For private services with an

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -114,13 +114,13 @@ next request:
 - `Authorization`
 - `Proxy-Authorization`
 - `Cookie`
-- `Host`
 - `Origin`
 - `Referer`
 
 This is intentionally strict. It prevents credentials, manually supplied
-cookies, host authority metadata, origin metadata, and referrer metadata from
-being forwarded to a different origin by a redirect response.
+cookies, origin metadata, and referrer metadata from being forwarded to a
+different origin by a redirect response. `Host` is transport-managed and cannot
+be set manually through the safe API.
 
 When a redirect rewrites `POST` to `GET`, FogHTTP drops the request body and
 strips body-specific headers:
@@ -129,6 +129,9 @@ strips body-specific headers:
 - `Content-Length`
 - `Content-Type`
 - `Transfer-Encoding`
+
+`Content-Length` and `Transfer-Encoding` are transport-managed and cannot be set
+manually through the safe API.
 
 For same-origin `307` and `308`, FogHTTP preserves the method and resends the
 current buffered body. For cross-origin `307` and `308`, FogHTTP preserves the

--- a/foghttp/_client/request_builder/builder.py
+++ b/foghttp/_client/request_builder/builder.py
@@ -5,6 +5,7 @@ from ...headers import Headers, HeaderSource
 from ...request import Request
 from ...types import QueryParams
 from ...url import URL, merge_params
+from .header_policy import validate_safe_request_headers
 from .models import RequestBuildOptions
 
 
@@ -16,6 +17,7 @@ class RequestBuilder:
     def build(self, options: RequestBuildOptions) -> Request:
         request_url = self._build_url(options.url, options.params)
         request_headers = self._build_headers(options.headers)
+        validate_safe_request_headers(request_headers)
         body = self._build_body(options, request_headers)
         return Request(
             options.method,

--- a/foghttp/_client/request_builder/header_policy.py
+++ b/foghttp/_client/request_builder/header_policy.py
@@ -1,0 +1,25 @@
+__all__ = ("TRANSPORT_MANAGED_REQUEST_HEADERS", "validate_safe_request_headers")
+
+from ...headers import Headers
+from ...messages import transport_managed_header_error
+
+
+TRANSPORT_MANAGED_REQUEST_HEADERS = frozenset(
+    {
+        "connection",
+        "content-length",
+        "host",
+        "keep-alive",
+        "proxy-connection",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    },
+)
+
+
+def validate_safe_request_headers(headers: Headers) -> None:
+    for name, _value in headers.multi_items():
+        if name.lower() in TRANSPORT_MANAGED_REQUEST_HEADERS:
+            raise ValueError(transport_managed_header_error(name))

--- a/foghttp/async_client.py
+++ b/foghttp/async_client.py
@@ -8,6 +8,7 @@ from ._client.config import ClientConfig
 from ._client.constants import DEFAULT_MAX_REDIRECTS
 from ._client.core import ClientCore
 from ._client.raw import close_raw_client, send_raw_request_async
+from ._client.request_builder.header_policy import validate_safe_request_headers
 from ._client.response import response_from_raw
 from .headers import HeaderSource
 from .limits import Limits
@@ -96,6 +97,7 @@ class AsyncClient(ClientCore):
 
     async def send(self, request: Request, *, timeout: Timeouts | None = None) -> Response:
         self._ensure_open()
+        validate_safe_request_headers(request.headers)
         timeouts = self._request_timeouts(timeout)
         started = time.perf_counter()
         raw_client = self._raw_client()

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -9,6 +9,7 @@ from ._client.config import ClientConfig
 from ._client.constants import DEFAULT_MAX_REDIRECTS
 from ._client.core import ClientCore
 from ._client.raw import close_raw_client, send_raw_request
+from ._client.request_builder.header_policy import validate_safe_request_headers
 from ._client.response import response_from_raw
 from .headers import HeaderSource
 from .limits import Limits
@@ -119,6 +120,8 @@ class Client(ClientCore):
         return self.send(request, timeout=timeout)
 
     def send(self, request: Request, *, timeout: Timeouts | None = None) -> Response:
+        self._ensure_open()
+        validate_safe_request_headers(request.headers)
         timeouts = self._request_timeouts(timeout)
         started = time.perf_counter()
         raw_client = self._begin_sync_send()

--- a/foghttp/messages.py
+++ b/foghttp/messages.py
@@ -12,6 +12,7 @@ __all__ = (
     "UNCLOSED_CLIENT",
     "http_status_error",
     "http_status_reason",
+    "transport_managed_header_error",
 )
 
 from http import HTTPStatus
@@ -41,3 +42,7 @@ def http_status_reason(status_code: int) -> str:
         return HTTPStatus(status_code).phrase
     except ValueError:
         return ""
+
+
+def transport_managed_header_error(name: str) -> str:
+    return f"request header {name!r} is managed by FogHTTP transport and cannot be set manually"

--- a/tests/redirect_helpers.py
+++ b/tests/redirect_helpers.py
@@ -14,7 +14,6 @@ REDIRECT_SECURITY_HEADERS = {
     "accept": "application/json",
     "authorization": "Bearer secret",
     "cookie": "session=secret",
-    "host": "example.com",
     "origin": "https://example.com",
     "proxy-authorization": "Basic proxy-secret",
     "referer": "https://example.com/source",

--- a/tests/request_builder/test_header_policy.py
+++ b/tests/request_builder/test_header_policy.py
@@ -1,0 +1,103 @@
+from faker import Faker
+import pytest
+
+import foghttp
+from foghttp.methods import GET, POST
+
+
+TRANSPORT_MANAGED_HEADER_NAMES = (
+    "Host",
+    "Content-Length",
+    "Transfer-Encoding",
+    "Trailer",
+    "TE",
+    "Connection",
+    "Upgrade",
+    "Keep-Alive",
+    "Proxy-Connection",
+)
+
+
+@pytest.mark.parametrize("header_name", TRANSPORT_MANAGED_HEADER_NAMES)
+def test_build_request_rejects_transport_managed_headers(
+    faker: Faker,
+    header_name: str,
+) -> None:
+    with foghttp.Client() as client, pytest.raises(ValueError) as exc_info:
+        client.build_request(
+            GET,
+            faker.url(),
+            headers={header_name: faker.word()},
+        )
+
+    assert header_name in str(exc_info.value)
+    assert "managed by FogHTTP transport" in str(exc_info.value)
+
+
+def test_build_request_rejects_transport_managed_repeated_header(faker: Faker) -> None:
+    headers = foghttp.Headers(
+        [
+            ("Accept", "application/json"),
+            ("content-length", "12"),
+        ],
+    )
+
+    with foghttp.Client() as client, pytest.raises(ValueError) as exc_info:
+        client.build_request(GET, faker.url(), headers=headers)
+
+    assert "content-length" in str(exc_info.value)
+    assert "managed by FogHTTP transport" in str(exc_info.value)
+
+
+def test_build_request_allows_semantic_body_headers(faker: Faker) -> None:
+    headers = {
+        "Content-Encoding": "identity",
+        "Content-Type": "text/plain",
+    }
+    content = faker.sentence()
+
+    with foghttp.Client() as client:
+        request = client.build_request(POST, faker.url(), headers=headers, content=content)
+
+    assert request.headers["content-encoding"] == "identity"
+    assert request.headers["content-type"] == "text/plain"
+    assert request.content == content.encode()
+
+
+def test_build_request_leaves_framing_headers_to_transport(faker: Faker) -> None:
+    payload = {"name": faker.name()}
+
+    with foghttp.Client() as client:
+        request = client.build_request(POST, faker.url(), json=payload)
+
+    assert request.headers["content-type"] == "application/json"
+    assert "content-length" not in request.headers
+    assert "transfer-encoding" not in request.headers
+
+
+def test_sync_send_rejects_transport_managed_header_added_after_build(faker: Faker) -> None:
+    with foghttp.Client() as client:
+        request = client.build_request(POST, faker.url(), content=faker.sentence())
+        request.headers["Content-Length"] = "10"
+
+        with pytest.raises(ValueError, match="managed by FogHTTP transport"):
+            client.send(request)
+
+        stats = client.stats()
+
+    assert stats.total_requests == 0
+
+
+async def test_async_send_rejects_transport_managed_header_added_after_build(
+    faker: Faker,
+) -> None:
+    async with foghttp.AsyncClient() as client:
+        request = client.build_request(POST, faker.url(), content=faker.sentence())
+        request.headers["Content-Length"] = "10"
+
+        with pytest.raises(ValueError, match="managed by FogHTTP transport"):
+            await client.send(request)
+
+        stats = client.stats()
+
+    assert stats.total_requests == 0

--- a/tests/test_async_redirects.py
+++ b/tests/test_async_redirects.py
@@ -123,7 +123,7 @@ async def test_same_origin_redirect_preserves_sensitive_headers(http_server: str
     assert header_values(payload, "authorization") == ["Bearer secret"]
     assert header_values(payload, "proxy-authorization") == ["Basic proxy-secret"]
     assert header_values(payload, "cookie") == ["session=secret"]
-    assert header_values(payload, "host") == ["example.com"]
+    assert header_values(payload, "host") == [urlsplit(http_server).netloc]
     assert header_values(payload, "origin") == ["https://example.com"]
     assert header_values(payload, "referer") == ["https://example.com/source"]
 

--- a/tests/test_sync_redirects.py
+++ b/tests/test_sync_redirects.py
@@ -116,7 +116,7 @@ def test_same_origin_redirect_preserves_sensitive_headers(sync_http_server: str)
     assert header_values(payload, "authorization") == ["Bearer secret"]
     assert header_values(payload, "proxy-authorization") == ["Basic proxy-secret"]
     assert header_values(payload, "cookie") == ["session=secret"]
-    assert header_values(payload, "host") == ["example.com"]
+    assert header_values(payload, "host") == [urlsplit(sync_http_server).netloc]
     assert header_values(payload, "origin") == ["https://example.com"]
     assert header_values(payload, "referer") == ["https://example.com/source"]
 


### PR DESCRIPTION
- validate unsafe headers in request builder and send paths
- block manual Host and framing or hop-by-hop headers
- preserve semantic request headers such as Content-Type
- cover sync and async prepared request mutation cases