### PR TITLE
feat(client): add base_url support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Runtime requirements:
 import foghttp
 
 
-with foghttp.Client() as client:
+with foghttp.Client(base_url="https://api.example.com") as client:
     response = client.get(
-        "https://api.example.com/users",
+        "users",
         headers={"accept": "application/json"},
         params={"limit": 10},
     )
@@ -78,6 +78,7 @@ async with foghttp.AsyncClient() as client:
 
 - sync `Client` and async `AsyncClient`
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
+- `base_url` for reusable API clients and relative request paths
 - query params with repeated keys, JSON bodies, and buffered bytes/text bodies
 - buffered `Response` with status flags, `text`, `json()`,
   `raise_for_status()`, and request metadata

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: "home"
 hero:
   name: "FogHTTP"
   text: "Rust-powered HTTP client for Python"
-  tagline: "Buffered JSON requests, sync and async clients, redirects, custom CA certificates, cancellation, and observable request limits."
+  tagline: "Buffered JSON requests, base URL clients, sync and async APIs, redirects, custom CA certificates, cancellation, and observable request limits."
 
 features:
   - title: "Rust transport"
@@ -14,7 +14,7 @@ features:
     details: "Use Client in scripts and workers, or AsyncClient for high-concurrency asyncio workloads."
 
   - title: "Focused MVP"
-    details: "FogHTTP is intentionally small today: buffered responses, JSON, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
+    details: "FogHTTP is intentionally small today: buffered responses, JSON, base URL clients, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
 ---
 
 # FogHTTP Documentation
@@ -79,6 +79,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 
 - sync `Client` and async `AsyncClient`
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
+- `base_url` for reusable API clients and relative request paths
 - query params with repeated keys, JSON bodies, and buffered bytes/text bodies
 - response status flags for success, redirects, and client/server errors
 - prepared `Request` objects with `build_request()` and `send()`

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -13,6 +13,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - sync `Client`
 - async `AsyncClient`
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
+- `base_url` for reusable API clients and relative request paths
 - query parameters from mappings, repeated pairs, and raw query strings
 - JSON bodies through `json=`
 - raw bytes/text bodies through `content=`
@@ -55,7 +56,6 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | Disabling TLS verification | Not available; use `TLSConfig` with explicit CA certificates |
 | HTTP/2 | Not available |
 | Compression decoding | Not available |
-| `base_url` | Not available |
 | default client headers | Not available |
 | transport-managed request headers | Safe API rejects manual `Host`, `Content-Length`, `Transfer-Encoding`, `TE`, `Trailer`, `Connection`, `Upgrade`, `Keep-Alive`, and `Proxy-Connection` |
 | true active connection-level limits | `max_active_requests_per_origin` limits buffered request slots; physical TCP connection-level accounting is not exposed yet |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,6 +57,38 @@ with foghttp.Client() as client:
 
 :::
 
