### PR TITLE
feat(request-builder): support form-urlencoded data

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ async with foghttp.AsyncClient() as client:
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
 - `base_url` for reusable API clients and relative request paths
 - default client headers and query params for reusable API clients
-- query params with repeated keys, JSON bodies, and buffered bytes/text bodies
+- query params with repeated keys, JSON, form-urlencoded data, and buffered
+  bytes/text bodies
 - buffered `Response` with status flags, `text`, `json()`,
   `raise_for_status()`, and request metadata
 - prepared `Request` objects with `build_request()` and `send()`

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: "home"
 hero:
   name: "FogHTTP"
   text: "Rust-powered HTTP client for Python"
-  tagline: "Buffered JSON requests, base URL clients, default headers and params, sync and async APIs, redirects, custom CA certificates, cancellation, and observable request limits."
+  tagline: "Buffered JSON and form requests, base URL clients, default headers and params, sync and async APIs, redirects, custom CA certificates, cancellation, and observable request limits."
 
 features:
   - title: "Rust transport"
@@ -14,7 +14,7 @@ features:
     details: "Use Client in scripts and workers, or AsyncClient for high-concurrency asyncio workloads."
 
   - title: "Focused MVP"
-    details: "FogHTTP is intentionally small today: buffered responses, JSON, base URL clients, default headers and params, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
+    details: "FogHTTP is intentionally small today: buffered responses, JSON, form-urlencoded data, base URL clients, default headers and params, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
 ---
 
 # FogHTTP Documentation
@@ -44,7 +44,7 @@ FogHTTP is designed around a few engineering priorities:
 
 - one API shape for sync scripts, workers, and asyncio services
 - Rust-backed HTTP/1.1 transport with explicit runtime ownership
-- buffered JSON and bytes workflows that are simple to reason about
+- buffered JSON, form, and bytes workflows that are simple to reason about
 - graceful sync `close()` that waits for already-started sync requests
 - async cancellation that aborts in-flight Rust requests
 - redirect history and final request metadata for debugging
@@ -82,7 +82,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
 - `base_url` for reusable API clients and relative request paths
 - default client headers and query params for reusable API clients
-- query params with repeated keys, JSON bodies, and buffered bytes/text bodies
+- query params with repeated keys, JSON, form-urlencoded data, and buffered
+  bytes/text bodies
 - response status flags for success, redirects, and client/server errors
 - prepared `Request` objects with `build_request()` and `send()`
 - case-insensitive `Headers` with repeated value support

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -21,6 +21,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - default client query params with per-request params appended after defaults
 - query parameters from mappings, repeated pairs, and raw query strings
 - JSON bodies through `json=`
+- form-urlencoded bodies through mapping or repeated-pair `data=`
 - raw bytes/text bodies through `content=`
 - buffered responses
 - `response.text`, `response.json()`, response status flags, and
@@ -53,7 +54,6 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | Streaming responses | Not available; responses are fully buffered |
 | Streaming uploads | Not available; request bodies are buffered |
 | Multipart uploads | Not available |
-| `data=` form encoding | Reserved in the body matrix; not available yet |
 | `files=` | Reserved in the body matrix; not available yet |
 | Cookie jar | `cookies=True` is rejected |
 | Proxy support | `trust_env=True` is rejected |
@@ -62,7 +62,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | HTTP/2 | Not available |
 | Compression decoding | Not available |
 | transport-managed request headers | Safe API rejects manual `Host`, `Content-Length`, `Transfer-Encoding`, `TE`, `Trailer`, `Connection`, `Upgrade`, `Keep-Alive`, and `Proxy-Connection` |
-| request body source conflicts | Only one body source can be passed today: `json=` or `content=` |
+| request body source conflicts | Only one body source can be passed today: `json=`, `data=`, or `content=` |
 | true active connection-level limits | `max_active_requests_per_origin` limits buffered request slots; physical TCP connection-level accounting is not exposed yet |
 | per-request connect timeout changes | `Timeouts.connect` configures the Rust connector from client-level settings when transport state is created; per-request `timeout.connect` does not reconfigure the connector |
 | separate read/write timeout semantics | `Timeouts.read` and `Timeouts.write` exist, but separate body read/write deadlines are reserved for later streaming/body work |
