### PR TITLE
fix(headers): preserve obs-text response header values

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -29,6 +29,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - lightweight `response.request`
 - prepared `Request` objects with `build_request()` and `send()`
 - case-insensitive `Headers` with repeated values
+- response header bytes exposed as Latin-1 strings, including obs-text values
 - normalized `URL` with origin comparison and relative joins
 - redirect history
 - GET/HEAD/POST redirects

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -422,6 +422,8 @@ with foghttp.Client() as client:
 
 `response.headers` and `response.request.headers` are `foghttp.Headers`
 objects. Header lookup is case-insensitive, and repeated values are preserved.
+Response header bytes, including HTTP obs-text values, are exposed as Latin-1
+strings so visible headers are not silently dropped.
 
 ```python
 cookies = response.headers.get_list("set-cookie")

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -423,7 +423,7 @@ with foghttp.Client() as client:
 `response.headers` and `response.request.headers` are `foghttp.Headers`
 objects. Header lookup is case-insensitive, and repeated values are preserved.
 Response header bytes, including HTTP obs-text values, are exposed as Latin-1
-strings so visible headers are not silently dropped.
+strings so non-UTF-8 header values are preserved instead of silently dropped.
 
 ```python
 cookies = response.headers.get_list("set-cookie")

--- a/src/core/headers.rs
+++ b/src/core/headers.rs
@@ -3,6 +3,9 @@ use hyper::header::{HeaderMap, HeaderName, HeaderValue};
 use pyo3::prelude::*;
 use std::str::FromStr;
 
+#[cfg(test)]
+mod tests;
+
 pub type HeaderPairs = Vec<(String, String)>;
 
 pub fn request_headers(headers: HeaderPairs) -> PyResult<HeaderMap> {
@@ -23,10 +26,15 @@ pub fn response_headers(headers: &HeaderMap) -> HeaderPairs {
     let mut mapped = Vec::new();
 
     for (name, value) in headers {
-        if let Ok(value) = value.to_str() {
-            mapped.push((name.as_str().to_owned(), value.to_owned()));
-        }
+        mapped.push((
+            name.as_str().to_owned(),
+            response_header_value_as_latin_1(value),
+        ));
     }
 
     mapped
+}
+
+fn response_header_value_as_latin_1(value: &HeaderValue) -> String {
+    value.as_bytes().iter().copied().map(char::from).collect()
 }

--- a/src/core/headers/tests.rs
+++ b/src/core/headers/tests.rs
@@ -1,0 +1,37 @@
+use super::response_headers;
+use hyper::header::{HeaderMap, HeaderName, HeaderValue};
+
+#[test]
+fn response_headers_preserve_obs_text_values_as_latin_1() {
+    let mut headers = HeaderMap::new();
+    headers.append(
+        HeaderName::from_static("x-obs-text"),
+        HeaderValue::from_bytes(b"value-\xe9").unwrap(),
+    );
+
+    assert_eq!(
+        response_headers(&headers),
+        vec![("x-obs-text".to_owned(), "value-\u{e9}".to_owned())],
+    );
+}
+
+#[test]
+fn response_headers_preserve_repeated_mixed_ascii_and_obs_text_values() {
+    let mut headers = HeaderMap::new();
+    headers.append(
+        HeaderName::from_static("x-repeat"),
+        HeaderValue::from_static("ascii"),
+    );
+    headers.append(
+        HeaderName::from_static("x-repeat"),
+        HeaderValue::from_bytes(b"repeat-\xe9").unwrap(),
+    );
+
+    assert_eq!(
+        response_headers(&headers),
+        vec![
+            ("x-repeat".to_owned(), "ascii".to_owned()),
+            ("x-repeat".to_owned(), "repeat-\u{e9}".to_owned()),
+        ],
+    );
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ REDIRECT_PATH_PARTS = 2
 REDIRECT_TO_STATUS_PATH_PARTS = 3
 STATUS_PATH_PARTS = 2
 ECHO_HEADERS_PATH = "/headers/echo"
+OBS_TEXT_HEADERS_PATH = "/headers/obs-text"
 REPEATED_HEADERS_PATH = "/headers/repeated"
 REDIRECT_TO_LOCATION_PATH = "/redirect-to-location"
 SECURITY_HEADERS_PATH = "/headers/security"
@@ -251,6 +252,21 @@ def _raw_repeated_headers_response(path: str) -> bytes | None:
     )
 
 
+def _raw_obs_text_headers_response(path: str) -> bytes | None:
+    if path != OBS_TEXT_HEADERS_PATH:
+        return None
+
+    return (
+        b"HTTP/1.1 200 OK\r\n"
+        b"x-obs-text: value-\xe9\r\n"
+        b"x-repeat: ascii\r\n"
+        b"x-repeat: repeat-\xe9\r\n"
+        b"content-length: 0\r\n"
+        b"connection: close\r\n"
+        b"\r\n"
+    )
+
+
 def _raw_echo_headers_response(path: str, headers: str) -> bytes | None:
     if path != ECHO_HEADERS_PATH:
         return None
@@ -338,6 +354,7 @@ def _raw_http_server_response(headers: str, body: bytes) -> bytes:
         or _raw_unknown_size_bytes_response(path)
         or _raw_text_response(path)
         or _raw_repeated_headers_response(path)
+        or _raw_obs_text_headers_response(path)
         or _raw_echo_headers_response(path, headers)
         or _raw_security_headers_response(path, headers, body)
     )
