### PR TITLE
fix(security): redact secret debug surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ async with foghttp.AsyncClient() as client:
 - prepared `Request` objects with `build_request()` and `send()`
 - case-insensitive `Headers` with repeated values
 - safe policy for transport-managed request headers
+- redacted repr/error surfaces for sensitive headers, URL credentials,
+  token-like URL params, and buffered body bytes
 - normalized `URL` model with origin comparison and relative joins
 - GET/HEAD/POST redirects with final URL, history, and conservative replay policy
 - HTTPS with default WebPKI roots and explicit custom CA certificates

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - prepared `Request` objects with `build_request()` and `send()`
 - case-insensitive `Headers` with repeated value support
 - safe policy for transport-managed request headers
+- redacted repr/error surfaces for sensitive headers, URL credentials,
+  token-like URL params, and buffered body bytes
 - normalized `URL` model with origin comparison and relative joins
 - GET/HEAD/POST redirects with final URL, history, and conservative replay policy
 - HTTPS with default WebPKI roots and explicit custom CA certificates

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -354,6 +354,11 @@ transport-managed. The safe API rejects manual `Host`, `Content-Length`,
 and `Proxy-Connection` headers. Use semantic headers such as `Accept`,
 `Authorization`, `Content-Type`, and application-specific `X-*` headers.
 
+Debug-facing representations and `HTTPStatusError` messages redact sensitive
+header values, URL credentials, common token query or fragment parameters, and
+buffered body bytes. Explicit APIs such as `headers["authorization"]`,
+`str(url)`, and `response.content` still return the real values.
+
 ## Custom CA Certificates
 
 FogHTTP uses WebPKI roots by default for HTTPS. For private services with an

--- a/foghttp/_redaction.py
+++ b/foghttp/_redaction.py
@@ -1,0 +1,91 @@
+__all__ = (
+    "REDACTED_VALUE",
+    "redact_header_value",
+    "redact_url",
+)
+
+from urllib.parse import unquote_plus, urlsplit, urlunsplit
+
+
+REDACTED_VALUE = "<redacted>"
+
+SENSITIVE_HEADER_NAMES = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "proxy_authorization",
+        "set_cookie",
+        "x_api_key",
+        "x_auth_token",
+        "x_csrf_token",
+    },
+)
+
+SENSITIVE_QUERY_PARAM_NAMES = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "auth",
+        "authorization",
+        "client_secret",
+        "id_token",
+        "key",
+        "password",
+        "passwd",
+        "pwd",
+        "refresh_token",
+        "secret",
+        "session",
+        "session_id",
+        "sessionid",
+        "token",
+    },
+)
+
+
+def redact_header_value(name: str, value: str) -> str:
+    if _normalized_secret_name(name) in SENSITIVE_HEADER_NAMES:
+        return REDACTED_VALUE
+    return value
+
+
+def redact_url(url: str) -> str:
+    parts = urlsplit(url)
+    netloc = _redact_netloc(parts.netloc)
+    query = _redact_query(parts.query)
+    fragment = _redact_fragment(parts.fragment)
+    return urlunsplit((parts.scheme, netloc, parts.path, query, fragment))
+
+
+def _redact_netloc(netloc: str) -> str:
+    if "@" not in netloc:
+        return netloc
+    _userinfo, host_port = netloc.rsplit("@", maxsplit=1)
+    return f"{REDACTED_VALUE}@{host_port}"
+
+
+def _redact_query(query: str) -> str:
+    if not query:
+        return query
+    return "&".join(_redact_query_part(part) for part in query.split("&"))
+
+
+def _redact_fragment(fragment: str) -> str:
+    if not fragment:
+        return fragment
+    path, separator, query = fragment.partition("?")
+    if separator:
+        return f"{path}{separator}{_redact_query(query)}"
+    return _redact_query(fragment)
+
+
+def _redact_query_part(part: str) -> str:
+    key, _separator, _value = part.partition("=")
+    if _normalized_secret_name(unquote_plus(key)) not in SENSITIVE_QUERY_PARAM_NAMES:
+        return part
+    return f"{key}={REDACTED_VALUE}"
+
+
+def _normalized_secret_name(name: str) -> str:
+    return name.lower().replace("-", "_")

--- a/foghttp/headers.py
+++ b/foghttp/headers.py
@@ -3,6 +3,8 @@ __all__ = ("HeaderPairs", "HeaderSource", "Headers")
 from collections.abc import Iterable, Iterator, Mapping, MutableMapping
 from typing import TypeAlias
 
+from ._redaction import redact_header_value
+
 
 HeaderPairs: TypeAlias = list[tuple[str, str]]
 HeaderSource: TypeAlias = Mapping[str, str] | Iterable[tuple[str, str]] | None
@@ -49,7 +51,7 @@ class Headers(MutableMapping[str, str]):
         return len({lower_name for _original_name, lower_name, _value in self._items})
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.multi_items()!r})"
+        return f"{self.__class__.__name__}({self._redacted_items()!r})"
 
     def add(self, name: str, value: str) -> None:
         self._items.append((name, normalize_header_name(name), value))
