### PR TITLE
test(request-builder): add encoding property tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ Issues = "https://github.com/AmberFog/foghttp/issues"
 dev = [
     "coverage[toml]>=7,<8",
     "faker>=33",
+    "hypothesis>=6,<7",
     "pytest>=8",
     "pytest-asyncio>=0.23",
     "trustme>=1.2",

--- a/tests/request_builder/encoding_property_helpers.py
+++ b/tests/request_builder/encoding_property_helpers.py
@@ -1,0 +1,72 @@
+__all__ = (
+    "FIELD_MAPPING",
+    "FIELD_PAIRS",
+    "FIELD_PROPERTY_EXAMPLES",
+    "PATH_SEGMENTS",
+    "QUERY_FRAGMENT",
+    "REQUEST_URL",
+    "URL_PROPERTY_EXAMPLES",
+    "decoded_body_pairs",
+    "decoded_query_pairs",
+    "expected_pairs",
+    "url_with_query",
+)
+
+from urllib.parse import parse_qsl, urlencode
+
+from hypothesis import strategies as st
+
+from foghttp.types import QueryParams, RequestData
+
+
+URL_PROPERTY_EXAMPLES = 80
+FIELD_PROPERTY_EXAMPLES = 120
+QUERY_FRAGMENT = "results"
+REQUEST_URL = f"https://example.com/search#{QUERY_FRAGMENT}"
+
+FIELD_ALPHABET = st.characters(
+    blacklist_categories=("Cc", "Cs"),
+    blacklist_characters="\x00",
+)
+FIELD_NAME = st.text(FIELD_ALPHABET, min_size=1, max_size=12)
+FIELD_TEXT = st.text(FIELD_ALPHABET, max_size=16)
+FIELD_SCALAR = st.one_of(
+    FIELD_TEXT,
+    st.integers(min_value=-1000, max_value=1000),
+    st.booleans(),
+    st.none(),
+)
+FIELD_VALUE = st.one_of(FIELD_SCALAR, st.lists(FIELD_SCALAR, max_size=3))
+FIELD_PAIRS = st.lists(st.tuples(FIELD_NAME, FIELD_VALUE), max_size=8)
+FIELD_MAPPING = st.dictionaries(FIELD_NAME, FIELD_VALUE, max_size=8)
+PATH_SEGMENT = st.text(
+    st.characters(whitelist_categories=("Ll", "Lu"), whitelist_characters="-_0123456789"),
+    min_size=1,
+    max_size=10,
+)
+PATH_SEGMENTS = st.lists(PATH_SEGMENT, min_size=1, max_size=3)
+
+
+def url_with_query(url: str, pairs: QueryParams) -> str:
+    query = urlencode(pairs, doseq=True)
+    if not query:
+        return url
+
+    prefix, fragment = url.split("#", maxsplit=1)
+    separator = "&" if "?" in prefix else "?"
+    return f"{prefix}{separator}{query}#{fragment}"
+
+
+def expected_pairs(data: RequestData) -> list[tuple[str, str]]:
+    return decoded_query_pairs(urlencode(data, doseq=True))
+
+
+def decoded_query_pairs(query: str) -> list[tuple[str, str]]:
+    return parse_qsl(query, keep_blank_values=True)
+
+
+def decoded_body_pairs(content: bytes | None) -> list[tuple[str, str]]:
+    if content is None:
+        msg = "expected encoded request body content"
+        raise AssertionError(msg)
+    return decoded_query_pairs(content.decode("utf-8"))

--- a/tests/request_builder/test_encoding_properties.py
+++ b/tests/request_builder/test_encoding_properties.py
@@ -1,0 +1,117 @@
+from urllib.parse import unquote, urlencode, urlsplit
+
+from hypothesis import given, settings
+
+import foghttp
+from foghttp.methods import GET, POST
+from tests.request_builder.encoding_property_helpers import (
+    FIELD_MAPPING,
+    FIELD_PAIRS,
+    FIELD_PROPERTY_EXAMPLES,
+    PATH_SEGMENTS,
+    QUERY_FRAGMENT,
+    REQUEST_URL,
+    URL_PROPERTY_EXAMPLES,
+    decoded_body_pairs,
+    decoded_query_pairs,
+    expected_pairs,
+    url_with_query,
+)
+
+
+@given(
+    existing_pairs=FIELD_PAIRS,
+    request_pairs=FIELD_PAIRS,
+)
+@settings(max_examples=URL_PROPERTY_EXAMPLES)
+def test_query_params_preserve_existing_query_order_and_fragment(
+    existing_pairs: list[tuple[str, object]],
+    request_pairs: list[tuple[str, object]],
+) -> None:
+    url = url_with_query(REQUEST_URL, existing_pairs)
+
+    with foghttp.Client() as client:
+        request = client.build_request(GET, url, params=request_pairs)
+
+    parts = urlsplit(request.url)
+    assert parts.fragment == QUERY_FRAGMENT
+    assert decoded_query_pairs(parts.query) == [
+        *expected_pairs(existing_pairs),
+        *expected_pairs(request_pairs),
+    ]
+
+
+@given(
+    existing_pairs=FIELD_PAIRS,
+    raw_pairs=FIELD_PAIRS,
+)
+@settings(max_examples=URL_PROPERTY_EXAMPLES)
+def test_raw_query_string_is_appended_as_encoded_query(
+    existing_pairs: list[tuple[str, object]],
+    raw_pairs: list[tuple[str, object]],
+) -> None:
+    url = url_with_query(REQUEST_URL, existing_pairs)
+    raw_query = f"?{urlencode(raw_pairs, doseq=True)}"
+
+    with foghttp.Client() as client:
+        request = client.build_request(GET, url, params=raw_query)
+
+    parts = urlsplit(request.url)
+    assert parts.fragment == QUERY_FRAGMENT
+    assert decoded_query_pairs(parts.query) == [
+        *expected_pairs(existing_pairs),
+        *expected_pairs(raw_pairs),
+    ]
+
+
+@given(
+    base_segments=PATH_SEGMENTS,
+    request_segments=PATH_SEGMENTS,
+    url_pairs=FIELD_PAIRS,
+    client_pairs=FIELD_PAIRS,
+    request_pairs=FIELD_PAIRS,
+)
+@settings(max_examples=URL_PROPERTY_EXAMPLES)
+def test_base_url_join_preserves_query_merge_order_and_fragment(
+    base_segments: list[str],
+    request_segments: list[str],
+    url_pairs: list[tuple[str, object]],
+    client_pairs: list[tuple[str, object]],
+    request_pairs: list[tuple[str, object]],
+) -> None:
+    base_path = "/".join(base_segments)
+    request_path = "/".join(request_segments)
+    base_url = f"https://api.example.com/{base_path}"
+    request_url = url_with_query(f"{request_path}#{QUERY_FRAGMENT}", url_pairs)
+
+    with foghttp.Client(base_url=base_url, params=client_pairs) as client:
+        request = client.build_request(GET, request_url, params=request_pairs)
+
+    parts = urlsplit(request.url)
+    assert unquote(parts.path) == f"/{base_path}/{request_path}"
+    assert parts.fragment == QUERY_FRAGMENT
+    assert decoded_query_pairs(parts.query) == [
+        *expected_pairs(url_pairs),
+        *expected_pairs(client_pairs),
+        *expected_pairs(request_pairs),
+    ]
+
+
+@given(data=FIELD_PAIRS)
+@settings(max_examples=FIELD_PROPERTY_EXAMPLES)
+def test_form_data_pairs_encode_repeated_fields(data: list[tuple[str, object]]) -> None:
+    with foghttp.Client() as client:
+        request = client.build_request(POST, "https://example.com/token", data=data)
+
+    assert request.headers["content-type"] == "application/x-www-form-urlencoded"
+    assert decoded_body_pairs(request.content) == expected_pairs(data)
+
+
+@given(data=FIELD_MAPPING)
+@settings(max_examples=FIELD_PROPERTY_EXAMPLES)
+def test_form_data_mapping_encodes_sequence_values(data: dict[str, object]) -> None:
+    with foghttp.Client() as client:
+        request = client.build_request(POST, "https://example.com/token", data=data)
+
+    assert request.headers["content-type"] == "application/x-www-form-urlencoded"
+    assert decoded_body_pairs(request.content) == expected_pairs(data)

--- a/uv.lock
+++ b/uv.lock
@@ -268,6 +268,7 @@ dependencies = [
 dev = [
     { name = "coverage", extra = ["toml"] },
     { name = "faker" },
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "trustme" },
@@ -277,12 +278,25 @@ dev = [
 requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7,<8" },
     { name = "faker", marker = "extra == 'dev'", specifier = ">=33" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6,<7" },
     { name = "orjson", specifier = ">=3.11,<4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "trustme", marker = "extra == 'dev'", specifier = ">=1.2" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "hypothesis"
+version = "6.152.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/dd/19d273652eb20dac15f32bbc484f2f6d51ccd8fe51fdb27da3f85f9017e8/hypothesis-6.152.7.tar.gz", hash = "sha256:741dedcede2ae0f32c32929a5992804b61f2b0400403b6a51a881a2b58482782", size = 468147, upload-time = "2026-05-13T04:19:34.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/1e/8222edaee03c37350eaa726213614e343a62f1e56396dd000ad9277bfa3d/hypothesis-6.152.7-py3-none-any.whl", hash = "sha256:c0b17dd428fcb6e962f60315f6f4a77816c72fbb281ce9ba73699dabead5ec82", size = 533802, upload-time = "2026-05-13T04:19:30.635Z" },
+]
 
 [[package]]
 name = "idna"
@@ -433,6 +447,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- add hypothesis to development dependencies
- cover URL query merge order and raw query strings
- cover base_url joins with fragments and unicode path encoding
- cover form-urlencoded data encoding for repeated fields