### PR TITLE
refactor(request-builder): add client defaults merge contract

### DIFF
--- a/foghttp/_client/config.py
+++ b/foghttp/_client/config.py
@@ -7,6 +7,7 @@ from ..timeouts import Timeouts
 from ..tls import TLSConfig
 from ..types import HttpVersions
 from .options import validate_client_options
+from .request_builder.defaults import DEFAULT_REQUEST_BUILD_DEFAULTS, RequestBuildDefaults
 
 
 @dataclass(frozen=True, slots=True)
@@ -19,6 +20,7 @@ class ClientConfig:
     tls: TLSConfig | None
     runtime_workers: int | None
     observability: bool
+    request_defaults: RequestBuildDefaults
 
     @classmethod
     def from_options(
@@ -51,4 +53,5 @@ class ClientConfig:
             tls=tls,
             runtime_workers=runtime_workers,
             observability=observability,
+            request_defaults=DEFAULT_REQUEST_BUILD_DEFAULTS,
         )

--- a/foghttp/_client/core.py
+++ b/foghttp/_client/core.py
@@ -15,6 +15,7 @@ from ..url import URL
 from .config import ClientConfig
 from .raw import create_raw_client
 from .request_builder.builder import RequestBuilder
+from .request_builder.merge import RequestMergeContract
 from .request_builder.models import RequestBuildOptions
 from .stats import stats_from_raw
 
@@ -29,7 +30,9 @@ class ClientCore:
         self._closed = False
         self._client_lock = threading.Lock()
         self._client: _foghttp.RawClient | None = None
-        self._request_builder = RequestBuilder()
+        self._request_builder = RequestBuilder(
+            merge_contract=RequestMergeContract(defaults=config.request_defaults),
+        )
 
     def __del__(self) -> None:
         if getattr(self, "_closed", True) is False:

--- a/foghttp/_client/request_builder/builder.py
+++ b/foghttp/_client/request_builder/builder.py
@@ -4,15 +4,19 @@ from ...body import encode_body
 from ...headers import Headers, HeaderSource
 from ...request import Request
 from ...types import QueryParams
-from ...url import URL, merge_params
+from ...url import URL
 from .header_policy import validate_safe_request_headers
+from .merge import RequestMergeContract
 from .models import RequestBuildOptions
 
 
 class RequestBuilder:
     """Build prepared requests without touching transport state."""
 
-    __slots__ = ()
+    __slots__ = ("_merge_contract",)
+
+    def __init__(self, *, merge_contract: RequestMergeContract | None = None) -> None:
+        self._merge_contract = merge_contract or RequestMergeContract()
 
     def build(self, options: RequestBuildOptions) -> Request:
         request_url = self._build_url(options.url, options.params)
@@ -27,10 +31,10 @@ class RequestBuilder:
         )
 
     def _build_url(self, url: str | URL, params: QueryParams) -> str:
-        return merge_params(url, params)
+        return self._merge_contract.url(url, params)
 
     def _build_headers(self, headers: HeaderSource) -> Headers:
