### PR TITLE
fix(client): close sync send lifecycle race

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ FogHTTP is designed around a few engineering priorities:
 - one API shape for sync scripts, workers, and asyncio services
 - Rust-backed HTTP/1.1 transport with explicit runtime ownership
 - buffered JSON, form, and bytes workflows that are simple to reason about
-- graceful sync `close()` that waits for already-started sync requests
+- graceful sync `close()` that waits for in-flight sync requests
 - async cancellation that aborts in-flight Rust requests
 - redirect history and final request metadata for debugging
 - HTTPS with default WebPKI roots and explicit custom CA certificates

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -141,14 +141,17 @@ state.
 For `Client`, `close()` is a graceful lifecycle barrier:
 
 - new requests and transport stats calls are rejected immediately
-- requests that already entered `send()` are allowed to finish
-- `close()` waits until those in-flight sync sends complete
+- sync sends already admitted by the client lifecycle are allowed to finish
+- `close()` waits until those admitted in-flight sync sends complete
 - the Rust transport is closed only after active sync sends finish
 - concurrent `close()` calls wait for the same shutdown and return safely
 
-This means `close()` can block while an already-started sync request is still
+This means `close()` can block while an already-admitted sync request is still
 running. Configure request timeouts so shutdown cannot be held indefinitely by a
 stalled upstream.
