### PR TITLE
docs(request-builder): add compatibility guide and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ async with foghttp.AsyncClient() as client:
 
 - [Documentation](https://github.com/AmberFog/foghttp/blob/main/docs/index.md)
 - [Quickstart](https://github.com/AmberFog/foghttp/blob/main/docs/quickstart.md)
+- [Request builder compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/request-builder.md)
 - [Client lifecycle](https://github.com/AmberFog/foghttp/blob/main/docs/lifecycle.md)
 - [Timeout model](https://github.com/AmberFog/foghttp/blob/main/docs/timeouts.md)
 - [Use cases](https://github.com/AmberFog/foghttp/blob/main/docs/use-cases.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 ## Start Here
 
 - [Quickstart](./quickstart.md)
+- [Request builder compatibility](./request-builder.md)
 - [Client lifecycle](./lifecycle.md)
 - [Timeout model](./timeouts.md)
 - [Use cases](./use-cases.md)

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -3,6 +3,9 @@
 FogHTTP is an MVP. It can already be useful, but it is not trying to be a full
 `httpx` replacement yet.
 
+For request-parameter compatibility with common Python HTTP clients, see
+[Request builder compatibility](./request-builder.md).
+
 ## Compatibility Policy
 
 Until version `0.5.0`, backward compatibility is not guaranteed. I will still

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -412,6 +412,9 @@ header values, URL credentials, common token query or fragment parameters, and
 buffered body bytes. Explicit APIs such as `headers["authorization"]`,
 `str(url)`, and `response.content` still return the real values.
 
+For a parameter-by-parameter compatibility map with common Python HTTP clients,
+see [Request builder compatibility](./request-builder.md).
+
 ## Custom CA Certificates
 
 FogHTTP uses WebPKI roots by default for HTTPS. For private services with an

--- a/docs/request-builder.md
+++ b/docs/request-builder.md
@@ -1,0 +1,169 @@
+# Request Builder Compatibility
+
+FogHTTP request building is intentionally small and explicit. The same builder
+contract is used by sync clients, async clients, shortcut methods,
+`build_request()`, and prepared requests sent with `send()`.
+
+This page maps common `requests`, `httpx`, and `zapros` request parameters to
+the current FogHTTP API. The same flow is available as a runnable example in
+[request_builder_compatibility.py](../examples/request_builder_compatibility.py).
+
+## Compatibility Matrix
+
+| Common parameter | FogHTTP today | Notes |
+|---|---|---|
+| `method` | Supported | Methods are normalized to uppercase. Constants are available from `foghttp.methods`. |
+| `url` | Supported | Accepts absolute URLs. Relative URLs require client-level `base_url=`. |
+| `base_url` | Supported | Client-level only. Query and fragment are rejected; use `params=` instead. |
+| `params` | Supported | Accepts mappings, repeated pairs, and raw query strings. Existing URL query is preserved. |
+| client default `params` | Supported | Passed as `Client(params=...)` or `AsyncClient(params=...)`. Appended after URL query and before per-request params. |
+| `headers` | Supported | Accepts mappings, pairs, and `foghttp.Headers`. Lookups are case-insensitive and repeated values are preserved. |
+| client default `headers` | Supported | Passed as `Client(headers=...)` or `AsyncClient(headers=...)`. Per-request headers override defaults case-insensitively. |
+| `json` | Supported | Encoded with `orjson`. Adds `content-type: application/json` unless explicitly set. |
+| `content` | Supported | Accepts buffered `bytes` or `str`. Strings are encoded as UTF-8. No semantic content type is added. |
+| `data` | Reserved | Planned for form-urlencoded bodies. Not accepted yet. |
+| `files` | Reserved | Planned for multipart uploads. Not accepted yet. |
+| `auth` | Planned | Use explicit `Authorization` headers for simple static tokens. |
+| cookies/session jar | Planned | `cookies=True` is rejected today. |
+| proxy / `trust_env` | Planned | `trust_env=True` is rejected today. |
+| `timeout` | Partly supported | Per-request `pool` and `total` timeouts are supported. Per-request `connect` does not reconfigure the connector. `read` and `write` are reserved. |
+| `follow_redirects` | Supported | Client-level setting. GET/HEAD/POST redirects use conservative security rules. |
+| prepared request | Supported | Use `build_request()` and `send()`. Building a request does not create transport state. |
+
+## Merge Order
+
+FogHTTP applies request values in this order:
+
+| Area | Order |
+|---|---|
+| URL | `base_url` resolution, request URL query, client params, per-request params |
+| Headers | client headers, future auth-managed headers, per-request headers |
+| Body | exactly one body source: `json=` or `content=` |
+
+Repeated query keys are preserved. Per-request params are appended after client
+defaults instead of replacing them, which keeps API-version, tenant, locale, and
+feature flag defaults visible in the final URL.
+
+Per-request headers override client defaults case-insensitively. Repeated
+headers from defaults are preserved when the request does not override that
+header name.
+
+## Sync Example
+
+```python
+import foghttp
+from foghttp.methods import POST
+
+
+with foghttp.Client(
+    base_url="https://api.example.com/v1",
+    headers={"accept": "application/json"},
+    params={"api-version": "1"},
+    follow_redirects=True,
+) as client:
+    response = client.request(
+        POST,
+        "users?debug=1",
+        params=[("role", "admin"), ("role", "operator")],
+        headers={"x-trace": "sync-example"},
+        json={"name": "Ada Lovelace"},
+    )
+    response.raise_for_status()
+```
+
+The final request URL is equivalent to:
+
+```text
+https://api.example.com/v1/users?debug=1&api-version=1&role=admin&role=operator
+```
+
+## Async Example
+
+```python
+import foghttp
+from foghttp.methods import POST
+
+
+async with foghttp.AsyncClient(
+    base_url="https://api.example.com/v1",
+    headers={"accept": "application/json"},
+    params={"api-version": "1"},
+) as client:
+    response = await client.request(
+        POST,
+        "users",
+        headers={"x-trace": "async-example"},
+        json={"name": "Ada Lovelace"},
+    )
+    response.raise_for_status()
+```
+
+Sync and async request builders share the same merge and body conflict rules.
+
+## Prepared Requests
+
+Use `build_request()` when application code needs to inspect or adjust a request
+before sending it.
+
+```python
+import foghttp
+from foghttp.methods import POST
+
+
+with foghttp.Client(
+    base_url="https://api.example.com/v1",
+    headers={"accept": "application/json"},
+) as client:
+    request = client.build_request(
+        POST,
+        "users",
+        json={"name": "Grace Hopper"},
+    )
+    request.headers["x-trace"] = "prepared-request"
+    response = client.send(request)
+    response.raise_for_status()
+```
+
+`build_request()` is transport-free: it does not open sockets, create the lazy
+Rust client, or consume pool/request slots.
+
+## Body Conflict Matrix
+
+| Combination | Result |
+|---|---|
+| no body source | no request body |
+| `json=None` | no request body |
+| `json=False`, `json=0`, `{}`, `[]` | JSON body |
+| `content=None` | no request body |
+| `content=b""`, `content=""` | empty buffered body |
+| `json=` and `content=` together | `ValueError` |
+| iterator or async iterator `content=` | `TypeError` |
+| `data=` or `files=` | not accepted yet |
+
+`Content-Length` and `Transfer-Encoding` are transport-managed framing headers
+and cannot be set manually. `Content-Type` is semantic and can be set by the
+caller; FogHTTP only adds `application/json` for `json=` when the caller did not
+already provide a content type.
+
+Buffered `json=` and `content=` request bodies are replayable for the current
+redirect policy. Future streaming uploads will need an explicit non-replayable
+body contract.
+
+## Intentional Differences
+
+FogHTTP is not trying to clone the full `requests`, `httpx`, or `zapros`
+surface. Today it is best for buffered JSON/API clients with explicit lifecycle
+and observable request limits.
+
+Current intentional gaps:
+
+- no `data=` form encoding yet
+- no `files=` multipart uploads yet
+- no cookie jar
+- no `auth=` helper
+- no proxy or `trust_env` behavior
+- no streaming request or response body API yet
+- no disabling TLS verification
+
+For these gaps, keep logic outside FogHTTP for now or wait for the planned
+feature-specific layer.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,8 @@
 
 These examples focus on workloads where FogHTTP already works well, including
 reusable `base_url` clients, default headers, and default query params for
-one-upstream APIs.
+one-upstream APIs. They also show the current request builder contract and
+prepared request flow.
 
 Run them from the repository root after building the local extension:
 
@@ -13,6 +14,7 @@ uv run examples/async_json_fanout.py
 uv run examples/async_resource_limits.py
 uv run examples/redirects.py
 uv run examples/prepared_requests.py
+uv run examples/request_builder_compatibility.py
 ```
 
 ## Good Examples
@@ -26,6 +28,9 @@ uv run examples/prepared_requests.py
   history.
 - [prepared_requests.py](./prepared_requests.py): build, inspect, adjust, and
   send prepared requests.
+- [request_builder_compatibility.py](./request_builder_compatibility.py):
+  client defaults, repeated query params, prepared requests, and body conflict
+  validation.
 
 ## Limitations To Keep In Mind
 

--- a/examples/request_builder_compatibility.py
+++ b/examples/request_builder_compatibility.py
@@ -1,0 +1,71 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "foghttp",
+# ]
+#
+# [tool.uv.sources]
+# foghttp = { path = "../", editable = true }
+# ///
+
+import json
+
+import foghttp
+from foghttp.methods import POST
+
+
+BASE_URL = "https://httpbin.org"
+
+
+def print_httpbin_response(label: str, response: foghttp.Response) -> None:
+    data = response.json()
+    print(label, "status:", response.status_code)
+    print(label, "request:", response.request.method, response.request.url)
+    print(label, "args:", json.dumps(data.get("args", {}), sort_keys=True))
+    print(label, "trace:", data["headers"].get("X-Trace"))
+
+
+def main() -> None:
+    with foghttp.Client(
+        base_url=BASE_URL,
+        headers={"accept": "application/json", "x-client": "foghttp-example"},
+        params={"client": "foghttp", "api-version": "1"},
+    ) as client:
+        response = client.get(
+            "anything/search?debug=1",
+            params=[
+                ("tag", "rust"),
+                ("tag", "python"),
+                ("limit", "2"),
+            ],
+            headers={"x-trace": "shortcut-request"},
+        )
+        response.raise_for_status()
+        print_httpbin_response("shortcut", response)
+
+        request = client.build_request(
+            POST,
+            "anything/users",
+            params={"source": "prepared"},
+            json={"name": "Ada Lovelace", "role": "engineer"},
+        )
+        request.headers["x-trace"] = "prepared-request"
+
+        prepared_response = client.send(request)
+        prepared_response.raise_for_status()
+        print_httpbin_response("prepared", prepared_response)
+        print("prepared json:", json.dumps(prepared_response.json().get("json"), sort_keys=True))
+
+        try:
+            client.build_request(
+                POST,
+                "anything/body-conflict",
+                content=b"raw body",
+                json={"name": "Grace Hopper"},
+            )
+        except ValueError as exc:
+            print("body conflict:", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sync_json_api.py
+++ b/examples/sync_json_api.py
@@ -21,6 +21,7 @@ def main() -> None:
     ) as client:
         response = client.post(
             "post",
+            params={"request": "sync-json"},
             json={"name": "Ada Lovelace", "role": "engineer"},
         )
 


### PR DESCRIPTION
- document request builder merge rules and compatibility boundaries
- add runnable request builder compatibility example
- link request builder docs from README, docs index, and examples
- refresh examples for default params and prepared request flow