### PR TITLE
feat(types): add upload body provider contracts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: add-trailing-comma
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.47.2
     hooks:
       - id: typos
 
@@ -66,4 +66,4 @@ repos:
           - orjson>=3.11,<4
           - typing-extensions>=4.3.0,<5
         args: [--config-file=pyproject.toml, --install-types, --non-interactive]
-        files: ^foghttp/.*\.pyi?$
+        files: ^(foghttp|tests/types)/.*\.pyi?$

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ async with foghttp.AsyncClient() as client:
 - [Request builder compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/request-builder.md)
 - [Client lifecycle](https://github.com/AmberFog/foghttp/blob/main/docs/lifecycle.md)
 - [Timeout model](https://github.com/AmberFog/foghttp/blob/main/docs/timeouts.md)
+- [Upload typing contracts](https://github.com/AmberFog/foghttp/blob/main/docs/upload-types.md)
 - [Telemetry contract](https://github.com/AmberFog/foghttp/blob/main/docs/telemetry.md)
 - [Response streaming](https://github.com/AmberFog/foghttp/blob/main/docs/streaming.md)
 - [Proxy and trust_env](https://github.com/AmberFog/foghttp/blob/main/docs/proxies.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - [Request builder compatibility](./request-builder.md)
 - [Client lifecycle](./lifecycle.md)
 - [Timeout model](./timeouts.md)
+- [Upload typing contracts](./upload-types.md)
 - [Telemetry contract](./telemetry.md)
 - [Response streaming](./streaming.md)
 - [TLS trust](./tls.md)
@@ -104,6 +105,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - sync and async bytes/text/line response streaming with context-managed cleanup
 - response status flags for success, redirects, and client/server errors
 - prepared `Request` objects with `build_request()` and `send()`
+- public upload typing contracts for planned streaming and multipart body
+  providers
 - case-insensitive `Headers` with repeated value support
 - safe policy for transport-managed request headers
 - redacted repr/error surfaces for sensitive headers, URL credentials,

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -68,6 +68,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | Streaming uploads | Not available; request bodies are buffered |
 | Multipart uploads | Not available |
 | `files=` | Reserved in the body matrix; not available yet |
+| Upload typing contracts | Public provider/factory and multipart aliases are available for planned upload APIs, but they do not enable runtime streaming uploads yet |
 | Cookie jar | `cookies=True` is rejected |
 | Plain HTTP proxy routing | Available for `http://` targets through explicit `proxy=` or `trust_env=True` environment config |
 | HTTPS proxy `CONNECT` | Available for `https://` targets through explicit `proxy=` or `trust_env=True` when the proxy endpoint itself uses `http://`; TLS is validated against the target host |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -404,7 +404,9 @@ Passing more than one body source raises `ValueError`. `Content-Length` and
 in request headers; the Rust transport owns them. Buffered `json=`, `data=`,
 and `content=` bodies are replayable for the current redirect policy. Iterator,
 async iterator, and streaming request bodies are not accepted yet and will need
-an explicit non-replayable body contract later.
+an explicit non-replayable body contract later. Public provider and multipart
+type aliases are available for that planned contract; see
+[Upload typing contracts](./upload-types.md).
 
 ## Buffered Response Decoding
 

--- a/docs/request-builder.md
+++ b/docs/request-builder.md
@@ -179,7 +179,9 @@ already provide a content type.
 
 Buffered `json=`, `data=`, and `content=` request bodies are replayable for the
 current redirect policy. Future streaming uploads will need an explicit
-non-replayable body contract.
+non-replayable body contract. The public provider and multipart aliases that
+future upload APIs will use are documented in
+[Upload typing contracts](./upload-types.md).
 
 ## Intentional Differences
 

--- a/docs/upload-types.md
+++ b/docs/upload-types.md
@@ -1,0 +1,75 @@
+# Upload Typing Contracts
+
+FogHTTP exposes public typing contracts for the upload features planned in the
+`0.3.5` release scope. These names are available now so application code,
+wrappers, and future FogHTTP upload APIs can type body providers without
+importing internal classes.
+
+The runtime request API is still buffered-only today: `json=`, `data=`, and
+`content=` accept the same values described in
+[Request builder compatibility](./request-builder.md). Streaming request bodies
+and `files=` multipart uploads will be implemented in later tasks.
+
+## Public Types
+
+Import upload contracts from `foghttp.types`:
+
+```python
+from collections.abc import Iterator
+
+from foghttp.types import SyncByteStream, SyncByteStreamFactory
+
+
+class Chunks:
+    def __iter__(self) -> Iterator[bytes]:
+        yield b"chunk"
+
+
+def replayable_chunks() -> SyncByteStream:
+    return Chunks()
+
+
+stream: SyncByteStream = Chunks()
+factory: SyncByteStreamFactory = replayable_chunks
+```
+
+Available contracts:
+
+| Type | Meaning |
+|---|---|
+| `BodyChunk` | A request body chunk, currently `bytes`. |
+| `SyncByteStream` | Sync iterable body provider yielding `bytes` chunks. |
+| `AsyncByteStream` | Async iterable body provider yielding `bytes` chunks. |
+| `SyncByteStreamFactory` | Callable that returns a fresh sync byte stream. |
+| `AsyncByteStreamFactory` | Callable that returns a fresh async byte stream. |
+| `BinaryFile` | Binary file-like object with `read(size: int = -1, /) -> bytes`. |
+| `SyncMultipartFileContent` | Bytes, binary file, sync byte stream, or sync byte-stream factory for a file part. |
+| `SyncMultipartFileTuple` | `(filename, content)` or `(filename, content, content_type)` for sync multipart APIs. |
+| `SyncMultipartFileValue` | Sync file content or sync file tuple. |
+| `SyncMultipartFiles` | Mapping or repeated pairs of sync multipart file values. |
+| `AsyncMultipartFileContent` | Bytes, binary file, async byte stream, or async byte-stream factory for a file part. |
+| `AsyncMultipartFileTuple` | `(filename, content)` or `(filename, content, content_type)` for async multipart APIs. |
+| `AsyncMultipartFileValue` | Async file content or async file tuple. |
+| `AsyncMultipartFiles` | Mapping or repeated pairs of async multipart file values. |
+
+## Replayability
+
+Streaming and file-backed bodies are non-replayable by default. A body is
+replayable only when the caller provides a factory that can create a fresh,
+independent stream with the same bytes for each send attempt.
+
+Do not model replayability as a public boolean. Future redirect, retry, auth
+refresh, and multipart logic will use provider/factory shape to decide whether a
+body can be safely replayed.
+
+## Ownership And Cleanup
+
+The caller owns body providers and file objects passed to FogHTTP unless the
+future API explicitly documents that FogHTTP opened the resource. Future upload
+implementations must close FogHTTP-owned resources on success, timeout,
+cancellation, redirect rejection, transport error, and client close. Caller-owned
+files remain the caller's responsibility unless the API says otherwise.
+
+Providers should yield `bytes` chunks. Text, paths, and arbitrary iterables are
+not upload chunks; callers should encode or open them explicitly before passing
+them to a future streaming upload API.

--- a/foghttp/types/__init__.py
+++ b/foghttp/types/__init__.py
@@ -1,4 +1,12 @@
 __all__ = (
+    "AsyncByteStream",
+    "AsyncByteStreamFactory",
+    "AsyncMultipartFileContent",
+    "AsyncMultipartFileTuple",
+    "AsyncMultipartFileValue",
+    "AsyncMultipartFiles",
+    "BinaryFile",
+    "BodyChunk",
     "HttpVersion",
     "HttpVersions",
     "QueryParamItem",
@@ -9,8 +17,17 @@ __all__ = (
     "RequestDataItem",
     "RequestDataItems",
     "RequestDataValue",
+    "SyncByteStream",
+    "SyncByteStreamFactory",
+    "SyncMultipartFileContent",
+    "SyncMultipartFileTuple",
+    "SyncMultipartFileValue",
+    "SyncMultipartFiles",
 )
 
+from typing import TypeAlias
+
+from . import multipart as multipart_types
 from .http import HttpVersion, HttpVersions
 from .request import (
     QueryParamItem,
@@ -22,3 +39,21 @@ from .request import (
     RequestDataItems,
     RequestDataValue,
 )
+from .streams import (
+    AsyncByteStream,
+    AsyncByteStreamFactory,
+    BodyChunk,
+    SyncByteStream,
+    SyncByteStreamFactory,
+)
+
+
+BinaryFile = multipart_types.BinaryFile
+AsyncMultipartFileContent: TypeAlias = multipart_types.AsyncMultipartFileContent
+AsyncMultipartFileTuple: TypeAlias = multipart_types.AsyncMultipartFileTuple
+AsyncMultipartFileValue: TypeAlias = multipart_types.AsyncMultipartFileValue
+AsyncMultipartFiles: TypeAlias = multipart_types.AsyncMultipartFiles
+SyncMultipartFileContent: TypeAlias = multipart_types.SyncMultipartFileContent
+SyncMultipartFileTuple: TypeAlias = multipart_types.SyncMultipartFileTuple
+SyncMultipartFileValue: TypeAlias = multipart_types.SyncMultipartFileValue
+SyncMultipartFiles: TypeAlias = multipart_types.SyncMultipartFiles

--- a/foghttp/types/multipart.py
+++ b/foghttp/types/multipart.py
@@ -1,0 +1,36 @@
+__all__ = (
+    "AsyncMultipartFileContent",
+    "AsyncMultipartFileTuple",
+    "AsyncMultipartFileValue",
+    "AsyncMultipartFiles",
+    "BinaryFile",
+    "SyncMultipartFileContent",
+    "SyncMultipartFileTuple",
+    "SyncMultipartFileValue",
+    "SyncMultipartFiles",
+)
+
+from collections.abc import Mapping, Sequence
+from typing import Protocol, TypeAlias
+
+from .streams import (
+    AsyncByteStream,
+    AsyncByteStreamFactory,
+    SyncByteStream,
+    SyncByteStreamFactory,
+)
+
+
+class BinaryFile(Protocol):
+    def read(self, size: int = -1, /) -> bytes: ...
+
+
+SyncMultipartFileContent: TypeAlias = bytes | BinaryFile | SyncByteStream | SyncByteStreamFactory
+SyncMultipartFileTuple: TypeAlias = tuple[str, SyncMultipartFileContent] | tuple[str, SyncMultipartFileContent, str]
+SyncMultipartFileValue: TypeAlias = SyncMultipartFileContent | SyncMultipartFileTuple
+SyncMultipartFiles: TypeAlias = Mapping[str, SyncMultipartFileValue] | Sequence[tuple[str, SyncMultipartFileValue]]
+
+AsyncMultipartFileContent: TypeAlias = bytes | BinaryFile | AsyncByteStream | AsyncByteStreamFactory
+AsyncMultipartFileTuple: TypeAlias = tuple[str, AsyncMultipartFileContent] | tuple[str, AsyncMultipartFileContent, str]
+AsyncMultipartFileValue: TypeAlias = AsyncMultipartFileContent | AsyncMultipartFileTuple
+AsyncMultipartFiles: TypeAlias = Mapping[str, AsyncMultipartFileValue] | Sequence[tuple[str, AsyncMultipartFileValue]]

--- a/foghttp/types/streams.py
+++ b/foghttp/types/streams.py
@@ -1,0 +1,29 @@
+__all__ = (
+    "AsyncByteStream",
+    "AsyncByteStreamFactory",
+    "BodyChunk",
+    "SyncByteStream",
+    "SyncByteStreamFactory",
+)
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Protocol, TypeAlias
+
+
+BodyChunk: TypeAlias = bytes
+
+
+class SyncByteStream(Protocol):
+    def __iter__(self) -> Iterator[BodyChunk]: ...
+
+
+class AsyncByteStream(Protocol):
+    def __aiter__(self) -> AsyncIterator[BodyChunk]: ...
+
+
+class SyncByteStreamFactory(Protocol):
+    def __call__(self) -> SyncByteStream: ...
+
+
+class AsyncByteStreamFactory(Protocol):
+    def __call__(self) -> AsyncByteStream: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,13 +65,10 @@ show_missing = true
 
 [tool.mypy]
 python_version = "3.11"
-files = ["foghttp"]
+files = ["foghttp", "tests/types"]
 strict = true
 warn_unreachable = true
 warn_unused_configs = true
 pretty = true
 show_error_codes = true
 namespace_packages = false
-exclude = [
-    "^tests/",
-]

--- a/tests/types/test_upload_contracts.py
+++ b/tests/types/test_upload_contracts.py
@@ -1,0 +1,129 @@
+from collections.abc import AsyncIterator, Iterator
+from io import BytesIO
+from pathlib import Path
+from typing import assert_type
+
+import foghttp.types as foghttp_types
+from foghttp.types import (
+    AsyncByteStream,
+    AsyncByteStreamFactory,
+    AsyncMultipartFileContent,
+    AsyncMultipartFiles,
+    AsyncMultipartFileTuple,
+    BinaryFile,
+    SyncByteStream,
+    SyncByteStreamFactory,
+    SyncMultipartFileContent,
+    SyncMultipartFiles,
+    SyncMultipartFileTuple,
+)
+
+
+class SyncChunks:
+    def __init__(self, chunks: tuple[bytes, ...]) -> None:
+        self._chunks = chunks
+
+    def __iter__(self) -> Iterator[bytes]:
+        return iter(self._chunks)
+
+
+class AsyncChunks:
+    def __init__(self, chunks: tuple[bytes, ...]) -> None:
+        self._chunks = chunks
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+def sync_chunks() -> SyncByteStream:
+    return SyncChunks((b"sync",))
+
+
+def async_chunks() -> AsyncByteStream:
+    return AsyncChunks((b"async",))
+
+
+async def collect_chunks(stream: AsyncByteStream) -> list[bytes]:
+    return [chunk async for chunk in stream]
+
+
+async def test_upload_protocols_accept_structural_streams() -> None:
+    sync_stream: SyncByteStream = SyncChunks((b"one", b"two"))
+    async_stream: AsyncByteStream = AsyncChunks((b"one", b"two"))
+
+    assert list(sync_stream) == [b"one", b"two"]
+    assert await collect_chunks(async_stream) == [b"one", b"two"]
+
+
+def test_upload_factories_describe_replayable_stream_sources() -> None:
+    sync_factory: SyncByteStreamFactory = sync_chunks
+    async_factory: AsyncByteStreamFactory = async_chunks
+
+    assert list(sync_factory()) == [b"sync"]
+    assert async_factory() is not async_factory()
+
+
+def test_binary_file_contract_accepts_stdlib_file_objects(tmp_path: Path) -> None:
+    memory_file: BinaryFile = BytesIO(b"payload")
+    file_path = tmp_path / "payload.bin"
+    file_path.write_bytes(b"payload")
+
+    with file_path.open("rb") as opened_file:
+        disk_file: BinaryFile = opened_file
+        assert disk_file.read(4) == b"payl"
+
+    assert memory_file.read(4) == b"payl"
+    assert_type(memory_file, BinaryFile)
+
+
+def test_sync_multipart_file_aliases_accept_sync_sources() -> None:
+    file_obj: BinaryFile = BytesIO(b"payload")
+    file_content: SyncMultipartFileContent = file_obj
+    file_tuple: SyncMultipartFileTuple = (
+        "payload.bin",
+        file_content,
+        "application/octet-stream",
+    )
+    file_mapping = {"file": file_tuple, "stream": sync_chunks}
+    files: SyncMultipartFiles = file_mapping
+
+    assert files == file_mapping
+    assert file_mapping["file"] == file_tuple
+    assert file_mapping["stream"] is sync_chunks
+
+
+def test_async_multipart_file_aliases_accept_async_sources() -> None:
+    file_content: AsyncMultipartFileContent = async_chunks
+    file_tuple: AsyncMultipartFileTuple = (
+        "payload.bin",
+        file_content,
+        "application/octet-stream",
+    )
+    file_pairs = (("file", file_tuple),)
+    files: AsyncMultipartFiles = file_pairs
+
+    assert files == file_pairs
+    assert file_pairs[0][1] == file_tuple
+
+
+def test_stream_contract_rejects_text_and_raw_buffers() -> None:
+    text_stream: SyncByteStream = "payload"  # type: ignore[assignment]
+    bytes_stream: SyncByteStream = b"payload"  # type: ignore[assignment]
+    bytearray_stream: SyncByteStream = bytearray(b"payload")  # type: ignore[assignment]
+
+    assert text_stream != bytes_stream
+    assert bytearray_stream
+
+
+def test_upload_types_are_public_reexports() -> None:
+    assert foghttp_types.SyncByteStream is SyncByteStream
+    assert foghttp_types.AsyncByteStream is AsyncByteStream
+    assert foghttp_types.SyncByteStreamFactory is SyncByteStreamFactory
+    assert foghttp_types.AsyncByteStreamFactory is AsyncByteStreamFactory
+    assert foghttp_types.BinaryFile is BinaryFile
+    assert foghttp_types.SyncMultipartFiles is not None
+    assert foghttp_types.AsyncMultipartFiles is not None


### PR DESCRIPTION
Add public sync/async byte stream and multipart upload typing contracts under foghttp.types without changing runtime upload behavior

Harden the contract with mypy covered conformance tests for stdlib binary files, stream providers, replayable factories, and sync/async multipart aliases. Pin typos precommit to an immutable release