@@ -74,7 +74,7 @@ Use FogHTTP today when:
 - you control the API or know its behavior well
 - responses are small enough to buffer in memory or bounded by
   `max_response_body_size`
-- requests are JSON-heavy
+- requests are JSON-heavy or use small form-urlencoded bodies
 - redirects are simple and do not require cookie jar or auth helper integration
 - sync and async clients with explicit lifecycle are enough
 - async request cancellation behavior is useful, but you do not need streaming
@@ -91,7 +91,7 @@ Wait before using FogHTTP when:
 - you upload large files
 - you need proxy behavior from environment variables
 - you rely on cookies across requests
-- you need multipart form-data
+- you need multipart form-data or large uploads
 - you need per-request connect timeout reconfiguration or mature read/write
   timeout semantics
 - you need strict active per-host connection limits

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -267,6 +267,42 @@ with foghttp.Client() as client:
 
 :::
 
+## Form Data
+
+Pass `data=` with a mapping or repeated pairs to send a buffered
+`application/x-www-form-urlencoded` request body.
+
+::: code-group
+
+```python [Async]
+async with foghttp.AsyncClient() as client:
+    response = await client.post(
+        "https://httpbin.org/post",
+        data={
+            "grant_type": "client_credentials",
+            "scope": ["read", "write"],
+        },
+    )
+    response.raise_for_status()
+```
+
+```python [Sync]
+with foghttp.Client() as client:
+    response = client.post(
+        "https://httpbin.org/post",
+        data={
+            "grant_type": "client_credentials",
+            "scope": ["read", "write"],
+        },
+    )
+    response.raise_for_status()
+```
+
+:::
+
+If `data=` is `bytes` or `str`, FogHTTP treats it as already encoded buffered
+body content and does not add `content-type` automatically.
+
 ## Raw Content
 
 Use `content=` for already encoded bytes or text.
@@ -300,14 +336,14 @@ FogHTTP currently accepts one body source per request:
 | Parameter | Current behavior |
 |---|---|
 | `json=` | Encodes with `orjson` and adds `content-type: application/json` when no explicit content type is set |
+| `data=` | Encodes mappings and repeated pairs as `application/x-www-form-urlencoded`; raw `bytes` and `str` are sent as buffered body content |
 | `content=` | Accepts buffered `bytes` or `str`; strings are encoded as UTF-8 and no semantic content type is added |
-| `data=` | Reserved for future form-urlencoded support |
 | `files=` | Reserved for future multipart uploads |
 
 Passing more than one body source raises `ValueError`. `Content-Length` and
 `Transfer-Encoding` are transport-managed framing headers and are not accepted
-in request headers; the Rust transport owns them. Buffered `json=` and
-`content=` bodies are replayable for the current redirect policy. Iterator,
+in request headers; the Rust transport owns them. Buffered `json=`, `data=`,
+and `content=` bodies are replayable for the current redirect policy. Iterator,
 async iterator, and streaming request bodies are not accepted yet and will need
 an explicit non-replayable body contract later.
 

--- a/docs/request-builder.md
+++ b/docs/request-builder.md
@@ -21,7 +21,7 @@ the current FogHTTP API. The same flow is available as a runnable example in
 | client default `headers` | Supported | Passed as `Client(headers=...)` or `AsyncClient(headers=...)`. Per-request headers override defaults case-insensitively. |
 | `json` | Supported | Encoded with `orjson`. Adds `content-type: application/json` unless explicitly set. |
 | `content` | Supported | Accepts buffered `bytes` or `str`. Strings are encoded as UTF-8. No semantic content type is added. |
-| `data` | Reserved | Planned for form-urlencoded bodies. Not accepted yet. |
+| `data` | Supported | Mappings and repeated pairs are encoded as `application/x-www-form-urlencoded`. Raw `bytes` or `str` are sent as buffered body content without adding a semantic content type. |
 | `files` | Reserved | Planned for multipart uploads. Not accepted yet. |
 | `auth` | Planned | Use explicit `Authorization` headers for simple static tokens. |
 | cookies/session jar | Planned | `cookies=True` is rejected today. |
