### PR TITLE
feat(client): add trust_env proxy resolver foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,10 @@ async with foghttp.AsyncClient() as client:
 
 FogHTTP is currently focused on controlled HTTP workloads. Buffered responses
 are the broadest supported path; sync and async response streaming are available
-as bytes/text/line context-managed APIs. Streaming uploads, cookies, auth helpers,
-proxy support, multipart uploads, HTTP/2, automatic `Accept-Encoding`
-negotiation, streaming decompression, strict connection-level pool limits,
+as bytes/text/line context-managed APIs. Streaming uploads, cookies, auth
+helpers, HTTP proxy routing, HTTPS proxy `CONNECT`, multipart uploads,
+HTTP/2, automatic `Accept-Encoding` negotiation, streaming decompression,
+strict connection-level pool limits,
 per-request connect timeout reconfiguration, and request-body write timeout
 semantics are planned for later versions. Response body read timeout is
 available for buffered and streaming response bodies. Socket lifecycle telemetry

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,8 +67,8 @@ The following areas are especially security-sensitive in FogHTTP:
 - URL credentials, token-like query parameters, or secrets in repr/error output
 - sensitive header redaction
 - request or response body leakage in diagnostics
-- SSRF-related behavior in redirects, URL normalization, proxy support, or
-  future environment-driven configuration
+- SSRF-related behavior in redirects, URL normalization, proxy support,
+  `trust_env` environment configuration, or future environment-driven behavior
 - header smuggling or unsafe manual framing headers
 - decompression, buffering, and response-body memory limits
 - denial of service through connection, request, pending queue, runtime, or
@@ -118,8 +118,9 @@ The following are usually out of scope unless they demonstrate a concrete
 FogHTTP vulnerability:
 
 - attacks that require arbitrary code execution in the caller process
-- reports about unsupported features such as proxy support, cookie jar behavior,
-  multipart uploads, or HTTP/2 unless the current code exposes unsafe behavior
+- reports about unsupported features such as proxy transport behavior, cookie
+  jar behavior, multipart uploads, or HTTP/2 unless the current code exposes
+  unsafe behavior
 - denial-of-service reports that ignore documented response and request limits
 - issues caused only by intentionally disabling security in user application
   code outside FogHTTP

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - [Telemetry contract](./telemetry.md)
 - [Response streaming](./streaming.md)
 - [TLS trust](./tls.md)
+- [Proxy and trust_env](./proxies.md)
 - [Use cases](./use-cases.md)
 - [Redirects](./redirects.md)
 - [Limitations](./limitations.md)
@@ -129,7 +130,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 ## Not Yet
 
 FogHTTP does not yet implement streaming uploads, cookies, multipart uploads,
-proxy support, `trust_env`, HTTP/2, automatic `Accept-Encoding` negotiation,
-streaming decompression, or advanced authentication helpers. Disabling TLS
-verification is intentionally not supported. See [Limitations](./limitations.md)
-for details.
+HTTP proxy routing, HTTPS proxy `CONNECT`, HTTP/2, automatic `Accept-Encoding`
+negotiation, streaming decompression, or advanced authentication helpers.
+`trust_env` currently snapshots and validates proxy/TLS environment settings,
+but proxy transport support is still planned. Disabling TLS verification is
+intentionally not supported. See [Limitations](./limitations.md) for details.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -38,6 +38,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - GET/HEAD/POST redirects
 - HTTPS with default WebPKI roots, explicit custom CA certificate files, and
   custom-only CA trust through `TLSConfig(trust_webpki_roots=False)`
+- `trust_env=True` environment snapshot for future proxy decisions and
+  `SSL_CERT_FILE`; see [Proxy and trust_env](./proxies.md)
 - async request cancellation that aborts the in-flight Rust request
 - global active request limit, per-origin active request limit, pending acquire
   limit, request stats, and stuck request pool diagnostics
@@ -65,7 +67,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | Multipart uploads | Not available |
 | `files=` | Reserved in the body matrix; not available yet |
 | Cookie jar | `cookies=True` is rejected |
-| Proxy support | `trust_env=True` is rejected |
+| HTTP proxy routing | Not available yet; `trust_env=True` snapshots and validates proxy env, but requests still use direct transport |
+| HTTPS proxy `CONNECT` | Not available yet |
 | Auth helpers | Use manual headers for simple cases |
 | Disabling TLS verification | Not available by design; use `TLSConfig` with explicit CA certificates |
 | OS trust store integration | Not available; FogHTTP uses bundled WebPKI roots unless `trust_webpki_roots=False` is set |
@@ -101,7 +104,7 @@ Wait before using FogHTTP when:
 
 - you need transparent streaming decompression
 - you upload large files
-- you need proxy behavior from environment variables
+- you need actual proxy routing from environment variables
 - you rely on cookies across requests
 - you need multipart form-data or large uploads
 - you need per-request connect timeout reconfiguration or request-body write

--- a/docs/proxies.md
+++ b/docs/proxies.md
@@ -1,0 +1,90 @@
+# Proxy and trust_env
+
+FogHTTP has a `trust_env` resolver foundation, but HTTP proxy routing is not
+implemented yet. The resolver snapshots and validates environment configuration
+when the client is created so future proxy transport work can use a typed,
+redacted decision model without reading environment variables on each request.
+
+## Current Behavior
+
+`trust_env=False` remains the default.
+
+With `trust_env=True`, FogHTTP currently:
+
+- accepts the client option
+- reads supported environment variables once during client configuration
+- validates proxy URLs and `NO_PROXY` rules
+- redacts proxy credentials in debug-facing representations
+- maps `SSL_CERT_FILE` to `TLSConfig` when no explicit `tls=` is passed
+
+It does not yet:
+
+- route HTTP requests through a proxy
+- tunnel HTTPS requests through `CONNECT`
+- support SOCKS, PAC, WPAD, browser proxy stores, or platform proxy discovery
+- read proxy environment variables on every request
+- use `SSL_CERT_DIR`
+- disable TLS verification through environment variables
+
+## Supported Environment Variables
+
+| Variable | Current behavior |
+|---|---|
+| `HTTP_PROXY` / `http_proxy` | Parsed for future HTTP proxy decisions. Uppercase `HTTP_PROXY` is ignored when `REQUEST_METHOD` is set to avoid HTTPoxy-style CGI leakage. |
+| `HTTPS_PROXY` / `https_proxy` | Parsed for future HTTPS proxy decisions. |
+| `ALL_PROXY` / `all_proxy` | Parsed as fallback when no scheme-specific proxy is set. |
+| `NO_PROXY` / `no_proxy` | Parsed as bypass rules for the selected target origin. |
+| `SSL_CERT_FILE` / `ssl_cert_file` | Converted to `TLSConfig(ca_certificates=(...))` if `tls=` is not passed explicitly. |
+| `SSL_CERT_DIR` | Ignored. Directory trust-store loading is not implemented. |
+
+Lowercase proxy variables win over uppercase variants for the same setting.
+Scheme-specific proxy variables win over `ALL_PROXY`.
+
+Proxy URLs may include userinfo for future proxy authentication support. FogHTTP
+keeps the canonical proxy endpoint without userinfo and exposes credentials only
+through internal typed fields with redacted debug representations.
+
+## NO_PROXY Rules
+
+FogHTTP supports a focused `NO_PROXY` subset:
+
+- wildcard `*`
+- exact hosts
+- domain suffixes such as `example.com`, `.example.com`, or `*.example.com`
+  matching both the apex host and subdomains, but not lookalikes such as
+  `badexample.com`
+- optional ports such as `example.com:8443`; ports must be in the `1..65535`
+  range
+- `localhost`
+- IPv4 addresses
+- bracketed IPv6 addresses such as `[::1]` and `[::1]:8080`
+- comma-separated values with surrounding whitespace
+
+Bracketed `NO_PROXY` hosts are IPv6-only. Bracketed DNS names, `localhost`
+and IPv4 addresses are rejected instead of being reinterpreted as normal host
+rules.
+
+Domain rules use strict label boundaries:
+
+| Rule | Matches apex | Matches subdomains | Does not match |
+|---|---:|---:|---|
+| `example.com` | yes | yes | `badexample.com` |
+| `.example.com` | yes | yes | `badexample.com` |
+| `*.example.com` | yes | yes | `badexample.com` |
+
+Invalid ports and malformed bracketed IPv6 rules are rejected when the client
+configuration is created. FogHTTP rejects the whole environment configuration
+instead of silently ignoring malformed `NO_PROXY` tokens. Empty comma-separated
+tokens are ignored.
+
+## TLS Environment Boundary
+
+Explicit `tls=` always wins over `SSL_CERT_FILE`.
+
+`SSL_CERT_FILE` is snapshotted when the client config is created. The
+certificate file itself is read and validated later, when the Rust transport is
+created.
+
+FogHTTP intentionally does not expose a `verify=False` compatibility mode and
+does not honor environment variables that disable certificate verification.
+Use explicit `TLSConfig` for custom CA bundles and custom-only trust.

