### PR TITLE
feat(client): add default headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ Runtime requirements:
 import foghttp
 
 
-with foghttp.Client(base_url="https://api.example.com") as client:
+with foghttp.Client(
+    base_url="https://api.example.com",
+    headers={"accept": "application/json"},
+) as client:
     response = client.get(
         "users",
-        headers={"accept": "application/json"},
         params={"limit": 10},
     )
 
@@ -79,6 +81,7 @@ async with foghttp.AsyncClient() as client:
 - sync `Client` and async `AsyncClient`
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
 - `base_url` for reusable API clients and relative request paths
+- default client headers with per-request overrides
 - query params with repeated keys, JSON bodies, and buffered bytes/text bodies
 - buffered `Response` with status flags, `text`, `json()`,
   `raise_for_status()`, and request metadata

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: "home"
 hero:
   name: "FogHTTP"
   text: "Rust-powered HTTP client for Python"
-  tagline: "Buffered JSON requests, base URL clients, sync and async APIs, redirects, custom CA certificates, cancellation, and observable request limits."
+  tagline: "Buffered JSON requests, base URL clients, default headers, sync and async APIs, redirects, custom CA certificates, cancellation, and observable request limits."
 
 features:
   - title: "Rust transport"
@@ -14,7 +14,7 @@ features:
     details: "Use Client in scripts and workers, or AsyncClient for high-concurrency asyncio workloads."
 
   - title: "Focused MVP"
-    details: "FogHTTP is intentionally small today: buffered responses, JSON, base URL clients, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
+    details: "FogHTTP is intentionally small today: buffered responses, JSON, base URL clients, default headers, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
 ---
 
 # FogHTTP Documentation
@@ -80,6 +80,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - sync `Client` and async `AsyncClient`
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
 - `base_url` for reusable API clients and relative request paths
+- default client headers with per-request overrides
 - query params with repeated keys, JSON bodies, and buffered bytes/text bodies
 - response status flags for success, redirects, and client/server errors
 - prepared `Request` objects with `build_request()` and `send()`

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -14,6 +14,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - async `AsyncClient`
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
 - `base_url` for reusable API clients and relative request paths
+- default client headers with per-request overrides
 - query parameters from mappings, repeated pairs, and raw query strings
 - JSON bodies through `json=`
 - raw bytes/text bodies through `content=`
@@ -56,7 +57,6 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | Disabling TLS verification | Not available; use `TLSConfig` with explicit CA certificates |
 | HTTP/2 | Not available |
 | Compression decoding | Not available |
-| default client headers | Not available |
 | transport-managed request headers | Safe API rejects manual `Host`, `Content-Length`, `Transfer-Encoding`, `TE`, `Trailer`, `Connection`, `Upgrade`, `Keep-Alive`, and `Proxy-Connection` |
 | true active connection-level limits | `max_active_requests_per_origin` limits buffered request slots; physical TCP connection-level accounting is not exposed yet |
 | per-request connect timeout changes | `Timeouts.connect` configures the Rust connector from client-level settings when transport state is created; per-request `timeout.connect` does not reconfigure the connector |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -89,6 +89,47 @@ Absolute request URLs ignore `base_url`.
 `base_url` must not include query parameters or a fragment. Use per-request
 `params=` for query parameters.
 
+## Default Headers
+
+Use client-level `headers=` for values that should be sent with every request
+from that client.
+
+::: code-group
+
+```python [Async]
+async with foghttp.AsyncClient(
+    base_url="https://api.example.com/v1",
+    headers={"accept": "application/json", "x-client": "foghttp"},
+) as client:
+    response = await client.get("users")
+    response.raise_for_status()
+```
+
+```python [Sync]
+with foghttp.Client(
+    base_url="https://api.example.com/v1",
+    headers={"accept": "application/json", "x-client": "foghttp"},
+) as client:
+    response = client.get("users")
+    response.raise_for_status()
+```
+
+:::
+
+Per-request headers override client defaults case-insensitively. Repeated
+headers are preserved when they are not overridden.
+
+```python
+with foghttp.Client(
+    base_url="https://api.example.com/v1",
+    headers={"accept": "application/json"},
+) as client:
+    response = client.get("users", headers={"accept": "text/plain"})
+```
+
+FogHTTP applies the same transport-managed header policy to client defaults and
+per-request headers.
+
 ## Query Parameters
 
 Use `params=` with mappings, repeated pairs, or an already encoded query string.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -173,7 +173,10 @@ upstream. Relative paths keep call sites focused on API resources instead of
 repeating the origin every time.
 
 ```python
-with foghttp.Client(base_url="https://api.example.com/v1") as client:
+with foghttp.Client(
+    base_url="https://api.example.com/v1",
+    headers={"accept": "application/json"},
+) as client:
     response = client.get("users", params={"limit": 10})
     response.raise_for_status()
 ```