@@ -68,6 +70,9 @@ class Headers(MutableMapping[str, str]):
 
     def copy(self) -> "Headers":
         return Headers(self.multi_items())
+
+    def _redacted_items(self) -> HeaderPairs:
+        return [(name, redact_header_value(name, value)) for name, _lower_name, value in self._items]
 
 
 def normalize_header_name(name: str) -> str:

--- a/foghttp/messages.py
+++ b/foghttp/messages.py
@@ -18,6 +18,8 @@ __all__ = (
 
 from http import HTTPStatus
 
+from ._redaction import redact_url
+
 
 BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED = "base_url must not include query or fragment"
 BODY_CONTENT_AND_JSON_CONFLICT = "pass either content or json, not both"
@@ -36,7 +38,7 @@ UNCLOSED_CLIENT = "AsyncClient was not closed"
 def http_status_error(method: str, url: str, status_code: int) -> str:
     reason = http_status_reason(status_code)
     status = f"{status_code} {reason}" if reason else str(status_code)
-    return f"{method} {url} returned {status}"
+    return f"{method} {redact_url(url)} returned {status}"
 
 
 def http_status_reason(status_code: int) -> str:

--- a/foghttp/request.py
+++ b/foghttp/request.py
@@ -1,5 +1,6 @@
 __all__ = ("Request",)
 
+from ._redaction import redact_url
 from .headers import Headers, HeaderSource
 from .url import URL
 
@@ -26,4 +27,4 @@ class Request:
         self.content = content
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.method!r}, {self.url!r})"
+        return f"{self.__class__.__name__}({self.method!r}, {redact_url(self.url)!r})"

--- a/foghttp/request_info.py
+++ b/foghttp/request_info.py
@@ -2,6 +2,7 @@ __all__ = ("RequestInfo",)
 
 from dataclasses import dataclass
 
+from ._redaction import redact_url
 from .headers import Headers
 
 
@@ -10,3 +11,8 @@ class RequestInfo:
     method: str
     url: str
     headers: Headers
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(method={self.method!r}, url={redact_url(self.url)!r}, headers={self.headers!r})"
+        )

--- a/foghttp/response.py
+++ b/foghttp/response.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import orjson
 
+from ._redaction import redact_url
 from .errors import HTTPStatusError
 from .headers import Headers
 from .messages import http_status_error
@@ -25,6 +26,19 @@ class Response:
     http_version: str
     elapsed: float
     history: tuple["Response", ...] = ()
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"status_code={self.status_code!r}, "
+            f"headers={self.headers!r}, "
+            f"content=<{len(self.content)} bytes>, "
+            f"url={redact_url(self.url)!r}, "
+            f"request={self.request!r}, "
+            f"http_version={self.http_version!r}, "
+            f"elapsed={self.elapsed!r}, "
+            f"history=<{len(self.history)} responses>)"
+        )
 
     @property
     def is_success(self) -> bool:

--- a/foghttp/url.py
+++ b/foghttp/url.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import foghttp._foghttp as _foghttp  # noqa: PLR0402
 
+from ._redaction import redact_url
 from .types import QueryParams
 
 