--- a/docs/request-builder.md
+++ b/docs/request-builder.md
@@ -25,7 +25,7 @@ the current FogHTTP API. The same flow is available as a runnable example in
 | `files` | Reserved | Planned for multipart uploads. Not accepted yet. |
 | `auth` | Planned | Use explicit `Authorization` headers for simple static tokens. |
 | cookies/session jar | Planned | `cookies=True` is rejected today. |
-| proxy / `trust_env` | Planned | `trust_env=True` is rejected today. |
+| proxy / `trust_env` | Partly supported | `trust_env=True` snapshots and validates proxy/TLS environment settings. HTTP proxy routing and HTTPS `CONNECT` are planned follow-ups. |
 | `timeout` | Partly supported | Per-request `pool`, `read`, and `total` timeouts are supported. Per-request `connect` does not reconfigure the connector. `write` is reserved. |
 | `follow_redirects` | Supported | Client-level setting. GET/HEAD/POST redirects use conservative security rules. |
 | prepared request | Supported | Use `build_request()` and `send()`. Building a request does not create transport state. |
@@ -192,7 +192,7 @@ Current intentional gaps:
 - no `files=` multipart uploads yet
 - no cookie jar
 - no `auth=` helper
-- no proxy or `trust_env` behavior
+- no proxy routing behavior
 - no streaming request body API yet
 - no streaming decompression helpers yet
 - no disabling TLS verification

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -82,9 +82,14 @@ only an internal or regulated CA bundle.
 
 ## Native Roots And Environment
 
-FogHTTP does not load operating-system trust stores today. It also does not read
-TLS settings from `trust_env`. The active trust boundary is always the explicit
-`TLSConfig` plus bundled WebPKI roots when `trust_webpki_roots=True`.
+FogHTTP does not load operating-system trust stores today. With
+`trust_env=True`, `SSL_CERT_FILE` is mapped to
+`TLSConfig(ca_certificates=(...))` only when no explicit `tls=` is passed.
+The environment path is snapshotted at client config creation; the certificate
+file is read and validated later, when the Rust transport is created.
+`SSL_CERT_DIR` and environment-driven TLS verification disabling are not used.
+The active trust boundary is always explicit `TLSConfig`, env-derived
+`SSL_CERT_FILE`, and bundled WebPKI roots when `trust_webpki_roots=True`.
 
 ## Unsupported Unsafe Modes
 
@@ -97,6 +102,7 @@ internal trust replacement until a dedicated pinning API exists.
 - Custom certificates must be PEM files containing CA certificates.
 - Certificate files are read when the Rust transport is created.
 - The same `TLSConfig` works with `Client` and `AsyncClient`.
-- Operating-system trust stores and `trust_env` proxy/TLS behavior are not used
-  today.
+- Operating-system trust stores are not used today.
+- `trust_env=True` supports `SSL_CERT_FILE` only; proxy env variables are
+  parsed for future proxy transport work.
 - Disabling certificate verification is intentionally not supported.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -284,7 +284,7 @@ except foghttp.HTTPStatusError as exc:
 | Streaming uploads | Not implemented |
 | Multipart files | Not implemented |
 | Cookies/session jar | Not implemented |
-| Proxy and `trust_env` | Not implemented |
+| Proxy routing | Not implemented; `trust_env=True` validates env settings for future proxy support |
 | HTTP/2 | Not implemented |
 | Cookie jar and auth helper integration | Not implemented; cross-origin redirects still strip sensitive headers and drop body replay |
 | Unbounded buffered large downloads | `max_response_body_size` defaults to 10 MiB and `max_buffered_response_bytes` defaults to 100 MiB for buffered fail-fast protection; use `stream()` for incremental byte downloads |

--- a/foghttp/_client/config.py
+++ b/foghttp/_client/config.py
@@ -1,5 +1,6 @@
 __all__ = ("ClientConfig",)
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from ..lifecycle_debug import AsyncLifecycleDebugConfig
@@ -8,6 +9,7 @@ from ..telemetry import TelemetryConfig
 from ..timeouts import Timeouts
 from ..tls import TLSConfig
 from .options import ClientOptions, validate_client_options
+from .proxy import ProxyResolver, environment_proxy_config, tls_from_trusted_environment
 from .request_builder.defaults import DEFAULT_REQUEST_BUILD_DEFAULTS, RequestBuildDefaults
 
 
@@ -23,6 +25,7 @@ class ClientConfig:
     max_redirects: int
     trust_env: bool
     tls: TLSConfig | None
+    proxy_resolver: ProxyResolver
     runtime_workers: int | None
     telemetry: TelemetryConfig | None
     lifecycle_debug: AsyncLifecycleDebugConfig | None
@@ -32,15 +35,21 @@ class ClientConfig:
     def from_options(
         cls,
         options: ClientOptions,
+        *,
+        environ: Mapping[str, str] | None = None,
     ) -> "ClientConfig":
         validate_client_options(options)
