### PR TITLE
fix(client): harden TLS trust boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "bitflags"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,22 +29,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "displaydoc"
@@ -212,11 +190,9 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -378,12 +354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,18 +485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,38 +502,6 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,8 @@ version = "0.27.3"
 default-features = false
 features = [
     "http1",
-    "native-tokio",
     "ring",
     "tls12",
-    "webpki-roots",
 ]
 
 [dependencies.hyper-util]

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -4,6 +4,14 @@ FogHTTP verifies HTTPS certificates by default. There is no `verify=False`
 mode because disabling certificate verification creates a silent production
 security footgun. Use explicit trust roots instead.
 
+## Trust Modes
+
+| Mode | Configuration | Trust boundary |
+|---|---|---|
+| Default WebPKI | `foghttp.Client()` | Bundled WebPKI roots only |
+| WebPKI plus custom CA | `TLSConfig(ca_certificates=(...))` | Bundled WebPKI roots plus explicit CA files |
+| Custom-only CA | `TLSConfig(ca_certificates=(...), trust_webpki_roots=False)` | Explicit CA files only |
+
 ## Default Trust
 
 By default FogHTTP trusts the bundled WebPKI root store used by the Rust
@@ -68,6 +76,21 @@ with foghttp.Client(tls=tls) as client:
 This mode trusts only the CA files you pass. `TLSConfig` rejects
 `trust_webpki_roots=False` without custom CA certificates so the transport
 cannot accidentally run with an empty or verification-free trust boundary.
+
+Use custom-only trust when the client must reject public WebPKI chains and trust
+only an internal or regulated CA bundle.
+
+## Native Roots And Environment
+
+FogHTTP does not load operating-system trust stores today. It also does not read
+TLS settings from `trust_env`. The active trust boundary is always the explicit
+`TLSConfig` plus bundled WebPKI roots when `trust_webpki_roots=True`.
+
+## Unsupported Unsafe Modes
+
+FogHTTP intentionally does not expose a `verify=False` compatibility switch.
+Certificate or SPKI pinning is not implemented yet; use custom-only CA trust for
+internal trust replacement until a dedicated pinning API exists.
 
 ## Current Boundaries
 

--- a/tests/client_tls/conftest.py
+++ b/tests/client_tls/conftest.py
@@ -14,6 +14,13 @@ def tls_certificates(tmp_path: Path) -> TLSCertificateBundle:
 
 
 @pytest.fixture
+def unrelated_tls_certificates(tmp_path: Path) -> TLSCertificateBundle:
+    directory = tmp_path / "unrelated-ca"
+    directory.mkdir()
+    return create_tls_certificate_bundle(directory)
+
+
+@pytest.fixture
 def tls_http_server(tls_certificates: TLSCertificateBundle) -> Iterator[TLSServer]:
     with start_tls_server(tls_certificates) as server:
         yield server

--- a/tests/client_tls/test_tls_config.py
+++ b/tests/client_tls/test_tls_config.py
@@ -44,6 +44,29 @@ def test_client_accepts_custom_only_ca_trust(
     assert response.content == TLS_OK_BODY
 
 
+def test_client_rejects_custom_only_trust_signed_by_unrelated_ca(
+    tls_http_server: TLSServer,
+    unrelated_tls_certificates: TLSCertificateBundle,
+) -> None:
+    tls = foghttp.TLSConfig(
+        ca_certificates=(unrelated_tls_certificates.ca_path,),
+        trust_webpki_roots=False,
+    )
+
+    with (
+        foghttp.Client(tls=tls) as client,
+        pytest.raises(foghttp.RequestError) as exc_info,
+    ):
+        client.get(tls_http_server.url + TLS_PATH)
+
+    assert not isinstance(exc_info.value, foghttp.TimeoutError)
+
+
+def test_tls_config_does_not_expose_verify_false_escape_hatch() -> None:
+    with pytest.raises(TypeError, match="unexpected keyword argument 'verify'"):
+        foghttp.TLSConfig(verify=False)  # type: ignore[call-arg]
+
+
 def test_tls_config_rejects_custom_only_without_ca_certificates() -> None:
     with pytest.raises(ValueError, match="custom-only TLS trust requires at least one CA certificate"):
         foghttp.TLSConfig(trust_webpki_roots=False)


### PR DESCRIPTION
issues-117
update: document TLS trust modes
test: cover custom-only CA boundaries