-        return Headers(headers)
+        return self._merge_contract.headers(headers)
 
     def _build_body(self, options: RequestBuildOptions, headers: Headers) -> bytes | None:
         return encode_body(

--- a/foghttp/_client/request_builder/defaults.py
+++ b/foghttp/_client/request_builder/defaults.py
@@ -1,0 +1,38 @@
+__all__ = ("DEFAULT_REQUEST_BUILD_DEFAULTS", "FrozenHeaderPairs", "RequestBuildDefaults")
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+from ...headers import Headers, HeaderSource
+from ...types import QueryParams
+from ...url import URL, _query_string
+
+
+FrozenHeaderPairs: TypeAlias = tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RequestBuildDefaults:
+    """Immutable snapshot of client-level request builder defaults."""
+
+    base_url: URL | None = None
+    headers: FrozenHeaderPairs = ()
+    params: str | None = None
+
+    @classmethod
+    def from_options(
+        cls,
+        *,
+        base_url: str | URL | None = None,
+        headers: HeaderSource = None,
+        params: QueryParams = None,
+    ) -> "RequestBuildDefaults":
+        query = _query_string(params)
+        return cls(
+            base_url=None if base_url is None else URL(base_url),
+            headers=tuple(Headers(headers).multi_items()),
+            params=query or None,
+        )
+
+
+DEFAULT_REQUEST_BUILD_DEFAULTS = RequestBuildDefaults()

--- a/foghttp/_client/request_builder/merge.py
+++ b/foghttp/_client/request_builder/merge.py
@@ -1,0 +1,53 @@
+__all__ = ("RequestMergeContract",)
+
+from dataclasses import dataclass
+
+from ...headers import HeaderPairs, Headers, HeaderSource
+from ...types import QueryParams
+from ...url import URL
+from .defaults import DEFAULT_REQUEST_BUILD_DEFAULTS, RequestBuildDefaults
+
+
+@dataclass(frozen=True, slots=True)
+class RequestMergeContract:
+    """Apply the client defaults merge contract for prepared requests.
+
+    URL order is base URL resolution, request URL query, client params, then
+    per-request params. Header order is client defaults, reserved future
+    auth-managed headers, then per-request headers.
+    """
+
+    defaults: RequestBuildDefaults = DEFAULT_REQUEST_BUILD_DEFAULTS
+
+    def url(self, url: str | URL, params: QueryParams) -> str:
+        request_url = self._request_url(url)
+        if self.defaults.params is not None:
+            request_url = request_url.with_params(self.defaults.params)
+        return str(request_url.with_params(params))
+
+    def headers(self, headers: HeaderSource) -> Headers:
+        default_headers = Headers(self.defaults.headers)
+        request_headers = Headers(headers)
+        override_names = {name.lower() for name, _value in request_headers.multi_items()}
+        merged = Headers(
+            self._default_headers_without_overrides(default_headers, override_names),
+        )
+        for name, value in request_headers.multi_items():
+            merged.add(name, value)
+        return merged
+
+    def _default_headers_without_overrides(
+        self,
+        headers: Headers,
+        override_names: set[str],
+    ) -> HeaderPairs:
+        items = []
+        for name, value in headers.multi_items():
+            if name.lower() not in override_names:
+                items.append((name, value))
+        return items
+
+    def _request_url(self, url: str | URL) -> URL:
+        if self.defaults.base_url is None:
+            return URL(url)
+        return self.defaults.base_url.join(url)

--- a/tests/request_builder/test_merge_contract.py
+++ b/tests/request_builder/test_merge_contract.py
@@ -1,0 +1,128 @@
+import pytest
+
+from foghttp._client.request_builder.builder import RequestBuilder
+from foghttp._client.request_builder.defaults import RequestBuildDefaults
+from foghttp._client.request_builder.merge import RequestMergeContract
+from foghttp._client.request_builder.models import RequestBuildOptions
+from foghttp.headers import Headers, HeaderSource
+from foghttp.messages import transport_managed_header_error
+from foghttp.methods import GET
+from foghttp.types import QueryParams
+
+
+def test_merge_contract_combines_base_url_query_and_params_in_order() -> None:
+    builder = _builder(
+        base_url="https://api.example.com/v1/",
+        params=[
+            ("client", "default"),
+            ("trace", "client"),
+        ],
+    )
+
+    request = builder.build(
+        RequestBuildOptions(
+            method=GET,
+            url="users?debug=1#profile",
+            params=[
+                ("trace", "request"),
+                ("page", 2),
+            ],
+        ),
+    )
+
+    assert (
+        request.url == "https://api.example.com/v1/users"
+        "?debug=1&client=default&trace=client&trace=request&page=2#profile"
+    )
+
+
+def test_merge_contract_absolute_request_url_ignores_base_url() -> None:
+    builder = _builder(
+        base_url="https://internal.example.com/v1/",
+        params={"client": "default"},
+    )
+
+    request = builder.build(
+        RequestBuildOptions(
+            method=GET,
+            url="https://api.example.com/search?debug=1",
+            params={"page": 2},
+        ),
+    )
+
+    assert request.url == "https://api.example.com/search?debug=1&client=default&page=2"
+
+
+def test_merge_contract_request_headers_override_defaults_case_insensitively() -> None:
+    builder = _builder(
+        headers=[
+            ("Accept", "application/json"),
+            ("X-Client", "default-client"),
+            ("X-Trace", "client-trace"),
+        ],
+    )
+
+    request = builder.build(
+        RequestBuildOptions(
+            method=GET,
+            url="https://api.example.com/users",
+            headers=[
+                ("accept", "text/plain"),
+                ("x-trace", "request-trace-1"),
+                ("X-Trace", "request-trace-2"),
+            ],
+        ),
+    )
+
+    assert request.headers.multi_items() == [
+        ("X-Client", "default-client"),
+        ("accept", "text/plain"),
+        ("x-trace", "request-trace-1"),
+        ("X-Trace", "request-trace-2"),
+    ]
+
+
+def test_merge_contract_snapshots_user_supplied_defaults() -> None:
+    default_headers = Headers([("Accept", "application/json")])
+    default_tags = ["rust"]
+    default_params = {"tag": default_tags}
+    builder = _builder(headers=default_headers, params=default_params)
+
+    default_headers["Accept"] = "text/plain"
+    default_tags.append("python")
+
+    request = builder.build(
+        RequestBuildOptions(
+            method=GET,
+            url="https://api.example.com/search",
+        ),
+    )
+
+    assert request.headers["accept"] == "application/json"
+    assert request.url == "https://api.example.com/search?tag=rust"
+
+
+def test_merge_contract_rejects_transport_managed_default_headers() -> None:
+    builder = _builder(headers={"Host": "api.example.com"})
+
+    with pytest.raises(ValueError, match=transport_managed_header_error("Host")):
+        builder.build(
+            RequestBuildOptions(
+                method=GET,
+                url="https://api.example.com/users",
+            ),
+        )
+
+
+def _builder(
+    *,
+    base_url: str | None = None,
+    headers: HeaderSource = None,
+    params: QueryParams = None,
+) -> RequestBuilder:
+    defaults = RequestBuildDefaults.from_options(
+        base_url=base_url,
+        headers=headers,
+        params=params,
+    )
+    return RequestBuilder(merge_contract=RequestMergeContract(defaults=defaults))


### PR DESCRIPTION
- add immutable request build defaults snapshot
- centralize URL, query params, and header merge order
- wire ClientConfig through the shared request builder pipeline
- cover merge order, default snapshots, and safe header validation