### PR TITLE
fix(client): make lifecycle errors client-neutral

### DIFF
--- a/foghttp/messages.py
+++ b/foghttp/messages.py
@@ -27,7 +27,7 @@ BASE_URL_QUERY_OR_FRAGMENT_UNSUPPORTED = "base_url must not include query or fra
 BODY_CONTENT_UNSUPPORTED = "content must be bytes, str, or None"
 BODY_DATA_UNSUPPORTED = "data must be a mapping, sequence of pairs, bytes, str, or None"
 BODY_PARAMETER_CONFLICT = "pass only one body parameter: content, data, or json"
-CLIENT_CLOSED = "AsyncClient is closed"
+CLIENT_CLOSED = "FogHTTP client is closed"
 COOKIES_UNSUPPORTED = "cookies are planned after the MVP"
 HTTP_VERSION_UNSUPPORTED = "only HTTP/1.1 is supported in the MVP"
 MAX_REDIRECTS_INVALID = "max_redirects must be greater than or equal to 0"
@@ -36,7 +36,7 @@ POOL_ACQUIRE_TIMEOUT = "request acquire timeout expired"
 RUNTIME_WORKERS_ENV_INVALID = "FOGHTTP_RUNTIME_WORKERS must be an integer between 1 and 32"
 RUNTIME_WORKERS_INVALID = "runtime_workers must be an integer between 1 and 32"
 TRUST_ENV_UNSUPPORTED = "trust_env/proxy support is planned after the MVP"
-UNCLOSED_CLIENT = "AsyncClient was not closed"
+UNCLOSED_CLIENT = "FogHTTP client was not closed"
 
 
 def http_status_error(method: str, url: str, status_code: int) -> str:

--- a/tests/client_lifecycle/test_client_lifecycle.py
+++ b/tests/client_lifecycle/test_client_lifecycle.py
@@ -53,7 +53,7 @@ def test_sync_closed_client_rejects_stats(
     client = sync_client_factory()
     client.close()
 
-    with pytest.raises(foghttp.ClientClosedError):
+    with pytest.raises(foghttp.ClientClosedError, match="FogHTTP client is closed"):
         client.stats()
 
 
@@ -304,7 +304,7 @@ async def test_async_closed_client_rejects_stats(
     client = async_client_factory()
     await client.aclose()
 
-    with pytest.raises(foghttp.ClientClosedError):
+    with pytest.raises(foghttp.ClientClosedError, match="FogHTTP client is closed"):
         client.stats()
 
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -151,7 +151,7 @@ async def test_close_is_idempotent() -> None:
 async def test_unclosed_client_warns() -> None:
     client = foghttp.AsyncClient()
 
-    with pytest.warns(foghttp.UnclosedClientError, match="was not closed"):
+    with pytest.warns(foghttp.UnclosedClientError, match="FogHTTP client was not closed"):
         del client
         gc.collect()
 

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -150,7 +150,7 @@ def test_close_is_idempotent() -> None:
 def test_unclosed_client_warns() -> None:
     client = foghttp.Client()
 
-    with pytest.warns(foghttp.UnclosedClientError, match="was not closed"):
+    with pytest.warns(foghttp.UnclosedClientError, match="FogHTTP client was not closed"):
         del client
         gc.collect()
 


### PR DESCRIPTION
- replace AsyncClient-specific lifecycle messages with FogHTTP client wording
- cover sync and async closed-client errors
- cover sync and async unclosed-client warnings