### PR TITLE
feat(client): add default query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ import foghttp
 with foghttp.Client(
     base_url="https://api.example.com",
     headers={"accept": "application/json"},
+    params={"api-version": "1"},
 ) as client:
     response = client.get(
         "users",
@@ -81,7 +82,7 @@ async with foghttp.AsyncClient() as client:
 - sync `Client` and async `AsyncClient`
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
 - `base_url` for reusable API clients and relative request paths
-- default client headers with per-request overrides
+- default client headers and query params for reusable API clients
 - query params with repeated keys, JSON bodies, and buffered bytes/text bodies
 - buffered `Response` with status flags, `text`, `json()`,
   `raise_for_status()`, and request metadata

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: "home"
 hero:
   name: "FogHTTP"
   text: "Rust-powered HTTP client for Python"
-  tagline: "Buffered JSON requests, base URL clients, default headers, sync and async APIs, redirects, custom CA certificates, cancellation, and observable request limits."
+  tagline: "Buffered JSON requests, base URL clients, default headers and params, sync and async APIs, redirects, custom CA certificates, cancellation, and observable request limits."
 
 features:
   - title: "Rust transport"
@@ -14,7 +14,7 @@ features:
     details: "Use Client in scripts and workers, or AsyncClient for high-concurrency asyncio workloads."
 
   - title: "Focused MVP"
-    details: "FogHTTP is intentionally small today: buffered responses, JSON, base URL clients, default headers, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
+    details: "FogHTTP is intentionally small today: buffered responses, JSON, base URL clients, default headers and params, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
 ---
 
 # FogHTTP Documentation
@@ -80,7 +80,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - sync `Client` and async `AsyncClient`
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
 - `base_url` for reusable API clients and relative request paths
-- default client headers with per-request overrides
+- default client headers and query params for reusable API clients
 - query params with repeated keys, JSON bodies, and buffered bytes/text bodies
 - response status flags for success, redirects, and client/server errors
 - prepared `Request` objects with `build_request()` and `send()`

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -15,6 +15,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
 - `base_url` for reusable API clients and relative request paths
 - default client headers with per-request overrides
+- default client query params with per-request params appended after defaults
 - query parameters from mappings, repeated pairs, and raw query strings
 - JSON bodies through `json=`
 - raw bytes/text bodies through `content=`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -86,8 +86,8 @@ with `/` is root-relative and resolves against the origin root:
 
 Absolute request URLs ignore `base_url`.
 
-`base_url` must not include query parameters or a fragment. Use per-request
-`params=` for query parameters.
+`base_url` must not include query parameters or a fragment. Use client-level or
+per-request `params=` for query parameters.
 
 ## Default Headers
 
@@ -129,6 +129,41 @@ with foghttp.Client(
 
 FogHTTP applies the same transport-managed header policy to client defaults and
 per-request headers.
+
+## Default Query Parameters
+
+Use client-level `params=` for values that should be appended to every request
+from that client, such as API version, locale, tenant, or feature flags.
+
+::: code-group
+
+```python [Async]
+async with foghttp.AsyncClient(
+    base_url="https://api.example.com/v1",
+    params={"api-version": "1", "locale": "en-US"},
+) as client:
+    response = await client.get("users", params={"limit": 10})
+    response.raise_for_status()
+```
+
+```python [Sync]
+with foghttp.Client(
+    base_url="https://api.example.com/v1",
+    params={"api-version": "1", "locale": "en-US"},
+) as client:
+    response = client.get("users", params={"limit": 10})
+    response.raise_for_status()
+```
+
+:::
+
+Client defaults are appended after query parameters already present in the
+request URL and before per-request `params=`. Per-request params do not replace
+client defaults; repeated keys are preserved in order.
+
+Client-level params apply to every request built by that client, including
+absolute request URLs. If defaults contain credentials or tenant identifiers,
+prefer a dedicated client scoped to one upstream.
 
 ## Query Parameters
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -176,6 +176,7 @@ repeating the origin every time.
 with foghttp.Client(
     base_url="https://api.example.com/v1",
     headers={"accept": "application/json"},
+    params={"api-version": "1"},
 ) as client:
     response = client.get("users", params={"limit": 10})
     response.raise_for_status()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,8 @@
 # FogHTTP Examples
 
 These examples focus on workloads where FogHTTP already works well, including
-reusable `base_url` clients and default headers for one-upstream APIs.
+reusable `base_url` clients, default headers, and default query params for
+one-upstream APIs.
 
 Run them from the repository root after building the local extension:
 

--- a/examples/sync_json_api.py
+++ b/examples/sync_json_api.py
@@ -17,6 +17,7 @@ def main() -> None:
     with foghttp.Client(
         base_url="https://httpbin.org",
         headers={"accept": "application/json"},
+        params={"client": "foghttp"},
     ) as client:
         response = client.post(
             "post",

--- a/foghttp/_client/config.py
+++ b/foghttp/_client/config.py
@@ -6,7 +6,7 @@ from ..headers import HeaderSource
 from ..limits import Limits
 from ..timeouts import Timeouts
 from ..tls import TLSConfig
-from ..types import HttpVersions
+from ..types import HttpVersions, QueryParams
 from ..url import URL
 from .options import validate_client_options
 from .request_builder.defaults import DEFAULT_REQUEST_BUILD_DEFAULTS, RequestBuildDefaults
@@ -30,6 +30,7 @@ class ClientConfig:
         *,
         base_url: str | URL | None,
         headers: HeaderSource,
+        params: QueryParams,
         limits: Limits | None,
         timeouts: Timeouts | None,
         http_versions: HttpVersions,
@@ -59,7 +60,7 @@ class ClientConfig:
             observability=observability,
             request_defaults=(
                 DEFAULT_REQUEST_BUILD_DEFAULTS
-                if base_url is None and headers is None
-                else RequestBuildDefaults.from_options(base_url=base_url, headers=headers)
+                if base_url is None and headers is None and params is None
+                else RequestBuildDefaults.from_options(base_url=base_url, headers=headers, params=params)
             ),
         )

--- a/foghttp/async_client.py
+++ b/foghttp/async_client.py
@@ -27,6 +27,7 @@ class AsyncClient(ClientCore):
         *,
         base_url: str | URL | None = None,
         headers: HeaderSource = None,
+        params: QueryParams = None,
         limits: Limits | None = None,
         timeouts: Timeouts | None = None,
         http_versions: HttpVersions = None,
@@ -42,6 +43,7 @@ class AsyncClient(ClientCore):
             config=ClientConfig.from_options(
                 base_url=base_url,
                 headers=headers,
+                params=params,
                 limits=limits,
                 timeouts=timeouts,
                 http_versions=http_versions,

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -32,6 +32,7 @@ class Client(ClientCore):
         *,
         base_url: str | URL | None = None,
         headers: HeaderSource = None,
+        params: QueryParams = None,
         limits: Limits | None = None,
         timeouts: Timeouts | None = None,
         http_versions: HttpVersions = None,
@@ -47,6 +48,7 @@ class Client(ClientCore):
             config=ClientConfig.from_options(
                 base_url=base_url,
                 headers=headers,
+                params=params,
                 limits=limits,
                 timeouts=timeouts,
                 http_versions=http_versions,

--- a/tests/request_builder/test_default_params.py
+++ b/tests/request_builder/test_default_params.py
@@ -1,0 +1,87 @@
+import foghttp
+from foghttp.methods import GET
+
+
+API_BASE_URL = "https://api.example.com/v1"
+DEFAULT_CLIENT = "default"
+DEFAULT_TAG = "rust"
+REQUEST_TAG = "python"
+EXPECTED_SENT_QUERY = f"client={DEFAULT_CLIENT}&tag={DEFAULT_TAG}&tag={REQUEST_TAG}&page=2"
+SEARCH_PATH = "/search"
+SEARCH_URL = "https://api.example.com/search?debug=1#results"
+
+
+def test_sync_build_request_applies_default_params() -> None:
+    with foghttp.Client(params={"client": DEFAULT_CLIENT}) as client:
+        request = client.build_request(GET, SEARCH_URL)
+
+    assert request.url == f"https://api.example.com/search?debug=1&client={DEFAULT_CLIENT}#results"
+
+
+async def test_async_build_request_applies_default_params() -> None:
+    async with foghttp.AsyncClient(params={"client": DEFAULT_CLIENT}) as client:
+        request = client.build_request(GET, SEARCH_URL)
+
+    assert request.url == f"https://api.example.com/search?debug=1&client={DEFAULT_CLIENT}#results"
+
+
+def test_request_params_are_appended_after_default_params() -> None:
+    with foghttp.Client(
+        base_url=API_BASE_URL,
+        params=[
+            ("client", DEFAULT_CLIENT),
+            ("tag", DEFAULT_TAG),
+        ],
+    ) as client:
+        request = client.build_request(
+            GET,
+            "search?debug=1#results",
+            params=[
+                ("tag", REQUEST_TAG),
+                ("page", 2),
+            ],
+        )
+
+    assert (
+        request.url == "https://api.example.com/v1/search"
+        f"?debug=1&client={DEFAULT_CLIENT}&tag={DEFAULT_TAG}&tag={REQUEST_TAG}&page=2#results"
+    )
+
+
+def test_default_params_accept_raw_query_string_with_leading_question_mark() -> None:
+    with foghttp.Client(params="?client=default&tag=rust") as client:
+        request = client.build_request(GET, "https://api.example.com/search")
+
+    assert request.url == "https://api.example.com/search?client=default&tag=rust"
+
+
+def test_default_params_snapshot_user_supplied_params() -> None:
+    default_tags = [DEFAULT_TAG]
+    default_params = {"tag": default_tags}
+
+    with foghttp.Client(params=default_params) as client:
+        default_tags.append(REQUEST_TAG)
+        request = client.build_request(GET, "https://api.example.com/search")
+
+    assert default_params == {"tag": [DEFAULT_TAG, REQUEST_TAG]}
+    assert request.url == f"https://api.example.com/search?tag={DEFAULT_TAG}"
+
+
+def test_sync_request_sends_default_params(sync_http_server: str) -> None:
+    default_params = {"client": DEFAULT_CLIENT, "tag": [DEFAULT_TAG, REQUEST_TAG]}
+
+    with foghttp.Client(params=default_params) as client:
+        response = client.get(f"{sync_http_server}{SEARCH_PATH}", params={"page": 2})
+
+    assert response.request.url == f"{sync_http_server}{SEARCH_PATH}?{EXPECTED_SENT_QUERY}"
+    assert response.json()["request_line"] == f"GET {SEARCH_PATH}?{EXPECTED_SENT_QUERY} HTTP/1.1"
+
+
+async def test_async_request_sends_default_params(http_server: str) -> None:
+    default_params = {"client": DEFAULT_CLIENT, "tag": [DEFAULT_TAG, REQUEST_TAG]}
+
+    async with foghttp.AsyncClient(params=default_params) as client:
+        response = await client.get(f"{http_server}{SEARCH_PATH}", params={"page": 2})
+
+    assert response.request.url == f"{http_server}{SEARCH_PATH}?{EXPECTED_SENT_QUERY}"
+    assert response.json()["request_line"] == f"GET {SEARCH_PATH}?{EXPECTED_SENT_QUERY} HTTP/1.1"


### PR DESCRIPTION
- accept client-level params in sync and async clients
- merge default params through the shared request builder contract
- preserve repeated query keys and snapshot user inputs
- document default params and cover sync/async request scenarios