### PR TITLE
feat(request-builder): define body parameter matrix

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -50,8 +50,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | Streaming responses | Not available; responses are fully buffered |
 | Streaming uploads | Not available; request bodies are buffered |
 | Multipart uploads | Not available |
-| `data=` form encoding | Not available |
-| `files=` | Not available |
+| `data=` form encoding | Reserved in the body matrix; not available yet |
+| `files=` | Reserved in the body matrix; not available yet |
 | Cookie jar | `cookies=True` is rejected |
 | Proxy support | `trust_env=True` is rejected |
 | Auth helpers | Use manual headers for simple cases |
@@ -59,6 +59,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | HTTP/2 | Not available |
 | Compression decoding | Not available |
 | transport-managed request headers | Safe API rejects manual `Host`, `Content-Length`, `Transfer-Encoding`, `TE`, `Trailer`, `Connection`, `Upgrade`, `Keep-Alive`, and `Proxy-Connection` |
+| request body source conflicts | Only one body source can be passed today: `json=` or `content=` |
 | true active connection-level limits | `max_active_requests_per_origin` limits buffered request slots; physical TCP connection-level accounting is not exposed yet |
 | per-request connect timeout changes | `Timeouts.connect` configures the Rust connector from client-level settings when transport state is created; per-request `timeout.connect` does not reconfigure the connector |
 | separate read/write timeout semantics | `Timeouts.read` and `Timeouts.write` exist, but separate body read/write deadlines are reserved for later streaming/body work |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -293,6 +293,24 @@ with foghttp.Client() as client:
 
 :::
 
+## Request Body Matrix
+
+FogHTTP currently accepts one body source per request:
+
+| Parameter | Current behavior |
+|---|---|
+| `json=` | Encodes with `orjson` and adds `content-type: application/json` when no explicit content type is set |
+| `content=` | Accepts buffered `bytes` or `str`; strings are encoded as UTF-8 and no semantic content type is added |
+| `data=` | Reserved for future form-urlencoded support |
+| `files=` | Reserved for future multipart uploads |
+
+Passing more than one body source raises `ValueError`. `Content-Length` and
+`Transfer-Encoding` are transport-managed framing headers and are not accepted
+in request headers; the Rust transport owns them. Buffered `json=` and
+`content=` bodies are replayable for the current redirect policy. Iterator,
+async iterator, and streaming request bodies are not accepted yet and will need
+an explicit non-replayable body contract later.
+
 ## Request Metadata
 
 Every response includes lightweight request metadata. The request body is not

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -202,8 +202,9 @@ for the planned auth/hooks layer or keep that logic outside FogHTTP.
 
 ### Small Buffered Uploads
 