@@ -38,7 +38,7 @@ FogHTTP applies request values in this order:
 |---|---|
 | URL | `base_url` resolution, request URL query, client params, per-request params |
 | Headers | client headers, future auth-managed headers, per-request headers |
-| Body | exactly one body source: `json=` or `content=` |
+| Body | exactly one body source: `json=`, `data=`, or `content=` |
 
 Repeated query keys are preserved. Per-request params are appended after client
 defaults instead of replacing them, which keeps API-version, tenant, locale, and
@@ -100,6 +100,33 @@ async with foghttp.AsyncClient(
 
 Sync and async request builders share the same merge and body conflict rules.
 
+## Form Data
+
+Use `data=` for buffered form-urlencoded requests.
+
+```python
+import foghttp
+
+
+with foghttp.Client(base_url="https://api.example.com") as client:
+    response = client.post(
+        "oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "scope": ["read", "write"],
+        },
+    )
+    response.raise_for_status()
+```
+
+Mappings and repeated pairs are encoded with repeated keys preserved. FogHTTP
+adds `content-type: application/x-www-form-urlencoded` for encoded form data
+unless the caller already set `content-type`.
+
+Raw `bytes` or `str` passed through `data=` are treated as already encoded
+buffered body content, so FogHTTP does not add a semantic content type for
+those values.
+
 ## Prepared Requests
 
 Use `build_request()` when application code needs to inspect or adjust a request
@@ -136,18 +163,23 @@ Rust client, or consume pool/request slots.
 | `json=False`, `json=0`, `{}`, `[]` | JSON body |
 | `content=None` | no request body |
 | `content=b""`, `content=""` | empty buffered body |
-| `json=` and `content=` together | `ValueError` |
+| `data=None` | no request body |
+| `data={}`, `data=[]` | empty form-urlencoded body |
+| `data=` mapping or repeated pairs | form-urlencoded body |
+| `data=` bytes or string | raw buffered body |
+| more than one of `json=`, `data=`, `content=` | `ValueError` |
 | iterator or async iterator `content=` | `TypeError` |
-| `data=` or `files=` | not accepted yet |
+| iterator `data=` | `TypeError` |
+| `files=` | not accepted yet |
 
 `Content-Length` and `Transfer-Encoding` are transport-managed framing headers
 and cannot be set manually. `Content-Type` is semantic and can be set by the
 caller; FogHTTP only adds `application/json` for `json=` when the caller did not
 already provide a content type.
 
-Buffered `json=` and `content=` request bodies are replayable for the current
-redirect policy. Future streaming uploads will need an explicit non-replayable
-body contract.
+Buffered `json=`, `data=`, and `content=` request bodies are replayable for the
+current redirect policy. Future streaming uploads will need an explicit
+non-replayable body contract.
 
 ## Intentional Differences
 
@@ -157,7 +189,6 @@ and observable request limits.
 
 Current intentional gaps:
 
-- no `data=` form encoding yet
 - no `files=` multipart uploads yet
 - no cookie jar
 - no `auth=` helper

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -202,15 +202,23 @@ for the planned auth/hooks layer or keep that logic outside FogHTTP.
 
 ### Small Buffered Uploads
 
-`content=` works for buffered bytes and strings, and `json=` works for JSON.
-Pass only one body source per request. Large file uploads, streaming bodies,
-`data=`, and `files=` should wait for the planned body support.
+`json=` works for JSON, `data=` works for small form-urlencoded bodies, and
+`content=` works for buffered bytes and strings. Pass only one body source per
+request. Large file uploads, streaming bodies, and `files=` should wait for the
+planned body support.
 
 ```python
 response = client.post(
     "https://api.example.com/import",
     content=b"small payload",
     headers={"content-type": "application/octet-stream"},
+)
+```
+
+```python
+response = client.post(
+    "https://api.example.com/oauth/token",
+    data={"grant_type": "client_credentials", "scope": ["read", "write"]},
 )
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,8 +29,8 @@ uv run examples/request_builder_compatibility.py
 - [prepared_requests.py](./prepared_requests.py): build, inspect, adjust, and
   send prepared requests.
 - [request_builder_compatibility.py](./request_builder_compatibility.py):
-  client defaults, repeated query params, prepared requests, and body conflict
-  validation.
+  client defaults, repeated query params, form data, prepared requests, and body
+  conflict validation.
 
 ## Limitations To Keep In Mind
 

--- a/examples/request_builder_compatibility.py
+++ b/examples/request_builder_compatibility.py
@@ -43,6 +43,18 @@ def main() -> None:
         response.raise_for_status()
         print_httpbin_response("shortcut", response)
 
+        form_response = client.post(
+            "anything/oauth/token",
+            data={
+                "grant_type": "client_credentials",
+                "scope": ["read", "write"],
+            },
+            headers={"x-trace": "form-request"},
+        )
+        form_response.raise_for_status()
+        print_httpbin_response("form", form_response)
+        print("form data:", json.dumps(form_response.json().get("form"), sort_keys=True))
+
         request = client.build_request(
             POST,
             "anything/users",
@@ -60,7 +72,7 @@ def main() -> None:
             client.build_request(
                 POST,
                 "anything/body-conflict",
-                content=b"raw body",
+                data={"name": "Grace Hopper"},
                 json={"name": "Grace Hopper"},
             )
         except ValueError as exc:

--- a/foghttp/_client/core.py
+++ b/foghttp/_client/core.py
@@ -10,7 +10,7 @@ from ..messages import CLIENT_CLOSED, UNCLOSED_CLIENT
 from ..request import Request
 from ..timeouts import Timeouts
 from ..transport_stats import TransportStats
-from ..types import QueryParams
+from ..types import QueryParams, RequestData
 from ..url import URL
 from .config import ClientConfig
 from .raw import create_raw_client
@@ -46,6 +46,7 @@ class ClientCore:
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
     ) -> Request:
         return self._request_builder.build(
@@ -55,6 +56,7 @@ class ClientCore:
                 headers=headers,
                 params=params,
                 content=content,
+                data=data,
                 json=json,
             ),
         )

--- a/foghttp/_client/request_builder/builder.py
+++ b/foghttp/_client/request_builder/builder.py
@@ -39,6 +39,7 @@ class RequestBuilder:
     def _build_body(self, options: RequestBuildOptions, headers: Headers) -> bytes | None:
         return encode_body(
             content=options.content,
+            data=options.data,
             json=options.json,
             headers=headers,
         )

--- a/foghttp/_client/request_builder/models.py
+++ b/foghttp/_client/request_builder/models.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ...headers import HeaderSource
-from ...types import QueryParams
+from ...types import QueryParams, RequestData
 from ...url import URL
 
 
@@ -15,4 +15,5 @@ class RequestBuildOptions:
     headers: HeaderSource = None
     params: QueryParams = None
     content: bytes | str | None = None
+    data: RequestData = None
     json: Any = None

--- a/foghttp/async_client.py
+++ b/foghttp/async_client.py
@@ -17,7 +17,7 @@ from .request import Request
 from .response import Response
 from .timeouts import Timeouts
 from .tls import TLSConfig
-from .types import HttpVersions, QueryParams
+from .types import HttpVersions, QueryParams, RequestData
 from .url import URL
 
 
@@ -87,6 +87,7 @@ class AsyncClient(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -97,6 +98,7 @@ class AsyncClient(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
         )
         return await self.send(request, timeout=timeout)
@@ -125,6 +127,7 @@ class AsyncClient(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -134,6 +137,7 @@ class AsyncClient(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -145,6 +149,7 @@ class AsyncClient(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -154,6 +159,7 @@ class AsyncClient(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -165,6 +171,7 @@ class AsyncClient(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -174,6 +181,7 @@ class AsyncClient(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -185,6 +193,7 @@ class AsyncClient(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -194,6 +203,7 @@ class AsyncClient(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -205,6 +215,7 @@ class AsyncClient(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -214,6 +225,7 @@ class AsyncClient(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -225,6 +237,7 @@ class AsyncClient(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -234,6 +247,7 @@ class AsyncClient(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )

--- a/foghttp/body.py
+++ b/foghttp/body.py
@@ -1,43 +1,57 @@
 __all__ = ("BodyParameter", "encode_body")
 
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping, Sequence
 from enum import StrEnum
-from typing import Any
+from typing import Any, TypeAlias, cast
+from urllib.parse import urlencode
 
 import orjson
 
-from .messages import BODY_CONTENT_AND_JSON_CONFLICT, BODY_CONTENT_UNSUPPORTED
+from .messages import BODY_CONTENT_UNSUPPORTED, BODY_DATA_UNSUPPORTED, BODY_PARAMETER_CONFLICT
+from .types import RequestData
+
+
+CONTENT_TYPE = "content-type"
+FORM_URLENCODED_CONTENT_TYPE = "application/x-www-form-urlencoded"
+JSON_CONTENT_TYPE = "application/json"
+_UrlEncodeData: TypeAlias = Mapping[str, object] | Sequence[tuple[str, object]]
 
 
 class BodyParameter(StrEnum):
     CONTENT = "content"
+    DATA = "data"
     JSON = "json"
 
 
 def encode_body(
     *,
     content: bytes | str | None,
+    data: RequestData,
     json: Any,
     headers: MutableMapping[str, str],
 ) -> bytes | None:
-    source = _body_parameter(content=content, json=json)
+    source = _body_parameter(content=content, data=data, json=json)
     match source:
         case None:
             return None
         case BodyParameter.CONTENT:
             return _encode_content_body(content)
+        case BodyParameter.DATA:
+            return _encode_data_body(data, headers)
         case BodyParameter.JSON:
             return _encode_json_body(json, headers)
 
 
-def _body_parameter(*, content: object, json: object) -> BodyParameter | None:
+def _body_parameter(*, content: object, data: object, json: object) -> BodyParameter | None:
     sources = []
     if content is not None:
         sources.append(BodyParameter.CONTENT)
+    if data is not None:
+        sources.append(BodyParameter.DATA)
     if json is not None:
         sources.append(BodyParameter.JSON)
     if len(sources) > 1:
-        raise ValueError(BODY_CONTENT_AND_JSON_CONFLICT)
+        raise ValueError(BODY_PARAMETER_CONFLICT)
     if sources:
         return sources[0]
     return None
@@ -51,6 +65,19 @@ def _encode_content_body(content: bytes | str | None) -> bytes:
     raise TypeError(BODY_CONTENT_UNSUPPORTED)
 
 
+def _encode_data_body(data: RequestData, headers: MutableMapping[str, str]) -> bytes:
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, str):
+        return data.encode("utf-8")
+
+    headers.setdefault(CONTENT_TYPE, FORM_URLENCODED_CONTENT_TYPE)
+    try:
+        return urlencode(cast("_UrlEncodeData", data), doseq=True).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise TypeError(BODY_DATA_UNSUPPORTED) from exc
+
+
 def _encode_json_body(json: Any, headers: MutableMapping[str, str]) -> bytes:
-    headers.setdefault("content-type", "application/json")
+    headers.setdefault(CONTENT_TYPE, JSON_CONTENT_TYPE)
     return orjson.dumps(json)

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -18,7 +18,7 @@ from .request import Request
 from .response import Response
 from .timeouts import Timeouts
 from .tls import TLSConfig
-from .types import HttpVersions, QueryParams
+from .types import HttpVersions, QueryParams, RequestData
 from .url import URL
 
 
@@ -111,6 +111,7 @@ class Client(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -121,6 +122,7 @@ class Client(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
         )
         return self.send(request, timeout=timeout)
@@ -152,6 +154,7 @@ class Client(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -161,6 +164,7 @@ class Client(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -172,6 +176,7 @@ class Client(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -181,6 +186,7 @@ class Client(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -192,6 +198,7 @@ class Client(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -201,6 +208,7 @@ class Client(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -212,6 +220,7 @@ class Client(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -221,6 +230,7 @@ class Client(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -232,6 +242,7 @@ class Client(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -241,6 +252,7 @@ class Client(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )
@@ -252,6 +264,7 @@ class Client(ClientCore):
         headers: HeaderSource = None,
         params: QueryParams = None,
         content: bytes | str | None = None,
+        data: RequestData = None,
         json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
@@ -261,6 +274,7 @@ class Client(ClientCore):
             headers=headers,
             params=params,
             content=content,
+            data=data,
             json=json,
             timeout=timeout,
         )

--- a/foghttp/messages.py
+++ b/foghttp/messages.py
@@ -1,7 +1,8 @@
 __all__ = (
     "BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED",
-    "BODY_CONTENT_AND_JSON_CONFLICT",
     "BODY_CONTENT_UNSUPPORTED",
+    "BODY_DATA_UNSUPPORTED",
+    "BODY_PARAMETER_CONFLICT",
     "CLIENT_CLOSED",
     "COOKIES_UNSUPPORTED",
     "HTTP_VERSION_UNSUPPORTED",
@@ -23,8 +24,9 @@ from ._redaction import redact_url
 
 
 BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED = "base_url must not include query or fragment"
-BODY_CONTENT_AND_JSON_CONFLICT = "pass only one body parameter: content or json"
 BODY_CONTENT_UNSUPPORTED = "content must be bytes, str, or None"
+BODY_DATA_UNSUPPORTED = "data must be a mapping, sequence of pairs, bytes, str, or None"
+BODY_PARAMETER_CONFLICT = "pass only one body parameter: content, data, or json"
 CLIENT_CLOSED = "AsyncClient is closed"
 COOKIES_UNSUPPORTED = "cookies are planned after the MVP"
 HTTP_VERSION_UNSUPPORTED = "only HTTP/1.1 is supported in the MVP"

--- a/foghttp/types/__init__.py
+++ b/foghttp/types/__init__.py
@@ -5,7 +5,20 @@ __all__ = (
     "QueryParamItems",
     "QueryParamValue",
     "QueryParams",
+    "RequestData",
+    "RequestDataItem",
+    "RequestDataItems",
+    "RequestDataValue",
 )
 
 from .http import HttpVersion, HttpVersions
-from .request import QueryParamItem, QueryParamItems, QueryParams, QueryParamValue
+from .request import (
+    QueryParamItem,
+    QueryParamItems,
+    QueryParams,
+    QueryParamValue,
+    RequestData,
+    RequestDataItem,
+    RequestDataItems,
+    RequestDataValue,
+)

--- a/foghttp/types/request.py
+++ b/foghttp/types/request.py
@@ -3,6 +3,10 @@ __all__ = (
     "QueryParamItems",
     "QueryParamValue",
     "QueryParams",
+    "RequestData",
+    "RequestDataItem",
+    "RequestDataItems",
+    "RequestDataValue",
 )
 
 from collections.abc import Mapping, Sequence
@@ -10,8 +14,14 @@ from typing import TypeAlias
 
 
 _QueryParamScalar: TypeAlias = str | bytes | int | float | bool | None
+_RequestDataScalar: TypeAlias = str | bytes | int | float | bool | None
 
 QueryParamValue: TypeAlias = _QueryParamScalar | Sequence[_QueryParamScalar]
 QueryParamItem: TypeAlias = tuple[str, QueryParamValue]
 QueryParamItems: TypeAlias = Sequence[QueryParamItem]
 QueryParams: TypeAlias = Mapping[str, QueryParamValue] | QueryParamItems | str | None
+
+RequestDataValue: TypeAlias = _RequestDataScalar | Sequence[_RequestDataScalar]
+RequestDataItem: TypeAlias = tuple[str, RequestDataValue]
+RequestDataItems: TypeAlias = Sequence[RequestDataItem]
+RequestData: TypeAlias = Mapping[str, RequestDataValue] | RequestDataItems | bytes | str | None

--- a/tests/request_builder/test_body.py
+++ b/tests/request_builder/test_body.py
@@ -5,8 +5,9 @@ import orjson
 import pytest
 
 import foghttp
-from foghttp.messages import BODY_CONTENT_AND_JSON_CONFLICT, BODY_CONTENT_UNSUPPORTED
+from foghttp.messages import BODY_CONTENT_UNSUPPORTED, BODY_DATA_UNSUPPORTED, BODY_PARAMETER_CONFLICT
 from foghttp.methods import POST
+from foghttp.types import RequestData
 
 
 def test_json_body_adds_content_type_when_missing(faker: Faker) -> None:
@@ -58,7 +59,7 @@ def test_content_body_matrix(content: bytes | str | None, expected_body: bytes |
 def test_build_request_rejects_content_and_json(faker: Faker) -> None:
     content = faker.sentence().encode()
 
-    with foghttp.Client() as client, pytest.raises(ValueError, match=BODY_CONTENT_AND_JSON_CONFLICT):
+    with foghttp.Client() as client, pytest.raises(ValueError, match=BODY_PARAMETER_CONFLICT):
         client.build_request(
             POST,
             faker.url(),
@@ -78,7 +79,7 @@ async def test_async_build_request_rejects_content_and_json(faker: Faker) -> Non
     content = faker.sentence().encode()
 
     async with foghttp.AsyncClient() as client:
-        with pytest.raises(ValueError, match=BODY_CONTENT_AND_JSON_CONFLICT):
+        with pytest.raises(ValueError, match=BODY_PARAMETER_CONFLICT):
             client.build_request(
                 POST,
                 faker.url(),
@@ -108,3 +109,83 @@ def test_json_body_none_is_not_a_body(json_body: Any, expected_body: bytes | Non
         assert request.headers["content-type"] == "application/json"
         assert "content-length" not in request.headers
         assert "transfer-encoding" not in request.headers
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_body"),
+    [
+        (
+            {"grant_type": "client credentials", "scope": ["read", "write"]},
+            b"grant_type=client+credentials&scope=read&scope=write",
+        ),
+        (
+            [("scope", "read"), ("scope", "write"), ("reserved", "a&b=c")],
+            b"scope=read&scope=write&reserved=a%26b%3Dc",
+        ),
+        (
+            (("city", "M\u00fcnchen"), ("enabled", True), ("count", 2)),
+            b"city=M%C3%BCnchen&enabled=True&count=2",
+        ),
+        ({}, b""),
+        ([], b""),
+    ],
+)
+def test_form_data_body_matrix(data: RequestData, expected_body: bytes, faker: Faker) -> None:
+    with foghttp.Client() as client:
+        request = client.build_request(POST, faker.url(), data=data)
+
+    assert request.content == expected_body
+    assert request.headers["content-type"] == "application/x-www-form-urlencoded"
+    assert "content-length" not in request.headers
+    assert "transfer-encoding" not in request.headers
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_body"),
+    [
+        ("grant_type=client_credentials&scope=read", b"grant_type=client_credentials&scope=read"),
+        (b"raw-form-body", b"raw-form-body"),
+    ],
+)
+def test_raw_data_body_matrix(data: RequestData, expected_body: bytes, faker: Faker) -> None:
+    with foghttp.Client() as client:
+        request = client.build_request(POST, faker.url(), data=data)
+
+    assert request.content == expected_body
+    assert "content-type" not in request.headers
+    assert "content-length" not in request.headers
+    assert "transfer-encoding" not in request.headers
+
+
+def test_form_data_body_preserves_explicit_content_type(faker: Faker) -> None:
+    content_type = "application/vnd.foghttp.form"
+
+    with foghttp.Client() as client:
+        request = client.build_request(
+            POST,
+            faker.url(),
+            headers={"content-type": content_type},
+            data={"name": faker.name()},
+        )
+
+    assert request.headers["content-type"] == content_type
+
+
+@pytest.mark.parametrize(
+    "body_kwargs",
+    [
+        {"content": b"raw body", "data": {"name": "Ada Lovelace"}},
+        {"data": {"name": "Ada Lovelace"}, "json": {"name": "Ada Lovelace"}},
+        {"content": b"raw body", "data": {"name": "Ada Lovelace"}, "json": {"name": "Ada Lovelace"}},
+    ],
+)
+def test_build_request_rejects_multiple_body_sources(body_kwargs: dict[str, object], faker: Faker) -> None:
+    with foghttp.Client() as client, pytest.raises(ValueError, match=BODY_PARAMETER_CONFLICT):
+        client.build_request(POST, faker.url(), **body_kwargs)
+
+
+def test_build_request_rejects_non_form_data_sequence(faker: Faker) -> None:
+    data: Any = iter([("name", faker.name())])
+
+    with foghttp.Client() as client, pytest.raises(TypeError, match=BODY_DATA_UNSUPPORTED):
+        client.build_request(POST, faker.url(), data=data)

--- a/tests/request_builder/test_parity.py
+++ b/tests/request_builder/test_parity.py
@@ -66,6 +66,22 @@ async def test_sync_and_async_build_request_have_same_prepared_request(faker: Fa
     assert async_request.content == expected_body
 
 
+async def test_sync_and_async_build_request_have_same_form_data_body(faker: Faker) -> None:
+    data = {"name": faker.name(), "scope": ["read", "write"]}
+    url = faker.url()
+
+    with foghttp.Client() as sync_client:
+        sync_request = sync_client.build_request(POST, url, data=data)
+
+    async with foghttp.AsyncClient() as async_client:
+        async_request = async_client.build_request(POST, url, data=data)
+
+    assert sync_request.url == async_request.url
+    assert sync_request.headers["content-type"] == "application/x-www-form-urlencoded"
+    assert async_request.headers["content-type"] == "application/x-www-form-urlencoded"
+    assert sync_request.content == async_request.content
+
+
 async def test_sync_and_async_build_request_normalize_mixed_case_method(faker: Faker) -> None:
     mixed_case_method = "gEt"
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,11 +1,12 @@
 import gc
+from urllib.parse import urlencode
 
 from faker import Faker
 import orjson
 import pytest
 
 import foghttp
-from foghttp.messages import BODY_CONTENT_AND_JSON_CONFLICT
+from foghttp.messages import BODY_PARAMETER_CONFLICT
 from foghttp.methods import GET, HEAD, POST
 from foghttp.status_codes.success import OK
 
@@ -39,8 +40,22 @@ async def test_post_rejects_content_and_json(http_server: str, faker: Faker) -> 
     payload = {"name": faker.name()}
 
     async with foghttp.AsyncClient() as client:
-        with pytest.raises(ValueError, match=BODY_CONTENT_AND_JSON_CONFLICT):
+        with pytest.raises(ValueError, match=BODY_PARAMETER_CONFLICT):
             await client.post(http_server + "/users", content=content, json=payload)
+
+
+async def test_post_form_data_body(http_server: str, faker: Faker) -> None:
+    name = faker.name()
+
+    async with foghttp.AsyncClient() as client:
+        response = await client.post(
+            http_server + "/users",
+            data={"name": name, "scope": ["read", "write"]},
+        )
+
+    assert response.request.method == POST
+    assert response.request.headers["content-type"] == "application/x-www-form-urlencoded"
+    assert response.json()["body"] == urlencode({"name": name, "scope": ["read", "write"]}, doseq=True)
 
 
 async def test_post_string_content(http_server: str, faker: Faker) -> None:

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -1,11 +1,12 @@
 import gc
+from urllib.parse import urlencode
 
 from faker import Faker
 import orjson
 import pytest
 
 import foghttp
-from foghttp.messages import BODY_CONTENT_AND_JSON_CONFLICT
+from foghttp.messages import BODY_PARAMETER_CONFLICT
 from foghttp.methods import GET, HEAD, POST
 from foghttp.status_codes.success import OK
 
@@ -38,8 +39,22 @@ def test_post_rejects_content_and_json(sync_http_server: str, faker: Faker) -> N
     content = faker.sentence().encode()
     payload = {"name": faker.name()}
 
-    with foghttp.Client() as client, pytest.raises(ValueError, match=BODY_CONTENT_AND_JSON_CONFLICT):
+    with foghttp.Client() as client, pytest.raises(ValueError, match=BODY_PARAMETER_CONFLICT):
         client.post(sync_http_server + "/users", content=content, json=payload)
+
+
+def test_post_form_data_body(sync_http_server: str, faker: Faker) -> None:
+    name = faker.name()
+
+    with foghttp.Client() as client:
+        response = client.post(
+            sync_http_server + "/users",
+            data={"name": name, "scope": ["read", "write"]},
+        )
+
+    assert response.request.method == POST
+    assert response.request.headers["content-type"] == "application/x-www-form-urlencoded"
+    assert response.json()["body"] == urlencode({"name": name, "scope": ["read", "write"]}, doseq=True)
 
 
 def test_post_string_content(sync_http_server: str, faker: Faker) -> None:


### PR DESCRIPTION
- add data= to sync and async request APIs
- encode mappings and repeated pairs as application/x-www-form-urlencoded
- allow raw bytes and str data as buffered body content
- validate content/data/json body source conflicts
- update request builder docs, examples, and tests