@@ -426,6 +443,7 @@ class SyncHTTPHandler(BaseHTTPRequestHandler):
                 lambda: self._write_unknown_size_bytes(path),
                 lambda: self._write_text(path),
                 lambda: self._write_repeated_headers(path),
+                lambda: self._write_obs_text_headers(path),
                 lambda: self._write_echo_headers(path),
                 lambda: self._write_security_headers(path, body),
             )
@@ -532,6 +550,19 @@ class SyncHTTPHandler(BaseHTTPRequestHandler):
         self.send_header("set-cookie", "second=2")
         self.send_header("x-trace", "one")
         self.send_header("x-trace", "two")
+        self.send_header("content-length", "0")
+        self.send_header("connection", "close")
+        self.end_headers()
+        return True
+
+    def _write_obs_text_headers(self, path: str) -> bool:
+        if path != OBS_TEXT_HEADERS_PATH:
+            return False
+
+        self.send_response(OK)
+        self.send_header("x-obs-text", "value-\xe9")
+        self.send_header("x-repeat", "ascii")
+        self.send_header("x-repeat", "repeat-\xe9")
         self.send_header("content-length", "0")
         self.send_header("connection", "close")
         self.end_headers()

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -89,6 +89,15 @@ def test_sync_response_preserves_repeated_headers(sync_http_server: str) -> None
     assert response.headers.get_list("x-trace") == ["one", "two"]
 
 
+def test_sync_response_preserves_obs_text_header_values(sync_http_server: str) -> None:
+    with foghttp.Client() as client:
+        response = client.get(sync_http_server + "/headers/obs-text")
+
+    assert response.status_code == OK
+    assert response.headers["x-obs-text"] == "value-\xe9"
+    assert response.headers.get_list("x-repeat") == ["ascii", "repeat-\xe9"]
+
+
 async def test_async_response_preserves_repeated_headers(http_server: str) -> None:
     async with foghttp.AsyncClient() as client:
         response = await client.get(http_server + "/headers/repeated")
@@ -97,6 +106,15 @@ async def test_async_response_preserves_repeated_headers(http_server: str) -> No
     assert response.headers["set-cookie"] == "second=2"
     assert response.headers.get_list("set-cookie") == ["first=1", "second=2"]
     assert response.headers.get_list("x-trace") == ["one", "two"]
+
+
+async def test_async_response_preserves_obs_text_header_values(http_server: str) -> None:
+    async with foghttp.AsyncClient() as client:
+        response = await client.get(http_server + "/headers/obs-text")
+
+    assert response.status_code == OK
+    assert response.headers["x-obs-text"] == "value-\xe9"
+    assert response.headers.get_list("x-repeat") == ["ascii", "repeat-\xe9"]
 
 
 def test_sync_request_sends_repeated_headers(sync_http_server: str, faker: Faker) -> None:


### PR DESCRIPTION
- map response header bytes as Latin-1 instead of dropping non-UTF-8 values
- cover sync, async, and Rust header mapping paths
- document response header byte preservation policy