-`content=` works for bytes and strings, and `json=` works for JSON. Large file
-uploads should wait for streaming upload support.
+`content=` works for buffered bytes and strings, and `json=` works for JSON.
+Pass only one body source per request. Large file uploads, streaming bodies,
+`data=`, and `files=` should wait for the planned body support.
 
 ```python
 response = client.post(

--- a/foghttp/body.py
+++ b/foghttp/body.py
@@ -1,11 +1,17 @@
-__all__ = ("encode_body",)
+__all__ = ("BodyParameter", "encode_body")
 
 from collections.abc import MutableMapping
+from enum import StrEnum
 from typing import Any
 
 import orjson
 
-from .messages import BODY_CONTENT_AND_JSON_CONFLICT
+from .messages import BODY_CONTENT_AND_JSON_CONFLICT, BODY_CONTENT_UNSUPPORTED
+
+
+class BodyParameter(StrEnum):
+    CONTENT = "content"
+    JSON = "json"
 
 
 def encode_body(
@@ -14,11 +20,37 @@ def encode_body(
     json: Any,
     headers: MutableMapping[str, str],
 ) -> bytes | None:
-    if content is not None and json is not None:
-        raise ValueError(BODY_CONTENT_AND_JSON_CONFLICT)
+    source = _body_parameter(content=content, json=json)
+    match source:
+        case None:
+            return None
+        case BodyParameter.CONTENT:
+            return _encode_content_body(content)
+        case BodyParameter.JSON:
+            return _encode_json_body(json, headers)
+
+
+def _body_parameter(*, content: object, json: object) -> BodyParameter | None:
+    sources = []
+    if content is not None:
+        sources.append(BodyParameter.CONTENT)
     if json is not None:
-        headers.setdefault("content-type", "application/json")
-        return orjson.dumps(json)
+        sources.append(BodyParameter.JSON)
+    if len(sources) > 1:
+        raise ValueError(BODY_CONTENT_AND_JSON_CONFLICT)
+    if sources:
+        return sources[0]
+    return None
+
+
+def _encode_content_body(content: bytes | str | None) -> bytes:
+    if isinstance(content, bytes):
+        return content
     if isinstance(content, str):
         return content.encode("utf-8")
-    return content
+    raise TypeError(BODY_CONTENT_UNSUPPORTED)
+
+
+def _encode_json_body(json: Any, headers: MutableMapping[str, str]) -> bytes:
+    headers.setdefault("content-type", "application/json")
+    return orjson.dumps(json)

--- a/foghttp/messages.py
+++ b/foghttp/messages.py
@@ -1,6 +1,7 @@
 __all__ = (
     "BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED",
     "BODY_CONTENT_AND_JSON_CONFLICT",
+    "BODY_CONTENT_UNSUPPORTED",
     "CLIENT_CLOSED",
     "COOKIES_UNSUPPORTED",
     "HTTP_VERSION_UNSUPPORTED",
@@ -22,7 +23,8 @@ from ._redaction import redact_url
 
 
 BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED = "base_url must not include query or fragment"
-BODY_CONTENT_AND_JSON_CONFLICT = "pass either content or json, not both"
+BODY_CONTENT_AND_JSON_CONFLICT = "pass only one body parameter: content or json"
+BODY_CONTENT_UNSUPPORTED = "content must be bytes, str, or None"
 CLIENT_CLOSED = "AsyncClient is closed"
 COOKIES_UNSUPPORTED = "cookies are planned after the MVP"
 HTTP_VERSION_UNSUPPORTED = "only HTTP/1.1 is supported in the MVP"

--- a/tests/request_builder/test_body.py
+++ b/tests/request_builder/test_body.py
@@ -5,7 +5,7 @@ import orjson
 import pytest
 
 import foghttp
-from foghttp.messages import BODY_CONTENT_AND_JSON_CONFLICT
+from foghttp.messages import BODY_CONTENT_AND_JSON_CONFLICT, BODY_CONTENT_UNSUPPORTED
 from foghttp.methods import POST
 
 
@@ -39,7 +39,9 @@ def test_json_body_preserves_explicit_content_type(faker: Faker) -> None:
     ("content", "expected_body"),
     [
         ("utf8-\u20ac", "utf8-\u20ac".encode("utf-8")),
+        ("", b""),
         (b"raw-body", b"raw-body"),
+        (b"", b""),
         (None, None),
     ],
 )
@@ -49,6 +51,8 @@ def test_content_body_matrix(content: bytes | str | None, expected_body: bytes |
 
     assert request.content == expected_body
     assert "content-type" not in request.headers
+    assert "content-length" not in request.headers
+    assert "transfer-encoding" not in request.headers
 
 
 def test_build_request_rejects_content_and_json(faker: Faker) -> None:
@@ -61,6 +65,13 @@ def test_build_request_rejects_content_and_json(faker: Faker) -> None:
             content=content,
             json={"name": faker.name()},
         )
+
+
+def test_build_request_rejects_non_buffered_content(faker: Faker) -> None:
+    content: Any = iter([faker.sentence().encode()])
+
+    with foghttp.Client() as client, pytest.raises(TypeError, match=BODY_CONTENT_UNSUPPORTED):
+        client.build_request(POST, faker.url(), content=content)
 
 
 async def test_async_build_request_rejects_content_and_json(faker: Faker) -> None:
@@ -80,6 +91,8 @@ async def test_async_build_request_rejects_content_and_json(faker: Faker) -> Non
     ("json_body", "expected_body"),
     [
         (None, None),
+        (False, b"false"),
+        (0, b"0"),
         ({}, b"{}"),
         ([], b"[]"),
     ],
@@ -93,3 +106,5 @@ def test_json_body_none_is_not_a_body(json_body: Any, expected_body: bytes | Non
         assert "content-type" not in request.headers
     else:
         assert request.headers["content-type"] == "application/json"
+        assert "content-length" not in request.headers
+        assert "transfer-encoding" not in request.headers

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -5,6 +5,7 @@ import orjson
 import pytest
 
 import foghttp
+from foghttp.messages import BODY_CONTENT_AND_JSON_CONFLICT
 from foghttp.methods import GET, HEAD, POST
 from foghttp.status_codes.success import OK
 
@@ -38,7 +39,7 @@ async def test_post_rejects_content_and_json(http_server: str, faker: Faker) -> 
     payload = {"name": faker.name()}
 
     async with foghttp.AsyncClient() as client:
-        with pytest.raises(ValueError, match="pass either content or json"):
+        with pytest.raises(ValueError, match=BODY_CONTENT_AND_JSON_CONFLICT):
             await client.post(http_server + "/users", content=content, json=payload)
 
 

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -5,6 +5,7 @@ import orjson
 import pytest
 
 import foghttp
+from foghttp.messages import BODY_CONTENT_AND_JSON_CONFLICT
 from foghttp.methods import GET, HEAD, POST
 from foghttp.status_codes.success import OK
 
@@ -37,7 +38,7 @@ def test_post_rejects_content_and_json(sync_http_server: str, faker: Faker) -> N
     content = faker.sentence().encode()
     payload = {"name": faker.name()}
 
-    with foghttp.Client() as client, pytest.raises(ValueError, match="pass either content or json"):
+    with foghttp.Client() as client, pytest.raises(ValueError, match=BODY_CONTENT_AND_JSON_CONFLICT):
         client.post(sync_http_server + "/users", content=content, json=payload)
 
 


### PR DESCRIPTION
- validate request body sources through an explicit body matrix
- reject conflicting content/json inputs with a stable error
- reject non-buffered content before the transport boundary
- document reserved data/files body sources and framing ownership
- cover sync/async body conflict and buffered body edge cases