### PR TITLE
docs: audit streaming release readiness

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -15,8 +15,15 @@ benchmarks, not a universal prediction for real network latency.
 - Shuffle seed: `20260507`.
 - `sync:aiohttp` is skipped because aiohttp is async-only.
 - Some suites skip clients that do not expose comparable APIs.
-- Higher `ok/s` or `ops/s` is better.
+- Higher `ok/s`, `ops/s`, or successful `streams/s` is better.
 - Lower `p95 ms`, threads, fds, and errors are better.
+- Throughput and latency rows are only release-comparable when the row has
+  `0` measured errors and `0` warmup errors. Rows with failures are treated as
+  compatibility or reliability signals, not as successful wins.
+- Streaming benchmark reports expose successful stream counts separately from
+  total errors. Unsupported client rows, line-limit failures, and failed
+  warmups must stay visible near the throughput numbers instead of being folded
+  into aggregate wins.
 
 ## Snapshots
 
@@ -54,6 +61,18 @@ suite.
 | one upstream | `48` | `-0.2%` geomean | `+1.0%` | `base_url`, defaults, prepared requests, JSON, and form bodies remain close to direct requests. |
 | resource/backpressure | `30` common rows | n/a | `-5.3%` | Existing resource scenarios improved slightly; `0.3.1` adds aggregate buffered budget checks. |
 | compressed response | new | n/a | n/a | New suite for transparent gzip, deflate, br, and stacked encodings. |
+
+## Release Readiness Checks
+
+Before copying benchmark numbers into release documentation:
+
+- refresh summaries from the benchmark repository for the exact release commit
+- verify `errors_total`, `warmup_errors_total`, and successful operation counts
+  before writing throughput conclusions
+- keep failed or unsupported competitor rows visible as compatibility rows
+- run or at least syntax-check the examples against the current branch
+- check README, quickstart, limitations, streaming docs, and raw GitHub
+  rendering for stale streaming boundaries
 
 ### Visual Summary
 
@@ -269,18 +288,28 @@ Scenarios: `gzip-json-small`, `gzip-64k`, `deflate-64k`, `br-64k`,
 | sync | zapros | `0/18` | `4073.8` | `3.25` | `52` | `157` | `9000` |
 | sync | httpx | `0/18` | `1982.9` | `6.83` | `52` | `107` | `0` |
 
+Compatibility failures are reported separately from successful throughput:
+
+| Mode | Client | Failed scenario family | Errors |
+|---|---|---|---:|
+| async | aiohttp | stacked `Content-Encoding` | `9000` |
+| async | zapros | stacked `Content-Encoding` | `9000` |
+| sync | zapros | stacked `Content-Encoding` | `9000` |
+
 ```mermaid
 xychart-beta
-    title "Compressed response median ok/s"
-    x-axis [FogHTTP_async, aiohttp_async, zapros_async, httpx_async, FogHTTP_sync, zapros_sync, httpx_sync]
+    title "Compressed response median ok/s with zero errors"
+    x-axis [FogHTTP_async, httpx_async, FogHTTP_sync, httpx_sync]
     y-axis "ok/s" 0 --> 15000
-    bar [12109.4, 6073.2, 3521.2, 1531.1, 14783.6, 4073.8, 1982.9]
+    bar [12109.4, 1531.1, 14783.6, 1982.9]
 ```
 
 In this local compressed-response suite, FogHTTP has the highest observed
-median throughput for concurrent buffered responses and stacked
-`Content-Encoding` decoding. The error totals for aiohttp and zapros come from
-the stacked encoding scenario in this suite.
+median throughput for successful concurrent buffered responses and stacked
+`Content-Encoding` decoding. The aiohttp and zapros rows are still shown in the
+table for transparency, but their non-zero error totals mean they should be
+read as partial compatibility results for this suite rather than clean
+throughput comparisons.
 
 ## Resource And Backpressure Workloads
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -98,6 +98,11 @@ with client.stream(GET, url) as response:
         process_text(text)
 ```
 
+Text and line iterators decode the streamed bytes as delivered after HTTP
+transfer framing. They do not transparently decompress `gzip`, `deflate`, or
+`br` response bodies yet. Use buffered responses for transparent decompression,
+or request an uncompressed response when streaming text or lines.
+
 Line streaming strips line endings and handles `LF`, `CRLF`, empty lines, and a
 final line without a trailing newline. Because a line iterator must buffer text
 until the next delimiter, FogHTTP limits one streamed line to `1048576`

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,9 @@ reusable `base_url` clients, default headers, and default query params for
 one-upstream APIs. They also show the current request builder contract and
 prepared request flow.
 
-Run them from the repository root after building the local extension:
+The examples use public `httpbin.org` endpoints, so they require outbound
+network access. Run them from the repository root after building the local
+extension:
 
 ```bash
 uv run --with "maturin>=1.7,<2" maturin develop