+## Base URL
+
+Use `base_url=` when one client talks to one upstream service. Request URLs can
+then be relative paths.
+
+::: code-group
+
+```python [Async]
+async with foghttp.AsyncClient(base_url="https://api.example.com/v1") as client:
+    response = await client.get("users", params={"limit": 10})
+    response.raise_for_status()
+```
+
+```python [Sync]
+with foghttp.Client(base_url="https://api.example.com/v1") as client:
+    response = client.get("users", params={"limit": 10})
+    response.raise_for_status()
+```
+
+:::
+
+FogHTTP stores `base_url` as a path prefix, so both
+`https://api.example.com/v1` and `https://api.example.com/v1/` resolve
+`"users"` to `https://api.example.com/v1/users`. A request path that starts
+with `/` is root-relative and resolves against the origin root:
+`"/users"` becomes `https://api.example.com/users`.
+
+Absolute request URLs ignore `base_url`.
+
+`base_url` must not include query parameters or a fragment. Use per-request
+`params=` for query parameters.
+
 ## Query Parameters
 
 Use `params=` with mappings, repeated pairs, or an already encoded query string.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -166,6 +166,18 @@ with foghttp.Client() as client:
     response = client.send(request)
 ```
 
+### One-Upstream API Clients
+
+Use `base_url` for service clients that send many requests to the same
+upstream. Relative paths keep call sites focused on API resources instead of
+repeating the origin every time.
+
+```python
+with foghttp.Client(base_url="https://api.example.com/v1") as client:
+    response = client.get("users", params={"limit": 10})
+    response.raise_for_status()
+```
+
 ## Usable With Constraints
 
 ### Manual Bearer Tokens

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 # FogHTTP Examples
 
-These examples focus on workloads where FogHTTP already works well.
+These examples focus on workloads where FogHTTP already works well, including
+reusable `base_url` clients for one-upstream APIs.
 
 Run them from the repository root after building the local extension:
 

--- a/examples/sync_json_api.py
+++ b/examples/sync_json_api.py
@@ -14,9 +14,9 @@ import foghttp
 
 
 def main() -> None:
-    with foghttp.Client() as client:
+    with foghttp.Client(base_url="https://httpbin.org") as client:
         response = client.post(
-            "https://httpbin.org/post",
+            "post",
             json={"name": "Ada Lovelace", "role": "engineer"},
         )
 

--- a/foghttp/_client/config.py
+++ b/foghttp/_client/config.py
@@ -6,6 +6,7 @@ from ..limits import Limits
 from ..timeouts import Timeouts
 from ..tls import TLSConfig
 from ..types import HttpVersions
+from ..url import URL
 from .options import validate_client_options
 from .request_builder.defaults import DEFAULT_REQUEST_BUILD_DEFAULTS, RequestBuildDefaults
 
@@ -26,6 +27,7 @@ class ClientConfig:
     def from_options(
         cls,
         *,
+        base_url: str | URL | None,
         limits: Limits | None,
         timeouts: Timeouts | None,
         http_versions: HttpVersions,
@@ -53,5 +55,9 @@ class ClientConfig:
             tls=tls,
             runtime_workers=runtime_workers,
             observability=observability,
-            request_defaults=DEFAULT_REQUEST_BUILD_DEFAULTS,
+            request_defaults=(
+                DEFAULT_REQUEST_BUILD_DEFAULTS
+                if base_url is None
+                else RequestBuildDefaults.from_options(base_url=base_url)
+            ),
         )

--- a/foghttp/_client/request_builder/defaults.py
+++ b/foghttp/_client/request_builder/defaults.py
@@ -2,8 +2,10 @@ __all__ = ("DEFAULT_REQUEST_BUILD_DEFAULTS", "FrozenHeaderPairs", "RequestBuildD
 
 from dataclasses import dataclass
 from typing import TypeAlias
+from urllib.parse import urlsplit, urlunsplit
 
 from ...headers import Headers, HeaderSource
+from ...messages import BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED
 from ...types import QueryParams
 from ...url import URL, _query_string
 
@@ -29,10 +31,25 @@ class RequestBuildDefaults:
     ) -> "RequestBuildDefaults":
         query = _query_string(params)
         return cls(
-            base_url=None if base_url is None else URL(base_url),
+            base_url=_normalized_base_url(base_url),
             headers=tuple(Headers(headers).multi_items()),
             params=query or None,
         )
+
+
+def _normalized_base_url(url: str | URL | None) -> URL | None:
+    if url is None:
+        return None
+
+    parsed_url = URL(url)
+    if parsed_url.query or parsed_url.fragment:
+        raise ValueError(BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED)
+
+    parts = urlsplit(str(parsed_url))
+    path = parts.path or "/"
+    if not path.endswith("/"):
+        path = f"{path}/"
+    return URL(urlunsplit((parts.scheme, parts.netloc, path, "", "")))
 
 
 DEFAULT_REQUEST_BUILD_DEFAULTS = RequestBuildDefaults()

--- a/foghttp/async_client.py
+++ b/foghttp/async_client.py
@@ -25,6 +25,7 @@ class AsyncClient(ClientCore):
     def __init__(
         self,
         *,
+        base_url: str | URL | None = None,
         limits: Limits | None = None,
         timeouts: Timeouts | None = None,
         http_versions: HttpVersions = None,
@@ -38,6 +39,7 @@ class AsyncClient(ClientCore):
     ) -> None:
         super().__init__(
             config=ClientConfig.from_options(
+                base_url=base_url,
                 limits=limits,
                 timeouts=timeouts,
                 http_versions=http_versions,

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -30,6 +30,7 @@ class Client(ClientCore):
     def __init__(
         self,
         *,
+        base_url: str | URL | None = None,
         limits: Limits | None = None,
         timeouts: Timeouts | None = None,
         http_versions: HttpVersions = None,
@@ -43,6 +44,7 @@ class Client(ClientCore):
     ) -> None:
         super().__init__(
             config=ClientConfig.from_options(
+                base_url=base_url,
                 limits=limits,
                 timeouts=timeouts,
                 http_versions=http_versions,

--- a/foghttp/messages.py
+++ b/foghttp/messages.py
@@ -1,4 +1,5 @@
 __all__ = (
+    "BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED",
     "BODY_CONTENT_AND_JSON_CONFLICT",
     "CLIENT_CLOSED",
     "COOKIES_UNSUPPORTED",
@@ -18,6 +19,7 @@ __all__ = (
 from http import HTTPStatus
 
 
+BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED = "base_url must not include query or fragment"
 BODY_CONTENT_AND_JSON_CONFLICT = "pass either content or json, not both"
 CLIENT_CLOSED = "AsyncClient is closed"
 COOKIES_UNSUPPORTED = "cookies are planned after the MVP"

--- a/tests/request_builder/test_base_url.py
+++ b/tests/request_builder/test_base_url.py
@@ -1,0 +1,91 @@
+import pytest
+
+import foghttp
+from foghttp.messages import BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED
+from foghttp.methods import GET
+
+
+API_BASE_URL = "https://api.example.com/v1"
+API_BASE_URL_WITH_SLASH = f"{API_BASE_URL}/"
+API_USERS_URL = f"{API_BASE_URL}/users"
+ROOT_USERS_URL = "https://api.example.com/users"
+RELATIVE_USERS_URL = "users"
+USERS_URL_WITH_QUERY_AND_FRAGMENT = "users?debug=1#profile"
+
+
+@pytest.mark.parametrize("base_url", [API_BASE_URL, API_BASE_URL_WITH_SLASH])
+def test_sync_build_request_resolves_relative_url_against_base_url(base_url: str) -> None:
+    with foghttp.Client(base_url=base_url) as client:
+        request = client.build_request(
+            GET,
+            USERS_URL_WITH_QUERY_AND_FRAGMENT,
+            params={"page": 2},
+        )
+
+    assert request.url == f"{API_USERS_URL}?debug=1&page=2#profile"
+
+
+async def test_async_build_request_resolves_relative_url_against_base_url() -> None:
+    async with foghttp.AsyncClient(base_url=foghttp.URL(API_BASE_URL)) as client:
+        request = client.build_request(
+            GET,
+            USERS_URL_WITH_QUERY_AND_FRAGMENT,
+            params={"page": 2},
+        )
+
+    assert request.url == f"{API_USERS_URL}?debug=1&page=2#profile"
+
+
+def test_base_url_allows_root_relative_paths_to_escape_base_path() -> None:
+    with foghttp.Client(base_url=API_BASE_URL) as client:
+        request = client.build_request(GET, "/users")
+
+    assert request.url == ROOT_USERS_URL
+
+
+def test_absolute_request_url_ignores_base_url() -> None:
+    with foghttp.Client(base_url="https://internal.example.com/v1") as client:
+        request = client.build_request(GET, ROOT_USERS_URL)
+
+    assert request.url == ROOT_USERS_URL
+
+
+def test_build_request_with_base_url_does_not_create_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    def create_raw_client_probe(*_args: object, **_kwargs: object) -> object:
+        msg = "build_request() must not create a RawClient"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("foghttp._client.core.create_raw_client", create_raw_client_probe)
+
+    with foghttp.Client(base_url=API_BASE_URL) as client:
+        request = client.build_request(GET, RELATIVE_USERS_URL)
+
+    assert request.url == API_USERS_URL
+
+
+def test_sync_request_sends_relative_url_against_base_url(sync_http_server: str) -> None:
+    with foghttp.Client(base_url=sync_http_server) as client:
+        response = client.get(RELATIVE_USERS_URL, params={"limit": 10})
+
+    assert response.request.url == f"{sync_http_server}/users?limit=10"
+    assert response.json()["request_line"] == "GET /users?limit=10 HTTP/1.1"
+
+
+async def test_async_request_sends_relative_url_against_base_url(http_server: str) -> None:
+    async with foghttp.AsyncClient(base_url=http_server) as client:
+        response = await client.get(RELATIVE_USERS_URL, params={"limit": 10})
+
+    assert response.request.url == f"{http_server}/users?limit=10"
+    assert response.json()["request_line"] == "GET /users?limit=10 HTTP/1.1"
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.example.com/v1?token=secret",
+        "https://api.example.com/v1#users",
+    ],
+)
+def test_base_url_rejects_query_and_fragment(base_url: str) -> None:
+    with pytest.raises(ValueError, match=BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED):
+        foghttp.Client(base_url=base_url)


### PR DESCRIPTION
- accept base_url in sync and async clients
- resolve relative request URLs through the shared request builder contract
- normalize base_url as a path prefix and reject query or fragment
- document base_url behavior and cover sync/async request scenarios