@@ -25,7 +26,7 @@ class URL:
         return self._raw.value
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({str(self)!r})"
+        return f"{self.__class__.__name__}({redact_url(str(self))!r})"
 
     @property
     def scheme(self) -> str:

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,157 @@
+import pytest
+
+import foghttp
+from foghttp.messages import http_status_error
+from foghttp.methods import GET, POST
+from foghttp.status_codes.client_error import NOT_FOUND
+
+
+HEADER_VALUE = "redaction-header-value"
+COOKIE_VALUE = "session=redaction-cookie-value"
+BODY_VALUE = b"redaction response body"
+USERINFO_VALUE = "redaction-userinfo-value"
+QUERY_VALUE = "redaction-query-value"
+FRAGMENT_VALUE = "redaction-fragment-value"
+SAFE_HEADER_VALUE = "trace-id"
+SAFE_QUERY_VALUE = "public"
+
+
+def test_headers_repr_redacts_sensitive_values() -> None:
+    headers = foghttp.Headers(
+        [
+            ("Authorization", f"Bearer {HEADER_VALUE}"),
+            ("Cookie", COOKIE_VALUE),
+            ("X-Trace", SAFE_HEADER_VALUE),
+        ],
+    )
+
+    representation = repr(headers)
+
+    assert HEADER_VALUE not in representation
+    assert COOKIE_VALUE not in representation
+    assert "<redacted>" in representation
+    assert SAFE_HEADER_VALUE in representation
+    assert headers["authorization"] == f"Bearer {HEADER_VALUE}"
+    assert ("Cookie", COOKIE_VALUE) in headers.multi_items()
+
+
+def test_url_repr_redacts_userinfo_and_sensitive_query_and_fragment_params() -> None:
+    url = foghttp.URL(
+        (
+            f"https://user:{USERINFO_VALUE}@example.com/users?"
+            f"access_token={QUERY_VALUE}&q={SAFE_QUERY_VALUE}"
+            f"#/callback?token={FRAGMENT_VALUE}&section={SAFE_QUERY_VALUE}"
+        ),
+    )
+
+    representation = repr(url)
+
+    assert USERINFO_VALUE not in representation
+    assert QUERY_VALUE not in representation
+    assert FRAGMENT_VALUE not in representation
+    assert SAFE_QUERY_VALUE in representation
+    assert "<redacted>@example.com" in representation
+    assert "access_token=<redacted>" in representation
+    assert "token=<redacted>" in representation
+    assert USERINFO_VALUE in str(url)
+    assert QUERY_VALUE in str(url)
+    assert FRAGMENT_VALUE in str(url)
+
+
+def test_request_repr_redacts_url_and_never_includes_body() -> None:
+    request = foghttp.Request(
+        POST,
+        f"https://user:{USERINFO_VALUE}@example.com/users?token={QUERY_VALUE}",
+        headers={"Authorization": f"Bearer {HEADER_VALUE}"},
+        content=BODY_VALUE,
+    )
+
+    representation = repr(request)
+
+    assert USERINFO_VALUE not in representation
+    assert QUERY_VALUE not in representation
+    assert HEADER_VALUE not in representation
+    assert BODY_VALUE.decode() not in representation
+    assert "<redacted>" in representation
+
+
+def test_request_info_repr_redacts_url_and_headers() -> None:
+    request_info = foghttp.RequestInfo(
+        method=GET,
+        url=f"https://user:{USERINFO_VALUE}@example.com/users?api_key={QUERY_VALUE}",
+        headers=foghttp.Headers(
+            [
+                ("Authorization", f"Bearer {HEADER_VALUE}"),
+                ("X-Trace", SAFE_HEADER_VALUE),
+            ],
+        ),
+    )
+
+    representation = repr(request_info)
+
+    assert USERINFO_VALUE not in representation
+    assert QUERY_VALUE not in representation
+    assert HEADER_VALUE not in representation
+    assert SAFE_HEADER_VALUE in representation
+    assert "<redacted>" in representation
+
+
+def test_response_repr_redacts_url_headers_request_and_body() -> None:
+    response = foghttp.Response(
+        status_code=NOT_FOUND,
+        headers=foghttp.Headers([("Set-Cookie", COOKIE_VALUE)]),
+        content=BODY_VALUE,
+        url=f"https://user:{USERINFO_VALUE}@example.com/users?token={QUERY_VALUE}",
+        request=foghttp.RequestInfo(
+            method=GET,
+            url=f"https://user:{USERINFO_VALUE}@example.com/users?token={QUERY_VALUE}",
+            headers=foghttp.Headers([("Authorization", f"Bearer {HEADER_VALUE}")]),
+        ),
+        http_version="HTTP/1.1",
+        elapsed=0.1,
+    )
+
+    representation = repr(response)
+
+    assert USERINFO_VALUE not in representation
+    assert QUERY_VALUE not in representation
+    assert COOKIE_VALUE not in representation
+    assert HEADER_VALUE not in representation
+    assert BODY_VALUE.decode() not in representation
+    assert f"content=<{len(BODY_VALUE)} bytes>" in representation
+    assert "<redacted>" in representation
+
+
+def test_http_status_error_redacts_url_secrets() -> None:
+    message = http_status_error(
+        GET,
+        f"https://user:{USERINFO_VALUE}@example.com/users?api_key={QUERY_VALUE}",
+        NOT_FOUND,
+    )
+
+    assert USERINFO_VALUE not in message
+    assert QUERY_VALUE not in message
+    assert message == ("GET https://<redacted>@example.com/users?api_key=<redacted> returned 404 Not Found")
+
+
+def test_raise_for_status_uses_redacted_request_url() -> None:
+    response = foghttp.Response(
+        status_code=NOT_FOUND,
+        headers=foghttp.Headers(),
+        content=b"",
+        url="https://example.com/users",
+        request=foghttp.RequestInfo(
+            method=GET,
+            url=f"https://user:{USERINFO_VALUE}@example.com/users?token={QUERY_VALUE}",
+            headers=foghttp.Headers(),
+        ),
+        http_version="HTTP/1.1",
+        elapsed=0.1,
+    )
+
+    with pytest.raises(foghttp.HTTPStatusError) as exc_info:
+        response.raise_for_status()
+
+    assert USERINFO_VALUE not in str(exc_info.value)
+    assert QUERY_VALUE not in str(exc_info.value)
+    assert "https://<redacted>@example.com/users?token=<redacted>" in str(exc_info.value)


### PR DESCRIPTION
- redact sensitive headers in repr output
- redact URL credentials and token-like URL params in repr and status errors
- avoid printing buffered response body bytes in Response repr
- cover redaction surfaces while preserving explicit accessors