+
+An admitted sync send is one that passed the client lifecycle gate before
+shutdown started. Calls racing after shutdown starts are rejected as new work.
 
 ```python
 import foghttp

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -60,7 +60,7 @@ class Client(ClientCore):
             ),
         )
         self._lifecycle_condition = threading.Condition(self._client_lock)
-        self._active_sync_sends = 0
+        self._active_sync_send_tokens: set[object] = set()
         self._close_complete = False
 
     def __enter__(self) -> "Client":
@@ -84,7 +84,7 @@ class Client(ClientCore):
                 return
 
             self._closed = True
-            while self._active_sync_sends:
+            while self._active_sync_send_tokens:
                 self._lifecycle_condition.wait()
             raw_client = self._client
             self._client = None
@@ -126,8 +126,9 @@ class Client(ClientCore):
         return self.send(request, timeout=timeout)
 
     def send(self, request: Request, *, timeout: Timeouts | None = None) -> Response:
-        self._begin_sync_send()
+        sync_send_token = object()
         try:
+            self._begin_sync_send(sync_send_token)
             validate_safe_request_headers(request.headers)
             timeouts = self._request_timeouts(timeout)
             started = time.perf_counter()
@@ -143,7 +144,7 @@ class Client(ClientCore):
 
             return response_from_raw(raw=raw, started=started)
         finally:
-            self._finish_sync_send()
+            self._finish_sync_send(sync_send_token)
 
     def get(
         self,
@@ -277,20 +278,20 @@ class Client(ClientCore):
             timeout=timeout,
         )
 
-    def _begin_sync_send(self) -> None:
+    def _begin_sync_send(self, token: object) -> None:
         with self._lifecycle_condition:
             self._ensure_open()
-            self._active_sync_sends += 1
+            self._active_sync_send_tokens.add(token)
 
     def _sync_send_raw_client(self) -> "_foghttp.RawClient":
         with self._lifecycle_condition:
             return self._raw_client_locked()
 
-    def _finish_sync_send(self) -> None:
+    def _finish_sync_send(self, token: object) -> None:
         with self._lifecycle_condition:
-            self._finish_sync_send_locked()
+            self._finish_sync_send_locked(token)
 
-    def _finish_sync_send_locked(self) -> None:
-        self._active_sync_sends -= 1
-        if self._active_sync_sends == 0:
+    def _finish_sync_send_locked(self, token: object) -> None:
+        self._active_sync_send_tokens.discard(token)
+        if not self._active_sync_send_tokens:
             self._lifecycle_condition.notify_all()

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -126,12 +126,12 @@ class Client(ClientCore):
         return self.send(request, timeout=timeout)
 
     def send(self, request: Request, *, timeout: Timeouts | None = None) -> Response:
-        self._ensure_open()
-        validate_safe_request_headers(request.headers)
-        timeouts = self._request_timeouts(timeout)
-        started = time.perf_counter()
-        raw_client = self._begin_sync_send()
+        self._begin_sync_send()
         try:
+            validate_safe_request_headers(request.headers)
+            timeouts = self._request_timeouts(timeout)
+            started = time.perf_counter()
+            raw_client = self._sync_send_raw_client()
             raw = send_raw_request(
                 raw_client=raw_client,
                 method=request.method,
@@ -277,15 +277,14 @@ class Client(ClientCore):
             timeout=timeout,
         )
 
-    def _begin_sync_send(self) -> "_foghttp.RawClient":
+    def _begin_sync_send(self) -> None:
         with self._lifecycle_condition:
             self._ensure_open()
             self._active_sync_sends += 1
-            try:
-                return self._raw_client_locked()
-            except BaseException:
-                self._finish_sync_send_locked()
-                raise
+
+    def _sync_send_raw_client(self) -> "_foghttp.RawClient":
+        with self._lifecycle_condition:
+            return self._raw_client_locked()
 
     def _finish_sync_send(self) -> None:
         with self._lifecycle_condition:

--- a/tests/client_lifecycle/test_sync_close_race.py
+++ b/tests/client_lifecycle/test_sync_close_race.py
@@ -1,0 +1,136 @@
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    TimeoutError as FutureTimeoutError,
+)
+import importlib
+import threading
+
+from faker import Faker
+import pytest
+
+import foghttp
+from foghttp.methods import GET
+
+from .helpers import (
+    CloseTrackingRawClient,
+    RawClientFactory,
+    wait_until_sync_client_closed,
+)
+
+
+def test_sync_close_waits_for_send_in_validation_window(
+    sync_client_factory: type[foghttp.Client],
+    raw_client: CloseTrackingRawClient,
+    raw_client_factory: RawClientFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    faker: Faker,
+) -> None:
+    client_module = importlib.import_module("foghttp.client")
+    validation_started = threading.Event()
+    release_validation = threading.Event()
+    close_returned = threading.Event()
+    raw_close_started = threading.Event()
+    raw_response = object()
+    response = object()
+
+    def fake_validate_safe_request_headers(_headers: foghttp.Headers) -> None:
+        validation_started.set()
+        if not release_validation.wait(timeout=1.0):
+            msg = "validation release event was not set"
+            raise AssertionError(msg)
+
+    def fake_send_raw_request(**_kwargs: object) -> object:
+        return raw_response
+
+    def fake_response_from_raw(**_kwargs: object) -> object:
+        return response
+
+    def fake_close_raw_client(raw_client_to_close: CloseTrackingRawClient) -> None:
+        raw_close_started.set()
+        raw_client_to_close.close()
+
+    monkeypatch.setattr(
+        client_module,
+        "validate_safe_request_headers",
+        fake_validate_safe_request_headers,
+    )
+    monkeypatch.setattr(client_module, "send_raw_request", fake_send_raw_request)
+    monkeypatch.setattr(client_module, "response_from_raw", fake_response_from_raw)
+    monkeypatch.setattr(client_module, "close_raw_client", fake_close_raw_client)
+
+    client = sync_client_factory()
+    request = client.build_request(GET, faker.url())
+
+    def close_client() -> None:
+        client.close()
+        close_returned.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        request_future = executor.submit(client.send, request)
+        assert validation_started.wait(timeout=1.0)
+
+        close_future = executor.submit(close_client)
+        wait_until_sync_client_closed(client)
+
+        with pytest.raises(FutureTimeoutError):
+            close_future.result(timeout=0.05)
+        assert not close_returned.is_set()
+        assert not raw_close_started.wait(timeout=0.05)
+        assert raw_client_factory.calls == 0
+        assert raw_client.close_calls == 0
+
+        release_validation.set()
+        assert request_future.result(timeout=1.0) is response
+        close_future.result(timeout=1.0)
+
+    assert close_returned.is_set()
+    assert raw_close_started.is_set()
+    assert raw_client_factory.calls == 1
+    assert raw_client.close_calls == 1
+
+
+def test_sync_send_validation_error_releases_concurrent_close(
+    sync_client_factory: type[foghttp.Client],
+    raw_client: CloseTrackingRawClient,
+    raw_client_factory: RawClientFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    faker: Faker,
+) -> None:
+    client_module = importlib.import_module("foghttp.client")
+    validation_started = threading.Event()
+    release_validation = threading.Event()
+
+    def fake_validate_safe_request_headers(_headers: foghttp.Headers) -> None:
+        validation_started.set()
+        if not release_validation.wait(timeout=1.0):
+            msg = "validation release event was not set"
+            raise AssertionError(msg)
+        msg = "invalid request header"
+        raise ValueError(msg)
+
+    monkeypatch.setattr(
+        client_module,
+        "validate_safe_request_headers",
+        fake_validate_safe_request_headers,
+    )
+
+    client = sync_client_factory()
+    request = client.build_request(GET, faker.url())
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        request_future = executor.submit(client.send, request)
+        assert validation_started.wait(timeout=1.0)
+
+        close_future = executor.submit(client.close)
+        wait_until_sync_client_closed(client)
+
+        with pytest.raises(FutureTimeoutError):
+            close_future.result(timeout=0.05)
+
+        release_validation.set()
+        with pytest.raises(ValueError, match="invalid request header"):
+            request_future.result(timeout=1.0)
+        close_future.result(timeout=1.0)
+
+    assert raw_client_factory.calls == 0
+    assert raw_client.close_calls == 0

--- a/tests/client_lifecycle/test_sync_close_race.py
+++ b/tests/client_lifecycle/test_sync_close_race.py
@@ -18,6 +18,10 @@ from .helpers import (
 )
 
 
+class SyntheticBaseException(BaseException):
+    pass
+
+
 def test_sync_close_waits_for_send_in_validation_window(
     sync_client_factory: type[foghttp.Client],
     raw_client: CloseTrackingRawClient,
@@ -67,21 +71,24 @@ def test_sync_close_waits_for_send_in_validation_window(
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         request_future = executor.submit(client.send, request)
-        assert validation_started.wait(timeout=1.0)
+        try:
+            assert validation_started.wait(timeout=1.0)
 
-        close_future = executor.submit(close_client)
-        wait_until_sync_client_closed(client)
+            close_future = executor.submit(close_client)
+            wait_until_sync_client_closed(client)
 
-        with pytest.raises(FutureTimeoutError):
-            close_future.result(timeout=0.05)
-        assert not close_returned.is_set()
-        assert not raw_close_started.wait(timeout=0.05)
-        assert raw_client_factory.calls == 0
-        assert raw_client.close_calls == 0
+            with pytest.raises(FutureTimeoutError):
+                close_future.result(timeout=0.05)
+            assert not close_returned.is_set()
+            assert not raw_close_started.wait(timeout=0.05)
+            assert raw_client_factory.calls == 0
+            assert raw_client.close_calls == 0
 
-        release_validation.set()
-        assert request_future.result(timeout=1.0) is response
-        close_future.result(timeout=1.0)
+            release_validation.set()
+            assert request_future.result(timeout=1.0) is response
+            close_future.result(timeout=1.0)
+        finally:
+            release_validation.set()
 
     assert close_returned.is_set()
     assert raw_close_started.is_set()
@@ -89,12 +96,20 @@ def test_sync_close_waits_for_send_in_validation_window(
     assert raw_client.close_calls == 1
 
 
-def test_sync_send_validation_error_releases_concurrent_close(
+@pytest.mark.parametrize(
+    "error_type",
+    [
+        ValueError,
+        SyntheticBaseException,
+    ],
+)
+def test_sync_send_validation_failure_releases_concurrent_close(
     sync_client_factory: type[foghttp.Client],
     raw_client: CloseTrackingRawClient,
     raw_client_factory: RawClientFactory,
     monkeypatch: pytest.MonkeyPatch,
     faker: Faker,
+    error_type: type[BaseException],
 ) -> None:
     client_module = importlib.import_module("foghttp.client")
     validation_started = threading.Event()
@@ -106,7 +121,7 @@ def test_sync_send_validation_error_releases_concurrent_close(
             msg = "validation release event was not set"
             raise AssertionError(msg)
         msg = "invalid request header"
-        raise ValueError(msg)
+        raise error_type(msg)
 
     monkeypatch.setattr(
         client_module,
@@ -119,18 +134,62 @@ def test_sync_send_validation_error_releases_concurrent_close(
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         request_future = executor.submit(client.send, request)
-        assert validation_started.wait(timeout=1.0)
+        try:
+            assert validation_started.wait(timeout=1.0)
 
-        close_future = executor.submit(client.close)
-        wait_until_sync_client_closed(client)
+            close_future = executor.submit(client.close)
+            wait_until_sync_client_closed(client)
 
-        with pytest.raises(FutureTimeoutError):
-            close_future.result(timeout=0.05)
+            with pytest.raises(FutureTimeoutError):
+                close_future.result(timeout=0.05)
 
-        release_validation.set()
-        with pytest.raises(ValueError, match="invalid request header"):
-            request_future.result(timeout=1.0)
-        close_future.result(timeout=1.0)
+            release_validation.set()
+            with pytest.raises(error_type, match="invalid request header"):
+                request_future.result(timeout=1.0)
+            close_future.result(timeout=1.0)
+        finally:
+            release_validation.set()
 
+    assert raw_client_factory.calls == 0
+    assert raw_client.close_calls == 0
+
+
+def test_sync_send_lifecycle_admission_failure_releases_concurrent_close(
+    sync_client_factory: type[foghttp.Client],
+    raw_client: CloseTrackingRawClient,
+    raw_client_factory: RawClientFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    faker: Faker,
+) -> None:
+    client = sync_client_factory()
+    request = client.build_request(GET, faker.url())
+    begin_sync_send_name = "_begin_sync_send"
+    original_begin_sync_send = getattr(type(client), begin_sync_send_name)
+    admission_started = threading.Event()
+
+    def interrupted_begin_sync_send(instance: foghttp.Client, token: object) -> None:
+        original_begin_sync_send(instance, token)
+        admission_started.set()
+        msg = "interrupted lifecycle admission"
+        raise SyntheticBaseException(msg)
+
+    monkeypatch.setattr(type(client), begin_sync_send_name, interrupted_begin_sync_send)
+
+    with pytest.raises(SyntheticBaseException, match="interrupted lifecycle admission"):
+        client.send(request)
+    assert admission_started.is_set()
+
+    close_returned = threading.Event()
+
+    def close_client() -> None:
+        client.close()
+        close_returned.set()
+
+    close_thread = threading.Thread(target=close_client, daemon=True)
+    close_thread.start()
+
+    assert close_returned.wait(timeout=1.0)
+    close_thread.join(timeout=1.0)
+    assert not close_thread.is_alive()
     assert raw_client_factory.calls == 0
     assert raw_client.close_calls == 0


### PR DESCRIPTION
- register sync sends before pre-transport validation
- keep concurrent close waiting for already-entered send calls
- cover validation-window close and validation-error cleanup