### PR TITLE
chore(release): prepare 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foghttp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foghttp"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - graceful sync `close()` for in-flight requests and cancellable async requests
 - global/per-origin request backpressure and observable request stats
 - advanced per-client Tokio runtime worker tuning
-- focused buffered HTTP surface for JSON APIs, internal services, workers, and
-  benchmarks
+- focused buffered HTTP surface for JSON and form APIs, internal services,
+  workers, and benchmarks
 
 ## Install
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -3,7 +3,9 @@
 Benchmark harness and full benchmark reports live in a separate repository:
 [github.com/AmberFog/FogHttpBenchmark](https://github.com/AmberFog/FogHttpBenchmark).
 
-The tables below are copied summary snapshots from that repository. They are
+The tables below are copied summary snapshots from that repository. The latest
+published snapshot currently covers FogHTTP `0.2.0`; new release measurements
+are added after they are produced in the benchmark repository. These numbers are
 useful for release-to-release comparison, but they are still local loopback
 benchmarks, not a universal prediction for real network latency.
 
@@ -19,7 +21,7 @@ benchmarks, not a universal prediction for real network latency.
 
 ## Snapshots
 
-| Suite | Current | Previous baseline |
+| Suite | Latest snapshot | Previous baseline |
 |---|---:|---:|
 | request workloads | `20260516-102512` | `20260513-231641` |
 | client creation | `20260516-013723` | `20260513-231702` |
@@ -27,7 +29,7 @@ benchmarks, not a universal prediction for real network latency.
 
 ## Versions
 
-| Client | Current | Previous baseline |
+| Client | Latest snapshot | Previous baseline |
 |---|---:|---:|
 | FogHTTP | `0.2.0` | `0.1.3` |
 | aiohttp | `3.13.5` | `3.13.5` |
@@ -45,7 +47,7 @@ Buffered scenarios: `json-small`, `json-decode-small`, `bytes-64k`,
 
 Delay/resource scenarios: `delay-20ms`, `pool-contention-20ms`.
 
-### FogHTTP 0.2.0 Current Summary
+### Latest Snapshot: FogHTTP 0.2.0
 
 | Group | Client | Wins | Median ok/s | Median p95 ms | Max threads | Max fds | Errors |
 |---|---|---:|---:|---:|---:|---:|---:|
@@ -84,7 +86,7 @@ Iterations/run: `100`, client counts: `1,10,50`, repeats: `3`.
 Scenarios: `create-close`, `create-first-request`,
 `many-clients-open-close`, `reused-request`.
 
-### FogHTTP 0.2.0 Current Summary
+### Latest Snapshot: FogHTTP 0.2.0
 
 | Group | Client | Wins | Median ops/s | Median p95 ms | Peak threads | Peak fds | Errors |
 |---|---|---:|---:|---:|---:|---:|---:|

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,8 @@ features:
 # FogHTTP Documentation
 
 FogHTTP is currently an MVP. It is already useful for controlled HTTP workloads
-that use buffered request/response bodies, JSON APIs, explicit client lifecycle,
-and predictable redirect behavior.
+that use buffered request/response bodies, JSON and form APIs, explicit client
+lifecycle, and predictable redirect behavior.
 
 ## Positioning
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "foghttp"
-version = "0.2.1"
+version = "0.3.0"
 description = "Observable Rust-powered HTTP client for Python services."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -258,7 +258,7 @@ wheels = [
 
 [[package]]
 name = "foghttp"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
- bump Python and Rust package versions
- update lock metadata for 0.3.0
- clarify benchmark docs as latest published snapshot