@@ -189,6 +192,9 @@ headers.
 headers = {"authorization": f"Bearer {token}"}
 response = client.get("https://api.example.com/me", headers=headers)
 ```
+
+For one-upstream clients with a static token, client-level `headers=` can avoid
+repeating the same header at every call site.
 
 For token refresh, retries after `401`, request signing, or OAuth flows, wait
 for the planned auth/hooks layer or keep that logic outside FogHTTP.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # FogHTTP Examples
 
 These examples focus on workloads where FogHTTP already works well, including
-reusable `base_url` clients for one-upstream APIs.
+reusable `base_url` clients and default headers for one-upstream APIs.
 
 Run them from the repository root after building the local extension:
 

--- a/examples/sync_json_api.py
+++ b/examples/sync_json_api.py
@@ -14,7 +14,10 @@ import foghttp
 
 
 def main() -> None:
-    with foghttp.Client(base_url="https://httpbin.org") as client:
+    with foghttp.Client(
+        base_url="https://httpbin.org",
+        headers={"accept": "application/json"},
+    ) as client:
         response = client.post(
             "post",
             json={"name": "Ada Lovelace", "role": "engineer"},

--- a/foghttp/_client/config.py
+++ b/foghttp/_client/config.py
@@ -2,6 +2,7 @@ __all__ = ("ClientConfig",)
 
 from dataclasses import dataclass
 
+from ..headers import HeaderSource
 from ..limits import Limits
 from ..timeouts import Timeouts
 from ..tls import TLSConfig
@@ -28,6 +29,7 @@ class ClientConfig:
         cls,
         *,
         base_url: str | URL | None,
+        headers: HeaderSource,
         limits: Limits | None,
         timeouts: Timeouts | None,
         http_versions: HttpVersions,
@@ -57,7 +59,7 @@ class ClientConfig:
             observability=observability,
             request_defaults=(
                 DEFAULT_REQUEST_BUILD_DEFAULTS
-                if base_url is None
-                else RequestBuildDefaults.from_options(base_url=base_url)
+                if base_url is None and headers is None
+                else RequestBuildDefaults.from_options(base_url=base_url, headers=headers)
             ),
         )

--- a/foghttp/_client/request_builder/defaults.py
+++ b/foghttp/_client/request_builder/defaults.py
@@ -8,6 +8,7 @@ from ...headers import Headers, HeaderSource
 from ...messages import BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED
 from ...types import QueryParams
 from ...url import URL, _query_string
+from .header_policy import validate_safe_request_headers
 
 
 FrozenHeaderPairs: TypeAlias = tuple[tuple[str, str], ...]
@@ -30,9 +31,11 @@ class RequestBuildDefaults:
         params: QueryParams = None,
     ) -> "RequestBuildDefaults":
         query = _query_string(params)
+        default_headers = Headers(headers)
+        validate_safe_request_headers(default_headers)
         return cls(
             base_url=_normalized_base_url(base_url),
-            headers=tuple(Headers(headers).multi_items()),
+            headers=tuple(default_headers.multi_items()),
             params=query or None,
         )
 

--- a/foghttp/async_client.py
+++ b/foghttp/async_client.py
@@ -26,6 +26,7 @@ class AsyncClient(ClientCore):
         self,
         *,
         base_url: str | URL | None = None,
+        headers: HeaderSource = None,
         limits: Limits | None = None,
         timeouts: Timeouts | None = None,
         http_versions: HttpVersions = None,
@@ -40,6 +41,7 @@ class AsyncClient(ClientCore):
         super().__init__(
             config=ClientConfig.from_options(
                 base_url=base_url,
+                headers=headers,
                 limits=limits,
                 timeouts=timeouts,
                 http_versions=http_versions,

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -31,6 +31,7 @@ class Client(ClientCore):
         self,
         *,
         base_url: str | URL | None = None,
+        headers: HeaderSource = None,
         limits: Limits | None = None,
         timeouts: Timeouts | None = None,
         http_versions: HttpVersions = None,
@@ -45,6 +46,7 @@ class Client(ClientCore):
         super().__init__(
             config=ClientConfig.from_options(
                 base_url=base_url,
+                headers=headers,
                 limits=limits,
                 timeouts=timeouts,
                 http_versions=http_versions,

--- a/tests/request_builder/test_default_headers.py
+++ b/tests/request_builder/test_default_headers.py
@@ -1,0 +1,111 @@
+from faker import Faker
+import pytest
+
+import foghttp
+from foghttp.methods import GET
+
+
+DEFAULT_ACCEPT = "application/json"
+REQUEST_ACCEPT = "text/plain"
+DEFAULT_TENANT = "tenant-default"
+DEFAULT_TRACE = "trace-default"
+REQUEST_TRACE = "trace-request"
+ECHO_HEADERS_PATH = "/headers/echo"
+
+
+def test_sync_build_request_applies_default_headers() -> None:
+    with foghttp.Client(headers={"Accept": DEFAULT_ACCEPT}) as client:
+        request = client.build_request(GET, "https://api.example.com/users")
+
+    assert request.headers["accept"] == DEFAULT_ACCEPT
+
+
+async def test_async_build_request_applies_default_headers() -> None:
+    async with foghttp.AsyncClient(headers={"Accept": DEFAULT_ACCEPT}) as client:
+        request = client.build_request(GET, "https://api.example.com/users")
+
+    assert request.headers["accept"] == DEFAULT_ACCEPT
+
+
+def test_request_headers_override_default_headers_case_insensitively() -> None:
+    default_headers = [
+        ("Accept", DEFAULT_ACCEPT),
+        ("X-Tenant", DEFAULT_TENANT),
+        ("X-Trace", DEFAULT_TRACE),
+    ]
+    request_headers = [
+        ("accept", REQUEST_ACCEPT),
+        ("x-trace", REQUEST_TRACE),
+        ("X-Trace", f"{REQUEST_TRACE}-second"),
+    ]
+
+    with foghttp.Client(headers=default_headers) as client:
+        request = client.build_request(
+            GET,
+            "https://api.example.com/users",
+            headers=request_headers,
+        )
+
+    assert request.headers.multi_items() == [
+        ("X-Tenant", DEFAULT_TENANT),
+        ("accept", REQUEST_ACCEPT),
+        ("x-trace", REQUEST_TRACE),
+        ("X-Trace", f"{REQUEST_TRACE}-second"),
+    ]
+
+
+def test_default_headers_snapshot_user_supplied_headers(faker: Faker) -> None:
+    default_headers = foghttp.Headers([("Accept", DEFAULT_ACCEPT), ("X-Trace", faker.slug())])
+    expected_trace_values = default_headers.get_list("x-trace")
+
+    with foghttp.Client(headers=default_headers) as client:
+        default_headers["Accept"] = REQUEST_ACCEPT
+        default_headers.add("X-Trace", faker.slug())
+        request = client.build_request(GET, "https://api.example.com/users")
+
+    assert request.headers["accept"] == DEFAULT_ACCEPT
+    assert request.headers.get_list("x-trace") == expected_trace_values
+
+
+def test_default_headers_reject_transport_managed_header() -> None:
+    with pytest.raises(ValueError, match="managed by FogHTTP transport"):
+        foghttp.Client(headers={"Host": "api.example.com"})
+
+
+async def test_async_default_headers_reject_transport_managed_header() -> None:
+    with pytest.raises(ValueError, match="managed by FogHTTP transport"):
+        foghttp.AsyncClient(headers={"Content-Length": "10"})
+
+
+def test_sync_request_sends_default_headers(sync_http_server: str) -> None:
+    headers = foghttp.Headers(
+        [
+            ("X-Repeat", DEFAULT_TRACE),
+            ("x-repeat", REQUEST_TRACE),
+            ("X-Tenant", DEFAULT_TENANT),
+        ],
+    )
+
+    with foghttp.Client(headers=headers) as client:
+        response = client.get(f"{sync_http_server}{ECHO_HEADERS_PATH}")
+
+    assert response.json()["x-repeat"] == [DEFAULT_TRACE, REQUEST_TRACE]
+    assert response.request.headers.get_list("x-repeat") == [DEFAULT_TRACE, REQUEST_TRACE]
+    assert response.request.headers["x-tenant"] == DEFAULT_TENANT
+
+
+async def test_async_request_sends_default_headers(http_server: str) -> None:
+    headers = foghttp.Headers(
+        [
+            ("X-Repeat", DEFAULT_TRACE),
+            ("x-repeat", REQUEST_TRACE),
+            ("X-Tenant", DEFAULT_TENANT),
+        ],
+    )
+
+    async with foghttp.AsyncClient(headers=headers) as client:
+        response = await client.get(f"{http_server}{ECHO_HEADERS_PATH}")
+
+    assert response.json()["x-repeat"] == [DEFAULT_TRACE, REQUEST_TRACE]
+    assert response.request.headers.get_list("x-repeat") == [DEFAULT_TRACE, REQUEST_TRACE]
+    assert response.request.headers["x-tenant"] == DEFAULT_TENANT

--- a/tests/request_builder/test_merge_contract.py
+++ b/tests/request_builder/test_merge_contract.py
@@ -103,15 +103,8 @@ def test_merge_contract_snapshots_user_supplied_defaults() -> None:
 
 
 def test_merge_contract_rejects_transport_managed_default_headers() -> None:
-    builder = _builder(headers={"Host": "api.example.com"})
-
     with pytest.raises(ValueError, match=transport_managed_header_error("Host")):
-        builder.build(
-            RequestBuildOptions(
-                method=GET,
-                url="https://api.example.com/users",
-            ),
-        )
+        _builder(headers={"Host": "api.example.com"})
 
 
 def _builder(


### PR DESCRIPTION
- accept client-level headers in sync and async clients
- merge default headers through the shared request builder contract
- allow per-request headers to override defaults case-insensitively
- reject transport-managed default headers fail-fast
- document default headers and cover sync/async request scenarios