+        env_config = environment_proxy_config(environ) if options.trust_env else None
         return cls(
             limits=_DEFAULT_LIMITS if options.limits is None else options.limits,
             timeouts=_DEFAULT_TIMEOUTS if options.timeouts is None else options.timeouts,
             follow_redirects=options.follow_redirects,
             max_redirects=options.max_redirects,
             trust_env=options.trust_env,
-            tls=options.tls,
+            tls=tls_from_trusted_environment(explicit_tls=options.tls, env_config=env_config),
+            proxy_resolver=(
+                ProxyResolver.disabled() if env_config is None else ProxyResolver.from_environment(env_config.rules)
+            ),
             runtime_workers=options.runtime_workers,
             telemetry=options.telemetry,
             lifecycle_debug=options.lifecycle_debug,

--- a/foghttp/_client/options.py
+++ b/foghttp/_client/options.py
@@ -11,7 +11,6 @@ from ..messages import (
     MAX_REDIRECTS_INVALID,
     RUNTIME_WORKERS_ENV_INVALID,
     RUNTIME_WORKERS_INVALID,
-    TRUST_ENV_UNSUPPORTED,
 )
 from ..telemetry import TelemetryConfig
 from ..timeouts import Timeouts
@@ -48,7 +47,5 @@ def validate_client_options(options: ClientOptions) -> None:
         raise ValueError(RUNTIME_WORKERS_ENV_INVALID)
     if options.cookies:
         raise NotImplementedError(COOKIES_UNSUPPORTED)
-    if options.trust_env:
-        raise NotImplementedError(TRUST_ENV_UNSUPPORTED)
     if options.http_versions and options.http_versions != ["HTTP/1.1"]:
         raise NotImplementedError(HTTP_VERSION_UNSUPPORTED)

--- a/foghttp/_client/proxy/__init__.py
+++ b/foghttp/_client/proxy/__init__.py
@@ -1,0 +1,17 @@
+__all__ = (
+    "EnvironmentProxyConfig",
+    "NoProxyMatcher",
+    "ProxyDecision",
+    "ProxyResolver",
+    "ProxyRules",
+    "ProxySource",
+    "ProxyTarget",
+    "ProxyUrl",
+    "environment_proxy_config",
+    "tls_from_trusted_environment",
+)
+
+from .environment import EnvironmentProxyConfig, environment_proxy_config, tls_from_trusted_environment
+from .models import ProxyDecision, ProxySource, ProxyTarget, ProxyUrl
+from .no_proxy import NoProxyMatcher
+from .resolver import ProxyResolver, ProxyRules

--- a/foghttp/_client/proxy/constants.py
+++ b/foghttp/_client/proxy/constants.py
@@ -1,0 +1,31 @@
+__all__ = (
+    "ALL_PROXY_ENV_NAMES",
+    "DEFAULT_PROXY_PORTS",
+    "HTTPS_PROXY_ENV_NAMES",
+    "HTTP_PROXY_ENV_NAMES",
+    "MAX_PORT",
+    "MIN_PORT",
+    "NO_PROXY_ENV_NAMES",
+    "REQUEST_METHOD_ENV_NAME",
+    "SSL_CERT_FILE_ENV_NAMES",
+    "SUPPORTED_PROXY_SCHEMES",
+)
+
+from types import MappingProxyType
+
+
+ALL_PROXY_ENV_NAMES = ("all_proxy", "ALL_PROXY")
+HTTP_PROXY_ENV_NAMES = ("http_proxy", "HTTP_PROXY")
+HTTPS_PROXY_ENV_NAMES = ("https_proxy", "HTTPS_PROXY")
+NO_PROXY_ENV_NAMES = ("no_proxy", "NO_PROXY")
+REQUEST_METHOD_ENV_NAME = "REQUEST_METHOD"
+SSL_CERT_FILE_ENV_NAMES = ("ssl_cert_file", "SSL_CERT_FILE")
+MIN_PORT = 1
+MAX_PORT = 65535
+DEFAULT_PROXY_PORTS = MappingProxyType(
+    {
+        "http": 80,
+        "https": 443,
+    },
+)
+SUPPORTED_PROXY_SCHEMES = frozenset(DEFAULT_PROXY_PORTS)

--- a/foghttp/_client/proxy/environment.py
+++ b/foghttp/_client/proxy/environment.py
@@ -1,0 +1,91 @@
+__all__ = (
+    "EnvironmentProxyConfig",
+    "environment_proxy_config",
+    "tls_from_trusted_environment",
+)
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from os import environ
+
+from ...tls import TLSConfig
+from .constants import (
+    ALL_PROXY_ENV_NAMES,
+    HTTP_PROXY_ENV_NAMES,
+    HTTPS_PROXY_ENV_NAMES,
+    NO_PROXY_ENV_NAMES,
+    REQUEST_METHOD_ENV_NAME,
+    SSL_CERT_FILE_ENV_NAMES,
+)
+from .models import ProxyUrl
+from .no_proxy import NoProxyMatcher
+from .resolver import ProxyRules
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentProxyConfig:
+    rules: ProxyRules
+    ssl_cert_file: str | None
+
+
+def environment_proxy_config(env: Mapping[str, str] | None = None) -> EnvironmentProxyConfig:
+    env_values = environ if env is None else env
+    return EnvironmentProxyConfig(
+        rules=ProxyRules(
+            http=_proxy_url_from_env(env_values, _http_proxy_names(env_values)),
+            https=_proxy_url_from_env(env_values, HTTPS_PROXY_ENV_NAMES),
+            all_proxy=_proxy_url_from_env(env_values, ALL_PROXY_ENV_NAMES),
+            no_proxy=NoProxyMatcher.parse(_env_value(env_values, NO_PROXY_ENV_NAMES)),
+        ),
+        ssl_cert_file=_env_value(env_values, SSL_CERT_FILE_ENV_NAMES),
+    )
+
+
+def tls_from_trusted_environment(
+    *,
+    explicit_tls: TLSConfig | None,
+    env_config: EnvironmentProxyConfig | None,
+) -> TLSConfig | None:
+    if explicit_tls is not None or env_config is None or env_config.ssl_cert_file is None:
+        return explicit_tls
+    return TLSConfig(ca_certificates=(env_config.ssl_cert_file,))
+
+
+def _http_proxy_names(env: Mapping[str, str]) -> tuple[str, ...]:
+    if _env_value(env, (REQUEST_METHOD_ENV_NAME,)) is None:
+        return HTTP_PROXY_ENV_NAMES
+    return ("http_proxy",)
+
+
+def _proxy_url_from_env(
+    env: Mapping[str, str],
+    names: tuple[str, ...],
+) -> ProxyUrl | None:
+    selected = _selected_env_value(env, names)
+    if selected is None:
+        return None
+    name, value = selected
+    try:
+        return ProxyUrl.parse(value, source=name)
+    except ValueError as error:
+        msg = f"{name} is invalid: {error}"
+        raise ValueError(msg) from error
+
+
+def _env_value(env: Mapping[str, str], names: tuple[str, ...]) -> str | None:
+    selected = _selected_env_value(env, names)
+    if selected is None:
+        return None
+    _name, value = selected
+    return value
+
+
+def _selected_env_value(
+    env: Mapping[str, str],
+    names: tuple[str, ...],
+) -> tuple[str, str] | None:
+    for name in names:
+        value = env.get(name)
+        if value is not None and value.strip():
+            return name, value.strip()
+    return None

--- a/foghttp/_client/proxy/models.py
+++ b/foghttp/_client/proxy/models.py
@@ -1,0 +1,123 @@
+__all__ = (
+    "ProxyDecision",
+    "ProxySource",
+    "ProxyTarget",
+    "ProxyUrl",
+)
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from urllib.parse import urlunsplit
+
+from ..._redaction import REDACTED_VALUE
+from .constants import DEFAULT_PROXY_PORTS
+from .url_parsing import (
+    split_proxy_url,
+    split_url,
+    validate_proxy_url_shape,
+    validated_host,
+    validated_port,
+)
+
+
+class ProxySource(StrEnum):
+    NONE = "none"
+    EXPLICIT = "explicit"
+    ENVIRONMENT = "environment"
+    NO_PROXY = "no_proxy"
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyCredentials:
+    """Internal raw proxy credentials. Do not log or expose directly."""
+
+    username: str = field(repr=False)
+    password: str | None = field(repr=False)
+
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        return f"{class_name}({REDACTED_VALUE!r})"
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyUrl:
+    """Validated proxy endpoint. ``endpoint_url`` never contains credentials."""
+
+    endpoint_url: str
+    scheme: str
+    host: str
+    port: int
+    endpoint_netloc: str
+    credentials: ProxyCredentials | None
+
+    @classmethod
+    def parse(cls, value: str, *, source: str = "proxy URL") -> "ProxyUrl":
+        parts = split_proxy_url(value, source=source)
+        scheme = parts.scheme.lower()
+        host = validated_host(parts, source=source)
+        port = validated_port(parts, scheme=scheme, source=source)
+        validate_proxy_url_shape(parts, source=source)
+        endpoint_netloc = _proxy_endpoint_netloc(host, port)
+        return cls(
+            endpoint_url=urlunsplit((scheme, endpoint_netloc, "", "", "")),
+            scheme=scheme,
+            host=host,
+            port=port,
+            endpoint_netloc=endpoint_netloc,
+            credentials=_proxy_credentials(parts.username, parts.password),
+        )
+
+    @property
+    def redacted_url(self) -> str:
+        if self.credentials is None:
+            return self.endpoint_url
+        return urlunsplit((self.scheme, f"{REDACTED_VALUE}@{self.endpoint_netloc}", "", "", ""))
+
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        return f"{class_name}({self.redacted_url!r})"
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyTarget:
+    scheme: str
+    host: str
+    port: int
+
+    @classmethod
+    def parse(cls, value: str) -> "ProxyTarget":
+        parts = split_url(value, source="target URL")
+        scheme = parts.scheme.lower()
+        if scheme not in DEFAULT_PROXY_PORTS:
+            msg = "target URL scheme must be http or https"
+            raise ValueError(msg)
+        host = validated_host(parts, source="target URL")
+        port = validated_port(parts, scheme=scheme, source="target URL")
+        return cls(scheme=scheme, host=host, port=port)
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyDecision:
+    target: ProxyTarget
+    proxy: ProxyUrl | None
+    source: ProxySource
+    no_proxy_rule: str | None = None
+
+    @property
+    def uses_proxy(self) -> bool:
+        return self.proxy is not None
+
+
+def _proxy_credentials(
+    username: str | None,
+    password: str | None,
+) -> ProxyCredentials | None:
+    if username is None and password is None:
+        return None
+    return ProxyCredentials(username="" if username is None else username, password=password)
+
+
+def _proxy_endpoint_netloc(host: str, port: int) -> str:
+    if ":" in host:
+        return f"[{host}]:{port}"
+    return f"{host}:{port}"

--- a/foghttp/_client/proxy/no_proxy.py
+++ b/foghttp/_client/proxy/no_proxy.py
@@ -1,0 +1,33 @@
+__all__ = ("NoProxyMatcher", "NoProxyRule")
+
+from dataclasses import dataclass
+
+from .models import ProxyTarget
+from .no_proxy_rule import NoProxyRule
+
+
+@dataclass(frozen=True, slots=True)
+class NoProxyMatcher:
+    rules: tuple[NoProxyRule, ...]
+
+    @classmethod
+    def empty(cls) -> "NoProxyMatcher":
+        return cls(rules=())
+
+    @classmethod
+    def parse(cls, value: str | None) -> "NoProxyMatcher":
+        if not value:
+            return cls.empty()
+
+        rules: list[NoProxyRule] = []
+        for token in value.split(","):
+            rule = NoProxyRule.parse(token)
+            if rule is not None:
+                rules.append(rule)
+        return cls(rules=tuple(rules))
+
+    def find_match(self, target: ProxyTarget) -> NoProxyRule | None:
+        return next((rule for rule in self.rules if rule.matches(target)), None)
+
+    def matches(self, target: ProxyTarget) -> bool:
+        return self.find_match(target) is not None

--- a/foghttp/_client/proxy/no_proxy_rule.py
+++ b/foghttp/_client/proxy/no_proxy_rule.py
@@ -1,0 +1,75 @@
+__all__ = ("NoProxyRule",)
+
+from dataclasses import dataclass
+
+from .models import ProxyTarget
+from .no_proxy_tokens import (
+    is_ip_literal,
+    normalize_rule_host,
+    normalize_target_host,
+    split_no_proxy_host_port,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class NoProxyRule:
+    value: str
+    host: str
+    port: int | None
+    wildcard: bool
+    suffix_match: bool
+    ip_literal: bool
+
+    @classmethod
+    def parse(cls, value: str) -> "NoProxyRule | None":
+        stripped_value = value.strip()
+        if not stripped_value:
+            return None
+        if stripped_value == "*":
+            return cls(
+                value=stripped_value,
+                host="",
+                port=None,
+                wildcard=True,
+                suffix_match=False,
+                ip_literal=False,
+            )
+
+        host, port = split_no_proxy_host_port(stripped_value)
+        normalized_host = normalize_rule_host(host)
+        if _is_malformed_rule_host(host):
+            msg = "NO_PROXY host is invalid"
+            raise ValueError(msg)
+        return cls(
+            value=stripped_value,
+            host=normalized_host,
+            port=port,
+            wildcard=False,
+            suffix_match=_is_suffix_rule(host, normalized_host),
+            ip_literal=is_ip_literal(normalized_host),
+        )
+
+    def matches(self, target: ProxyTarget) -> bool:
+        if self.wildcard:
+            return True
+        if self.port is not None and self.port != target.port:
+            return False
+        return self._matches_host(normalize_target_host(target.host))
+
+    def _matches_host(self, target_host: str) -> bool:
+        if self.ip_literal or is_ip_literal(target_host) or not self.suffix_match:
+            return target_host == self.host
+        return target_host == self.host or target_host.endswith(f".{self.host}")
+
+
+def _is_suffix_rule(raw_host: str, normalized_host: str) -> bool:
+    return raw_host.startswith((".", "*.")) or "." in normalized_host
+
+
+def _is_malformed_rule_host(raw_host: str) -> bool:
+    host = raw_host.strip().lower().rstrip(".")
+    if host.startswith("*."):
+        host = host.removeprefix("*.")
+    elif host.startswith("."):
+        host = host.removeprefix(".")
+    return not host or host == "*" or "*" in host or "" in host.split(".")

--- a/foghttp/_client/proxy/no_proxy_tokens.py
+++ b/foghttp/_client/proxy/no_proxy_tokens.py
@@ -1,0 +1,72 @@
+__all__ = (
+    "is_ip_literal",
+    "normalize_rule_host",
+    "normalize_target_host",
+    "split_no_proxy_host_port",
+)
+
+from ipaddress import IPv6Address, ip_address
+
+from .constants import MAX_PORT, MIN_PORT
+
+
+def split_no_proxy_host_port(value: str) -> tuple[str, int | None]:
+    if value.startswith("["):
+        return _split_bracketed_host_port(value)
+    if value.count(":") == 1:
+        host, port = value.rsplit(":", maxsplit=1)
+        return host, _parse_no_proxy_port(port)
+    return value, None
+
+
+def normalize_rule_host(value: str) -> str:
+    host = value.strip().lower().rstrip(".")
+    host = host.removeprefix("*.")
+    return host.removeprefix(".")
+
+
+def normalize_target_host(value: str) -> str:
+    return value.strip("[]").lower().rstrip(".")
+
+
+def is_ip_literal(value: str) -> bool:
+    try:
+        ip_address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _split_bracketed_host_port(value: str) -> tuple[str, int | None]:
+    bracket_index = value.find("]")
+    if bracket_index < 0:
+        msg = "NO_PROXY IPv6 rule is missing closing bracket"
+        raise ValueError(msg)
+    host = value[1:bracket_index]
+    _validate_bracketed_ipv6_host(host)
+    suffix = value[bracket_index + 1 :]
+    if not suffix:
+        return host, None
+    if not suffix.startswith(":"):
+        msg = "NO_PROXY IPv6 rule suffix is invalid"
+        raise ValueError(msg)
+    return host, _parse_no_proxy_port(suffix[1:])
+
+
+def _validate_bracketed_ipv6_host(host: str) -> None:
+    try:
+        IPv6Address(host)
+    except ValueError as error:
+        msg = "NO_PROXY bracketed host must be an IPv6 address"
+        raise ValueError(msg) from error
+
+
+def _parse_no_proxy_port(value: str) -> int:
+    if not value.isdigit():
+        msg = "NO_PROXY port must be an integer"
+        raise ValueError(msg)
+    port = int(value)
+    if port < MIN_PORT or port > MAX_PORT:
+        msg = f"NO_PROXY port must be between {MIN_PORT} and {MAX_PORT}"
+        raise ValueError(msg)
+    return port

--- a/foghttp/_client/proxy/resolver.py
+++ b/foghttp/_client/proxy/resolver.py
@@ -1,0 +1,58 @@
+__all__ = ("ProxyResolver", "ProxyRules")
+
+from dataclasses import dataclass, field
+
+from .models import ProxyDecision, ProxySource, ProxyTarget, ProxyUrl
+from .no_proxy import NoProxyMatcher
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyRules:
+    http: ProxyUrl | None = None
+    https: ProxyUrl | None = None
+    all_proxy: ProxyUrl | None = None
+    no_proxy: NoProxyMatcher = field(default_factory=NoProxyMatcher.empty)
+
+    def proxy_for_scheme(self, scheme: str) -> ProxyUrl | None:
+        if scheme == "http":
+            return self.http or self.all_proxy
+        if scheme == "https":
+            return self.https or self.all_proxy
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyResolver:
+    explicit: ProxyRules | None
+    environment: ProxyRules | None
+
+    @classmethod
+    def disabled(cls) -> "ProxyResolver":
+        return cls(explicit=None, environment=None)
+
+    @classmethod
+    def from_environment(cls, rules: ProxyRules) -> "ProxyResolver":
+        return cls(explicit=None, environment=rules)
+
+    def resolve(self, url: str) -> ProxyDecision:
+        target = ProxyTarget.parse(url)
+        explicit_proxy = None if self.explicit is None else self.explicit.proxy_for_scheme(target.scheme)
+        if explicit_proxy is not None:
+            return ProxyDecision(target=target, proxy=explicit_proxy, source=ProxySource.EXPLICIT)
+
+        if self.environment is None:
+            return ProxyDecision(target=target, proxy=None, source=ProxySource.NONE)
+
+        no_proxy_rule = self.environment.no_proxy.find_match(target)
+        if no_proxy_rule is not None:
+            return ProxyDecision(
+                target=target,
+                proxy=None,
+                source=ProxySource.NO_PROXY,
+                no_proxy_rule=no_proxy_rule.value,
+            )
+
+        environment_proxy = self.environment.proxy_for_scheme(target.scheme)
+        if environment_proxy is not None:
+            return ProxyDecision(target=target, proxy=environment_proxy, source=ProxySource.ENVIRONMENT)
+        return ProxyDecision(target=target, proxy=None, source=ProxySource.NONE)

--- a/foghttp/_client/proxy/url_parsing.py
+++ b/foghttp/_client/proxy/url_parsing.py
@@ -1,0 +1,63 @@
+__all__ = (
+    "split_proxy_url",
+    "split_url",
+    "validate_proxy_url_shape",
+    "validated_host",
+    "validated_port",
+)
+
+from typing import NoReturn
+from urllib.parse import SplitResult, urlsplit
+
+from .constants import DEFAULT_PROXY_PORTS, MAX_PORT, MIN_PORT, SUPPORTED_PROXY_SCHEMES
+
+
+def split_proxy_url(value: str, *, source: str) -> SplitResult:
+    parts = split_url(value, source=source)
+    if not parts.scheme:
+        _raise_invalid_proxy_url(source, "must include a scheme")
+    if parts.scheme.lower() not in SUPPORTED_PROXY_SCHEMES:
+        _raise_invalid_proxy_url(source, "scheme must be http or https")
+    return parts
+
+
+def split_url(value: str, *, source: str) -> SplitResult:
+    try:
+        return urlsplit(value)
+    except ValueError as error:
+        msg = f"{source} is invalid"
+        raise ValueError(msg) from error
+
+
+def validated_host(parts: SplitResult, *, source: str) -> str:
+    try:
+        host = parts.hostname
+    except ValueError as error:
+        msg = f"{source} host is invalid"
+        raise ValueError(msg) from error
+    if host is None:
+        _raise_invalid_proxy_url(source, "must include a host")
+    return host.lower()
+
+
+def validated_port(parts: SplitResult, *, scheme: str, source: str) -> int:
+    try:
+        port = parts.port
+    except ValueError as error:
+        msg = f"{source} port is invalid"
+        raise ValueError(msg) from error
+    if port is None:
+        return DEFAULT_PROXY_PORTS[scheme]
+    if port < MIN_PORT or port > MAX_PORT:
+        _raise_invalid_proxy_url(source, f"port must be between {MIN_PORT} and {MAX_PORT}")
+    return port
+
+
+def validate_proxy_url_shape(parts: SplitResult, *, source: str) -> None:
+    if parts.path not in ("", "/") or parts.query or parts.fragment:
+        _raise_invalid_proxy_url(source, "must not include path, query or fragment")
+
+
+def _raise_invalid_proxy_url(source: str, reason: str) -> NoReturn:
+    msg = f"{source} {reason}"
+    raise ValueError(msg)

--- a/foghttp/_client/raw/lifecycle.py
+++ b/foghttp/_client/raw/lifecycle.py
@@ -30,7 +30,6 @@ def create_raw_client(
             config.max_redirects,
             ca_certificate_bytes(config.tls),
             trust_webpki_roots(config.tls),
-            config.trust_env,
             config.runtime_workers,
         )
     except _foghttp.FogHttpError as exc:

--- a/foghttp/_foghttp.pyi
+++ b/foghttp/_foghttp.pyi
@@ -288,7 +288,6 @@ class RawClient:
         max_redirects: int,
         ca_certificates: Sequence[bytes],
         trust_webpki_roots: bool,
-        trust_env: bool,
         runtime_workers: int | None,
     ) -> None: ...
     def request(

--- a/foghttp/messages.py
+++ b/foghttp/messages.py
@@ -14,7 +14,6 @@ __all__ = (
     "STREAM_CONTEXT_REENTERED",
     "STREAM_RESPONSE_BODY_CONSUMED",
     "STREAM_RESPONSE_CLOSED",
-    "TRUST_ENV_UNSUPPORTED",
     "UNCLOSED_CLIENT",
     "http_status_error",
     "http_status_reason",
@@ -41,7 +40,6 @@ RUNTIME_WORKERS_INVALID = "runtime_workers must be an integer between 1 and 32"
 STREAM_CONTEXT_REENTERED = "stream context cannot be entered more than once"
 STREAM_RESPONSE_BODY_CONSUMED = "stream response body can be consumed only once"
 STREAM_RESPONSE_CLOSED = "stream response is closed"
-TRUST_ENV_UNSUPPORTED = "trust_env/proxy support is planned after the MVP"
 UNCLOSED_CLIENT = "FogHTTP client was not closed"
 
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -8,7 +8,6 @@ pub const HTTPS_TO_HTTP_REDIRECT_BLOCKED: &str =
     "https-to-http redirect blocked by redirect security policy";
 pub const NON_REPLAYABLE_REQUEST_BODY_REDIRECT: &str =
     "cannot follow redirect with non-replayable request body";
-pub const TRUST_ENV_UNSUPPORTED: &str = "trust_env/proxy support is planned after the MVP";
 
 pub fn response_body_too_large(limit: usize) -> String {
     format!("response body exceeded max_response_body_size of {limit} bytes")

--- a/src/py/client/mod.rs
+++ b/src/py/client/mod.rs
@@ -21,8 +21,7 @@ use crate::py::client::async_requests::{
     AsyncStreamRequestSpawn, RequestCompletion,
 };
 use crate::py::client::options::{
-    validate_numeric_client_options, validate_request_timeouts, validate_unsupported_options,
-    NumericClientOptions,
+    validate_numeric_client_options, validate_request_timeouts, NumericClientOptions,
 };
 use crate::py::client::runtime::build_runtime;
 use crate::py::client::streams::StreamRegistry;
@@ -71,10 +70,8 @@ impl RawClient {
         max_redirects: usize,
         ca_certificates: Vec<Vec<u8>>,
         trust_webpki_roots: bool,
-        trust_env: bool,
         runtime_workers: Option<usize>,
     ) -> PyResult<Self> {
-        validate_unsupported_options(trust_env)?;
         validate_numeric_client_options(NumericClientOptions {
             max_active_requests,
             max_active_requests_per_origin,

--- a/src/py/client/options.rs
+++ b/src/py/client/options.rs
@@ -1,18 +1,8 @@
 use crate::core::numeric::{
     duration_from_secs, validate_optional_usize_option, validate_usize_option,
 };
-use crate::errors::FogHttpError;
-use crate::messages::TRUST_ENV_UNSUPPORTED;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-
-pub fn validate_unsupported_options(trust_env: bool) -> PyResult<()> {
-    if trust_env {
-        return Err(FogHttpError::new_err(TRUST_ENV_UNSUPPORTED));
-    }
-
-    Ok(())
-}
 
 #[derive(Clone, Copy)]
 pub struct NumericClientOptions {

--- a/tests/client_options/test_raw_numeric_boundary.py
+++ b/tests/client_options/test_raw_numeric_boundary.py
@@ -11,7 +11,6 @@ KEEPALIVE = True
 FOLLOW_REDIRECTS = False
 TRUST_WEBPKI_ROOTS = True
 CUSTOM_ONLY_TRUST_WEBPKI_ROOTS = False
-TRUST_ENV = False
 REQUEST_BODY_REPLAYABLE = True
 
 
@@ -34,7 +33,6 @@ def test_raw_client_rejects_empty_custom_only_tls_trust_store() -> None:
             20,
             (),
             CUSTOM_ONLY_TRUST_WEBPKI_ROOTS,
-            TRUST_ENV,
             None,
         )
 
@@ -58,7 +56,6 @@ def test_raw_client_rejects_invalid_idle_timeout_without_panic() -> None:
             20,
             (),
             TRUST_WEBPKI_ROOTS,
-            TRUST_ENV,
             None,
         )
 
@@ -82,7 +79,6 @@ def test_raw_client_rejects_too_large_active_request_limit_without_panic() -> No
             20,
             (),
             TRUST_WEBPKI_ROOTS,
-            TRUST_ENV,
             None,
         )
 
@@ -140,6 +136,5 @@ def _raw_client() -> _foghttp.RawClient:
         20,
         (),
         TRUST_WEBPKI_ROOTS,
-        TRUST_ENV,
         None,
     )

--- a/tests/client_proxy/client_options.py
+++ b/tests/client_proxy/client_options.py
@@ -1,0 +1,28 @@
+__all__ = ("client_options",)
+
+from foghttp._client.constants import DEFAULT_MAX_REDIRECTS
+from foghttp._client.options import ClientOptions
+from foghttp.tls import TLSConfig
+
+
+def client_options(
+    *,
+    trust_env: bool,
+    tls: TLSConfig | None = None,
+) -> ClientOptions:
+    return ClientOptions(
+        base_url=None,
+        headers=None,
+        params=None,
+        limits=None,
+        timeouts=None,
+        http_versions=None,
+        follow_redirects=False,
+        max_redirects=DEFAULT_MAX_REDIRECTS,
+        cookies=False,
+        trust_env=trust_env,
+        tls=tls,
+        runtime_workers=None,
+        telemetry=None,
+        lifecycle_debug=None,
+    )

--- a/tests/client_proxy/environment.py
+++ b/tests/client_proxy/environment.py
@@ -1,0 +1,24 @@
+__all__ = ("clear_proxy_environment",)
+
+import pytest
+
+from foghttp._client.proxy.constants import (
+    ALL_PROXY_ENV_NAMES,
+    HTTP_PROXY_ENV_NAMES,
+    HTTPS_PROXY_ENV_NAMES,
+    NO_PROXY_ENV_NAMES,
+    REQUEST_METHOD_ENV_NAME,
+    SSL_CERT_FILE_ENV_NAMES,
+)
+
+
+def clear_proxy_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        *ALL_PROXY_ENV_NAMES,
+        *HTTP_PROXY_ENV_NAMES,
+        *HTTPS_PROXY_ENV_NAMES,
+        *NO_PROXY_ENV_NAMES,
+        *SSL_CERT_FILE_ENV_NAMES,
+        REQUEST_METHOD_ENV_NAME,
+    ):
+        monkeypatch.delenv(name, raising=False)

--- a/tests/client_proxy/test_client_config.py
+++ b/tests/client_proxy/test_client_config.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+
+from faker import Faker
+import pytest
+
+import foghttp
+from foghttp._client.config import ClientConfig
+from foghttp._client.proxy import ProxySource
+from foghttp.tls import TLSConfig
+
+from .client_options import client_options
+from .environment import clear_proxy_environment
+
+
+def test_client_config_snapshots_trust_env_proxy_values() -> None:
+    env = {"HTTPS_PROXY": "http://first.proxy.example:8080"}
+    config = ClientConfig.from_options(client_options(trust_env=True), environ=env)
+
+    env["HTTPS_PROXY"] = "http://second.proxy.example:8080"
+
+    decision = config.proxy_resolver.resolve("https://api.example.com/items")
+    assert decision.source is ProxySource.ENVIRONMENT
+    assert decision.proxy is not None
+    assert decision.proxy.endpoint_url == "http://first.proxy.example:8080"
+
+
+def test_client_config_does_not_read_env_when_trust_env_is_disabled() -> None:
+    config = ClientConfig.from_options(
+        client_options(trust_env=False),
+        environ={"HTTPS_PROXY": "not a proxy URL"},
+    )
+
+    decision = config.proxy_resolver.resolve("https://api.example.com/items")
+    assert decision.source is ProxySource.NONE
+    assert decision.proxy is None
+
+
+def test_client_config_redacts_proxy_credentials_in_repr(faker: Faker) -> None:
+    username = faker.user_name()
+    hidden_value = faker.pystr(min_chars=12, max_chars=12)
+    config = ClientConfig.from_options(
+        client_options(trust_env=True),
+        environ={"HTTPS_PROXY": f"http://{username}:{hidden_value}@proxy.example:8080"},
+    )
+
+    representation = repr(config)
+    decision = config.proxy_resolver.resolve("https://api.example.com/items")
+
+    assert decision.proxy is not None
+    assert decision.proxy.endpoint_url == "http://proxy.example:8080"
+    assert decision.proxy.credentials is not None
+    assert decision.proxy.redacted_url == "http://<redacted>@proxy.example:8080"
+    assert username not in decision.proxy.endpoint_url
+    assert hidden_value not in decision.proxy.endpoint_url
+    assert username not in repr(decision.proxy)
+    assert hidden_value not in repr(decision.proxy)
+    assert username not in repr(decision.proxy.credentials)
+    assert hidden_value not in repr(decision.proxy.credentials)
+    assert "<redacted>@proxy.example:8080" in representation
+    assert username not in representation
+    assert hidden_value not in representation
+
+
+def test_trust_env_ssl_cert_file_maps_to_tls_config(tmp_path: Path) -> None:
+    ca_path = tmp_path / "ca.pem"
+    ca_path.write_text("certificate")
+
+    config = ClientConfig.from_options(
+        client_options(trust_env=True),
+        environ={"SSL_CERT_FILE": str(ca_path)},
+    )
+
+    assert config.tls == TLSConfig(ca_certificates=(str(ca_path),))
+
+
+def test_trust_env_ssl_cert_file_validation_is_delayed(tmp_path: Path) -> None:
+    ca_path = tmp_path / "missing-ca.pem"
+
+    config = ClientConfig.from_options(
+        client_options(trust_env=True),
+        environ={"SSL_CERT_FILE": str(ca_path)},
+    )
+
+    assert config.tls == TLSConfig(ca_certificates=(str(ca_path),))
+
+
+def test_trust_env_ignores_ssl_cert_dir(tmp_path: Path) -> None:
+    config = ClientConfig.from_options(
+        client_options(trust_env=True),
+        environ={"SSL_CERT_DIR": str(tmp_path)},
+    )
+
+    assert config.tls is None
+
+
+def test_explicit_tls_config_wins_over_ssl_cert_file(tmp_path: Path) -> None:
+    env_ca_path = tmp_path / "env-ca.pem"
+    explicit_ca_path = tmp_path / "explicit-ca.pem"
+    explicit_tls = TLSConfig(ca_certificates=(explicit_ca_path,), trust_webpki_roots=False)
+
+    config = ClientConfig.from_options(
+        client_options(trust_env=True, tls=explicit_tls),
+        environ={"SSL_CERT_FILE": str(env_ca_path)},
+    )
+
+    assert config.tls is explicit_tls
+
+
+def test_public_client_accepts_trust_env_without_creating_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_proxy_environment(monkeypatch)
+
+    with foghttp.Client(trust_env=True) as client:
+        assert client.stats() == foghttp.TransportStats()
+
+
+def test_public_client_rejects_invalid_trust_env_proxy_without_leaking_credentials(
+    faker: Faker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    username = faker.user_name()
+    hidden_value = faker.pystr(min_chars=12, max_chars=12)
+    clear_proxy_environment(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", f"socks5://{username}:{hidden_value}@proxy.example:1080")
+
+    with pytest.raises(ValueError, match="HTTPS_PROXY is invalid") as exc_info:
+        foghttp.Client(trust_env=True)
+
+    message = str(exc_info.value)
+    assert username not in message
+    assert hidden_value not in message
+
+
+def test_public_client_ignores_invalid_proxy_env_when_trust_env_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_proxy_environment(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "not a proxy URL")
+
+    with foghttp.Client(trust_env=False) as client:
+        assert client.stats() == foghttp.TransportStats()
+
+
+async def test_public_async_client_accepts_trust_env_without_creating_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_proxy_environment(monkeypatch)
+
+    async with foghttp.AsyncClient(trust_env=True) as client:
+        assert client.stats() == foghttp.TransportStats()

--- a/tests/client_proxy/test_environment.py
+++ b/tests/client_proxy/test_environment.py
@@ -1,0 +1,149 @@
+from faker import Faker
+import pytest
+
+from foghttp._client.proxy import (
+    NoProxyMatcher,
+    ProxyResolver,
+    ProxyRules,
+    ProxySource,
+    ProxyUrl,
+    environment_proxy_config,
+)
+
+
+def test_scheme_specific_proxy_wins_over_all_proxy() -> None:
+    config = environment_proxy_config(
+        {
+            "HTTPS_PROXY": "http://scheme.proxy.example:8080",
+            "ALL_PROXY": "http://all.proxy.example:8080",
+        },
+    )
+
+    decision = ProxyResolver.from_environment(config.rules).resolve("https://api.example.com/items")
+
+    assert decision.source is ProxySource.ENVIRONMENT
+    assert decision.proxy is not None
+    assert decision.proxy.endpoint_url == "http://scheme.proxy.example:8080"
+
+
+def test_all_proxy_is_used_when_scheme_specific_proxy_is_absent() -> None:
+    config = environment_proxy_config({"ALL_PROXY": "http://all.proxy.example:8080"})
+
+    decision = ProxyResolver.from_environment(config.rules).resolve("https://api.example.com/items")
+
+    assert decision.source is ProxySource.ENVIRONMENT
+    assert decision.proxy is not None
+    assert decision.proxy.endpoint_url == "http://all.proxy.example:8080"
+
+
+def test_lowercase_proxy_env_wins_over_uppercase_proxy_env() -> None:
+    config = environment_proxy_config(
+        {
+            "https_proxy": "http://lower.proxy.example:8080",
+            "HTTPS_PROXY": "http://upper.proxy.example:8080",
+        },
+    )
+
+    decision = ProxyResolver.from_environment(config.rules).resolve("https://api.example.com/items")
+
+    assert decision.proxy is not None
+    assert decision.proxy.endpoint_url == "http://lower.proxy.example:8080"
+
+
+def test_uppercase_http_proxy_is_ignored_in_cgi_environment() -> None:
+    config = environment_proxy_config(
+        {
+            "HTTP_PROXY": "http://header.proxy.example:8080",
+            "REQUEST_METHOD": "GET",
+        },
+    )
+
+    decision = ProxyResolver.from_environment(config.rules).resolve("http://api.example.com/items")
+
+    assert decision.source is ProxySource.NONE
+    assert decision.proxy is None
+
+
+def test_lowercase_http_proxy_is_allowed_in_cgi_environment() -> None:
+    config = environment_proxy_config(
+        {
+            "http_proxy": "http://trusted.proxy.example:8080",
+            "HTTP_PROXY": "http://header.proxy.example:8080",
+            "REQUEST_METHOD": "GET",
+        },
+    )
+
+    decision = ProxyResolver.from_environment(config.rules).resolve("http://api.example.com/items")
+
+    assert decision.source is ProxySource.ENVIRONMENT
+    assert decision.proxy is not None
+    assert decision.proxy.endpoint_url == "http://trusted.proxy.example:8080"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("HTTP_PROXY", id="http-proxy"),
+        pytest.param("HTTPS_PROXY", id="https-proxy"),
+    ],
+)
+def test_proxy_env_rejects_zero_port(name: str) -> None:
+    with pytest.raises(ValueError, match=f"{name} is invalid") as exc_info:
+        environment_proxy_config({name: "http://proxy.example:0"})
+
+    assert "port must be between 1 and 65535" in str(exc_info.value)
+
+
+def test_no_proxy_bypasses_environment_proxy() -> None:
+    config = environment_proxy_config(
+        {
+            "HTTPS_PROXY": "http://proxy.example:8080",
+            "NO_PROXY": "api.example.com",
+        },
+    )
+
+    decision = ProxyResolver.from_environment(config.rules).resolve("https://api.example.com/items")
+
+    assert decision.source is ProxySource.NO_PROXY
+    assert decision.proxy is None
+    assert decision.no_proxy_rule == "api.example.com"
+
+
+def test_explicit_proxy_rules_win_over_environment_and_no_proxy() -> None:
+    resolver = ProxyResolver(
+        explicit=ProxyRules(https=ProxyUrl.parse("http://explicit.proxy.example:8080")),
+        environment=ProxyRules(
+            https=ProxyUrl.parse("http://env.proxy.example:8080"),
+            no_proxy=NoProxyMatcher.parse("*"),
+        ),
+    )
+
+    decision = resolver.resolve("https://api.example.com/items")
+
+    assert decision.source is ProxySource.EXPLICIT
+    assert decision.proxy is not None
+    assert decision.proxy.endpoint_url == "http://explicit.proxy.example:8080"
+
+
+def test_invalid_proxy_url_error_does_not_leak_credentials(faker: Faker) -> None:
+    username = faker.user_name()
+    hidden_value = faker.pystr(min_chars=12, max_chars=12)
+    with pytest.raises(ValueError, match="HTTPS_PROXY is invalid") as exc_info:
+        environment_proxy_config({"HTTPS_PROXY": f"socks5://{username}:{hidden_value}@proxy.example:1080"})
+
+    message = str(exc_info.value)
+    assert "HTTPS_PROXY is invalid" in message
+    assert username not in message
+    assert hidden_value not in message
+
+
+def test_malformed_proxy_host_error_does_not_leak_credentials(faker: Faker) -> None:
+    username = faker.user_name()
+    hidden_value = faker.pystr(min_chars=12, max_chars=12)
+    with pytest.raises(ValueError, match="HTTPS_PROXY is invalid") as exc_info:
+        environment_proxy_config({"HTTPS_PROXY": f"http://{username}:{hidden_value}@[::1"})
+
+    message = str(exc_info.value)
+    assert "HTTPS_PROXY is invalid" in message
+    assert username not in message
+    assert hidden_value not in message

--- a/tests/client_proxy/test_no_proxy.py
+++ b/tests/client_proxy/test_no_proxy.py
@@ -1,0 +1,89 @@
+import pytest
+
+from foghttp._client.proxy import NoProxyMatcher, ProxyTarget
+
+
+@pytest.mark.parametrize(
+    ("no_proxy", "url", "expected_rule"),
+    [
+        pytest.param("*", "https://api.example.com/items", "*", id="wildcard"),
+        pytest.param("example.com", "https://example.com/items", "example.com", id="domain-apex"),
+        pytest.param("example.com", "https://api.example.com/items", "example.com", id="domain-subdomain"),
+        pytest.param(".example.com", "https://example.com/items", ".example.com", id="leading-dot-apex"),
+        pytest.param(".example.com", "https://api.example.com/items", ".example.com", id="leading-dot-subdomain"),
+        pytest.param("*.example.com", "https://example.com/items", "*.example.com", id="wildcard-dot-apex"),
+        pytest.param("*.example.com", "https://api.example.com/items", "*.example.com", id="wildcard-dot-subdomain"),
+        pytest.param("EXAMPLE.com", "https://api.example.com/items", "EXAMPLE.com", id="case-insensitive"),
+        pytest.param("example.com:8443", "https://api.example.com:8443/items", "example.com:8443", id="port"),
+        pytest.param("localhost", "http://localhost/items", "localhost", id="localhost"),
+        pytest.param("127.0.0.1", "http://127.0.0.1/items", "127.0.0.1", id="ipv4"),
+        pytest.param("[::1]", "http://[::1]/items", "[::1]", id="ipv6"),
+        pytest.param("[::1]:8080", "http://[::1]:8080/items", "[::1]:8080", id="ipv6-port"),
+        pytest.param(" *.example.org ", "https://api.example.org/items", "*.example.org", id="whitespace"),
+    ],
+)
+def test_no_proxy_matcher_matches_supported_rules(
+    no_proxy: str,
+    url: str,
+    expected_rule: str,
+) -> None:
+    target = ProxyTarget.parse(url)
+    rule = NoProxyMatcher.parse(no_proxy).find_match(target)
+
+    assert rule is not None
+    assert rule.value == expected_rule
+
+
+@pytest.mark.parametrize(
+    ("no_proxy", "url"),
+    [
+        pytest.param("example.com:8443", "https://api.example.com/items", id="different-port"),
+        pytest.param("example.com", "https://badexample.com/items", id="domain-boundary"),
+        pytest.param(".example.com", "https://badexample.com/items", id="leading-dot-domain-boundary"),
+        pytest.param("*.example.com", "https://badexample.com/items", id="wildcard-dot-domain-boundary"),
+        pytest.param("localhost", "http://api.localhost/items", id="single-label-boundary"),
+        pytest.param("127.0.0.1", "http://127.0.0.2/items", id="ipv4-exact"),
+        pytest.param("[::1]:8080", "http://[::1]:9090/items", id="ipv6-different-port"),
+    ],
+)
+def test_no_proxy_matcher_does_not_match_unrelated_targets(
+    no_proxy: str,
+    url: str,
+) -> None:
+    target = ProxyTarget.parse(url)
+
+    assert NoProxyMatcher.parse(no_proxy).find_match(target) is None
+
+
+@pytest.mark.parametrize(
+    "no_proxy",
+    [
+        pytest.param("example.com:not-a-port", id="named-port"),
+        pytest.param("[::1", id="unclosed-ipv6"),
+        pytest.param("[::1]suffix", id="invalid-ipv6-suffix"),
+        pytest.param("example.com:0", id="zero-port"),
+        pytest.param("example.com:65536", id="port-too-large"),
+        pytest.param(":8080", id="empty-host-with-port"),
+        pytest.param(".", id="empty-dotted-host"),
+        pytest.param("*.", id="empty-wildcard-suffix"),
+        pytest.param("*..example.com", id="empty-wildcard-domain-label"),
+        pytest.param("..example.com", id="empty-leading-domain-label"),
+        pytest.param("example..com", id="empty-middle-domain-label"),
+        pytest.param("exa*mple.com", id="stray-wildcard"),
+        pytest.param("[]", id="empty-ipv6-host"),
+        pytest.param("[]:8080", id="empty-ipv6-host-with-port"),
+        pytest.param("[example.com]", id="bracketed-domain"),
+        pytest.param("[localhost]", id="bracketed-localhost"),
+        pytest.param("[not-an-ip]", id="bracketed-non-ip"),
+        pytest.param("[127.0.0.1]", id="bracketed-ipv4"),
+    ],
+)
+def test_no_proxy_matcher_rejects_malformed_rules(no_proxy: str) -> None:
+    with pytest.raises(ValueError, match="NO_PROXY"):
+        NoProxyMatcher.parse(no_proxy)
+
+
+def test_no_proxy_matcher_ignores_empty_comma_tokens() -> None:
+    matcher = NoProxyMatcher.parse("example.com,,localhost")
+
+    assert tuple(rule.value for rule in matcher.rules) == ("example.com", "localhost")

--- a/tests/client_proxy/test_proxy_models.py
+++ b/tests/client_proxy/test_proxy_models.py
@@ -1,0 +1,62 @@
+from faker import Faker
+import pytest
+
+from foghttp._client.proxy import ProxyTarget, ProxyUrl
+
+
+HTTP_DEFAULT_PORT = 80
+TEST_PROXY_PORT = 8080
+
+
+def test_proxy_url_normalizes_endpoint_without_credentials(faker: Faker) -> None:
+    username = faker.user_name()
+    hidden_value = faker.pystr(min_chars=12, max_chars=12)
+    proxy = ProxyUrl.parse(f"http://{username}:{hidden_value}@Proxy.Example:080")
+    representation = repr(proxy)
+
+    assert proxy.host == "proxy.example"
+    assert proxy.port == HTTP_DEFAULT_PORT
+    assert proxy.endpoint_netloc == "proxy.example:80"
+    assert proxy.endpoint_url == "http://proxy.example:80"
+    assert proxy.redacted_url == "http://<redacted>@proxy.example:80"
+    assert username not in representation
+    assert hidden_value not in representation
+
+
+def test_proxy_url_normalizes_ipv6_endpoint() -> None:
+    proxy = ProxyUrl.parse("http://[::1]:8080")
+
+    assert proxy.host == "::1"
+    assert proxy.port == TEST_PROXY_PORT
+    assert proxy.endpoint_netloc == "[::1]:8080"
+    assert proxy.endpoint_url == "http://[::1]:8080"
+
+
+@pytest.mark.parametrize(
+    ("value", "source"),
+    [
+        pytest.param("http://proxy.example:0", "proxy URL", id="proxy-url"),
+        pytest.param("https://api.example.com:0/items", "target URL", id="target-url"),
+    ],
+)
+def test_proxy_urls_reject_zero_ports(value: str, source: str) -> None:
+    parser = ProxyUrl.parse if source == "proxy URL" else ProxyTarget.parse
+
+    with pytest.raises(ValueError, match=f"{source} port must be between 1 and 65535"):
+        parser(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("http://proxy.example:65536", id="port-too-large"),
+        pytest.param("http://proxy.example:-1", id="negative-port"),
+        pytest.param("http://proxy.example/path", id="path"),
+        pytest.param("http://proxy.example?x=1", id="query"),
+        pytest.param("http://proxy.example#frag", id="fragment"),
+        pytest.param("socks5://proxy.example:1080", id="unsupported-scheme"),
+    ],
+)
+def test_proxy_url_rejects_invalid_proxy_shapes(value: str) -> None:
+    with pytest.raises(ValueError, match="proxy URL"):
+        ProxyUrl.parse(value)

--- a/tests/test_client_options.py
+++ b/tests/test_client_options.py
@@ -34,11 +34,6 @@ def test_client_rejects_cookies_until_supported() -> None:
         foghttp.Client(cookies=True)
 
 
-def test_client_rejects_trust_env_until_supported() -> None:
-    with pytest.raises(NotImplementedError, match="trust_env/proxy support is planned after the MVP"):
-        foghttp.Client(trust_env=True)
-
-
 def test_client_rejects_unsupported_http_versions() -> None:
     with pytest.raises(NotImplementedError, match=r"only HTTP/1\.1 is supported in the MVP"):
         foghttp.Client(http_versions=["HTTP/2"])

--- a/tests/test_raw_client.py
+++ b/tests/test_raw_client.py
@@ -29,7 +29,6 @@ RAW_CLIENT_INIT_ARGUMENTS = (
     "max_redirects",
     "ca_certificates",
     "trust_webpki_roots",
-    "trust_env",
     "runtime_workers",
 )
 
@@ -116,7 +115,6 @@ def test_create_raw_client_passes_transport_limits_to_rust_client(
     follow_redirects = True
     max_redirects = 9
     runtime_workers = 3
-    trust_env = False
 
     raw_client = create_raw_client(
         config=_client_config(
@@ -125,7 +123,6 @@ def test_create_raw_client_passes_transport_limits_to_rust_client(
             follow_redirects=follow_redirects,
             max_redirects=max_redirects,
             runtime_workers=runtime_workers,
-            trust_env=trust_env,
         ),
     )
 
@@ -144,7 +141,6 @@ def test_create_raw_client_passes_transport_limits_to_rust_client(
         "max_redirects": max_redirects,
         "ca_certificates": (),
         "trust_webpki_roots": True,
-        "trust_env": trust_env,
         "runtime_workers": runtime_workers,
     }
 


### PR DESCRIPTION
## Summary

Adds the `trust_env` proxy resolver foundation for FogHTTP.

This PR makes `trust_env=True` accepted and resolves supported proxy/TLS environment settings once during client configuration. It does not implement actual HTTP proxy routing or HTTPS `CONNECT` yet; those remain follow-up transport tasks.

## Changes

- Added internal proxy resolver package under `foghttp/_client/proxy/`.
- Added typed proxy models for proxy URLs, targets, decisions, sources, and rules.
- Implemented environment parsing for:
  - `HTTP_PROXY` / `http_proxy`
  - `HTTPS_PROXY` / `https_proxy`
  - `ALL_PROXY` / `all_proxy`
  - `NO_PROXY` / `no_proxy`
  - `SSL_CERT_FILE` / `ssl_cert_file`
- Ignored uppercase `HTTP_PROXY` in CGI-like environments when `REQUEST_METHOD` is set.
- Added focused `NO_PROXY` matching for wildcard, exact host, suffix, port, localhost, IPv4, and IPv6 rules.
- Mapped `SSL_CERT_FILE` to `TLSConfig` only when explicit `tls=` is not provided.
- Removed the obsolete `trust_env` argument from the Rust `RawClient` constructor boundary.
- Added proxy/trust_env documentation and updated limitations/TLS/request-builder wording.

## Security / Lifecycle Notes

- Environment values are snapshotted at client config creation, not read on each request.
- Proxy credentials are redacted in repr/error-facing surfaces.
- `SSL_CERT_DIR`, TLS verification disabling, PAC/WPAD, SOCKS, HTTP proxy routing, and HTTPS `CONNECT` remain unsupported.
- Proxy decisions stay in Python control-plane until transport support is implemented.