@@ -23,14 +25,14 @@ uv run examples/request_builder_compatibility.py
 ## Good Examples
 
 - [sync_json_api.py](./sync_json_api.py): sync JSON request/response flow.
-- [sync_streaming.py](./sync_streaming.py): sync bytes and line response
+- [sync_streaming.py](./sync_streaming.py): sync bytes, text, and line response
   streaming with explicit context-managed cleanup.
 - [async_json_fanout.py](./async_json_fanout.py): concurrent async GET requests
   with global/per-origin active request limits and stats.
 - [async_resource_limits.py](./async_resource_limits.py): explicit global and
   per-origin request backpressure with expected pool-timeout handling and
   diagnostics.
-- [async_streaming.py](./async_streaming.py): async bytes and line response
+- [async_streaming.py](./async_streaming.py): async bytes, text, and line response
   streaming with explicit context-managed cleanup.
 - [compressed_response.py](./compressed_response.py): manual
   `Accept-Encoding` negotiation with transparent buffered response decoding.

--- a/examples/async_streaming.py
+++ b/examples/async_streaming.py
@@ -15,26 +15,33 @@ from foghttp.methods import GET
 
 
 async def main() -> None:
-    async with (
-        foghttp.AsyncClient() as client,
-        client.stream(GET, "https://httpbin.org/stream-bytes/65536") as response,
-    ):
-        response.raise_for_status()
+    async with foghttp.AsyncClient() as client:
+        async with client.stream(GET, "https://httpbin.org/stream-bytes/65536") as response:
+            response.raise_for_status()
 
-        total = 0
-        async for chunk in response.aiter_bytes():
-            total += len(chunk)
+            total = 0
+            async for chunk in response.aiter_bytes():
+                total += len(chunk)
 
-        print("status:", response.status_code)
-        print("bytes:", total)
-        print("stats:", client.stats())
+            print("status:", response.status_code)
+            print("bytes:", total)
+            print("stats:", client.stats())
 
-    async with client.stream(GET, "https://httpbin.org/stream/3") as response:
-        response.raise_for_status()
-        lines = [line async for line in response.aiter_lines()]
+        async with client.stream(GET, "https://httpbin.org/stream/3") as response:
+            response.raise_for_status()
+            lines = [line async for line in response.aiter_lines()]
 
-        print("line status:", response.status_code)
-        print("lines:", len(lines))
+            print("line status:", response.status_code)
+            print("lines:", len(lines))
+
+        async with client.stream(GET, "https://httpbin.org/encoding/utf8") as response:
+            response.raise_for_status()
+            char_count = 0
+            async for chunk in response.aiter_text():
+                char_count += len(chunk)
+
+            print("text status:", response.status_code)
+            print("text chars:", char_count)
 
 
 if __name__ == "__main__":

--- a/examples/sync_streaming.py
+++ b/examples/sync_streaming.py
@@ -13,26 +13,31 @@ from foghttp.methods import GET
 
 
 def main() -> None:
-    with (
-        foghttp.Client() as client,
-        client.stream(GET, "https://httpbin.org/stream-bytes/65536") as response,
-    ):
-        response.raise_for_status()
+    with foghttp.Client() as client:
+        with client.stream(GET, "https://httpbin.org/stream-bytes/65536") as response:
+            response.raise_for_status()
 
-        total = 0
-        for chunk in response.iter_bytes():
-            total += len(chunk)
+            total = 0
+            for chunk in response.iter_bytes():
+                total += len(chunk)
 
-        print("status:", response.status_code)
-        print("bytes:", total)
-        print("stats:", client.stats())
+            print("status:", response.status_code)
+            print("bytes:", total)
+            print("stats:", client.stats())
 
-    with client.stream(GET, "https://httpbin.org/stream/3") as response:
-        response.raise_for_status()
-        lines = list(response.iter_lines())
+        with client.stream(GET, "https://httpbin.org/stream/3") as response:
+            response.raise_for_status()
+            lines = list(response.iter_lines())
 
-        print("line status:", response.status_code)
-        print("lines:", len(lines))
+            print("line status:", response.status_code)
+            print("lines:", len(lines))
+
+        with client.stream(GET, "https://httpbin.org/encoding/utf8") as response:
+            response.raise_for_status()
+            char_count = sum(len(chunk) for chunk in response.iter_text())
+
+            print("text status:", response.status_code)
+            print("text chars:", char_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
issues-125
update: clarify streaming text and line decompression boundaries update: make benchmark docs separate successful throughput from failure rows fix: keep streaming examples within one live client lifecycle