### PR TITLE
fix(client): make get and head helpers bodyless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: uv run --extra dev --with "maturin>=1.7,<2" maturin develop
 
       - name: Run tests with coverage
-        run: uv run --extra dev coverage run -m pytest
+        run: uv run --extra dev coverage run -m pytest -vv
 
       - name: Report coverage
         run: uv run --extra dev coverage report -m

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -412,6 +412,11 @@ replayable because the factory returns a fresh stream per send attempt. Public
 provider and multipart type aliases are documented in
 [Upload typing contracts](./upload-types.md).
 
+`get()` and `head()` are bodyless convenience helpers. Use `post()`, `put()`,
+`patch()`, `delete()`, `request()`, or `stream()` for body parameters. If you
+intentionally need a non-standard GET or HEAD body, use the explicit
+`request("GET", ..., content=...)` / `request("HEAD", ..., content=...)` form.
+
 ## Buffered Response Decoding
 
 Buffered responses with `content-encoding: gzip`, `deflate`, or `br` are

--- a/docs/request-builder.md
+++ b/docs/request-builder.md
@@ -30,6 +30,12 @@ the current FogHTTP API. The same flow is available as a runnable example in
 | `follow_redirects` | Supported | Client-level setting. GET/HEAD/POST redirects use conservative security rules. |
 | prepared request | Supported | Use `build_request()` and `send()`. Building a request does not create transport state. |
 
+`get()` and `head()` are bodyless convenience helpers: they expose `headers`,
+`params`, and `timeout`, but not `json=`, `data=`, `content=`, or `files=`.
+If application code intentionally needs an unusual GET or HEAD request body,
+use the explicit `request("GET", ..., content=...)` or
+`request("HEAD", ..., content=...)` form.
+
 ## Merge Order
 
 FogHTTP applies request values in this order:
@@ -210,6 +216,10 @@ Rust client, or consume pool/request slots.
 | async bytes-like iterator `content=` with `AsyncClient` | streamed request body; non-replayable |
 | async byte iterator `content=` with sync `Client` | `TypeError` |
 | iterator `data=` | `TypeError` |
+
+Body parameters are part of `request()`, `stream()`, and body-capable method
+helpers such as `post()`, `put()`, `patch()`, and `delete()`. The `get()` and
+`head()` helpers intentionally do not expose body parameters.
 
 `Content-Length` and `Transfer-Encoding` are transport-managed framing headers
 and cannot be set manually. `Content-Type` is semantic and can be set by the

--- a/foghttp/_upload_body/runtime.py
+++ b/foghttp/_upload_body/runtime.py
@@ -160,6 +160,15 @@ class _AsyncStreamingUploadBody:
             )
 
     def _notify_ready(self) -> None:
+        if self._loop.is_closed():
+            return
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if running_loop is self._loop:
+            self._ready.set()
+            return
         self._loop.call_soon_threadsafe(self._ready.set)
 
 

--- a/foghttp/async_client.py
+++ b/foghttp/async_client.py
@@ -193,10 +193,6 @@ class AsyncClient(ClientCore):
         *,
         headers: HeaderSource = None,
         params: QueryParams = None,
-        content: AsyncRequestContent | None = None,
-        data: RequestData = None,
-        files: AsyncMultipartFiles | None = None,
-        json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
         return await self.request(
@@ -204,10 +200,6 @@ class AsyncClient(ClientCore):
             url,
             headers=headers,
             params=params,
-            content=content,
-            data=data,
-            files=files,
-            json=json,
             timeout=timeout,
         )
 
@@ -217,10 +209,6 @@ class AsyncClient(ClientCore):
         *,
         headers: HeaderSource = None,
         params: QueryParams = None,
-        content: AsyncRequestContent | None = None,
-        data: RequestData = None,
-        files: AsyncMultipartFiles | None = None,
-        json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
         return await self.request(
@@ -228,10 +216,6 @@ class AsyncClient(ClientCore):
             url,
             headers=headers,
             params=params,
-            content=content,
-            data=data,
-            files=files,
-            json=json,
             timeout=timeout,
         )
 

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -203,10 +203,6 @@ class Client(ClientCore):
         *,
         headers: HeaderSource = None,
         params: QueryParams = None,
-        content: SyncRequestContent | None = None,
-        data: RequestData = None,
-        files: SyncMultipartFiles | None = None,
-        json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
         return self.request(
@@ -214,10 +210,6 @@ class Client(ClientCore):
             url,
             headers=headers,
             params=params,
-            content=content,
-            data=data,
-            files=files,
-            json=json,
             timeout=timeout,
         )
 
@@ -227,10 +219,6 @@ class Client(ClientCore):
         *,
         headers: HeaderSource = None,
         params: QueryParams = None,
-        content: SyncRequestContent | None = None,
-        data: RequestData = None,
-        files: SyncMultipartFiles | None = None,
-        json: Any = None,
         timeout: Timeouts | None = None,
     ) -> Response:
         return self.request(
@@ -238,10 +226,6 @@ class Client(ClientCore):
             url,
             headers=headers,
             params=params,
-            content=content,
-            data=data,
-            files=files,
-            json=json,
             timeout=timeout,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pre-commit>=4,<5",
     "pytest>=8",
     "pytest-asyncio>=0.23",
+    "pytest-timeout>=2,<3",
     "ruff>=0.15,<0.16",
     "trustme>=1.2",
 ]
@@ -54,6 +55,8 @@ python-source = "."
 addopts = ["-p", "no:anyio"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+timeout = 20
+timeout_method = "thread"
 
 [tool.coverage.run]
 branch = true

--- a/src/core/client/body.rs
+++ b/src/core/client/body.rs
@@ -301,14 +301,45 @@ impl UploadBodyChannel {
         }
         state.closed = true;
         let waker = state.receive_waker.take();
-        let callback = state.ready_callback.clone();
         drop(state);
         self.send_ready.notify_all();
         if let Some(waker) = waker {
             waker.wake();
         }
-        if let Some(callback) = callback {
-            callback();
-        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::upload_body_channel;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn upload_body_finish_does_not_call_ready_callback() {
+        let (sender, _receiver) = upload_body_channel(1);
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_for_callback = Arc::clone(&callback_count);
+        sender.set_ready_callback(Some(Arc::new(move || {
+            callback_count_for_callback.fetch_add(1, Ordering::SeqCst);
+        })));
+
+        sender.finish();
+
+        assert_eq!(callback_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn upload_body_abort_calls_ready_callback() {
+        let (sender, _receiver) = upload_body_channel(1);
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_for_callback = Arc::clone(&callback_count);
+        sender.set_ready_callback(Some(Arc::new(move || {
+            callback_count_for_callback.fetch_add(1, Ordering::SeqCst);
+        })));
+
+        sender.close();
+
+        assert_eq!(callback_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/tests/client_multipart/test_async_multipart.py
+++ b/tests/client_multipart/test_async_multipart.py
@@ -27,10 +27,11 @@ MULTIPART_TOTAL_TIMEOUT = 3.0
 MULTIPART_WRITE_TIMEOUT = 0.05
 STALLED_PROVIDER_RETURN_LIMIT = 1.0
 STALLED_PROVIDER_SLEEP = 2.0
+FAST_MULTIPART_TIMEOUTS = foghttp.Timeouts(connect=1.0, read=1.0, write=1.0, pool=0.5, total=3.0)
 
 
 async def test_async_client_sends_multipart_files_and_form_fields(http_server: str) -> None:
-    async with foghttp.AsyncClient() as client:
+    async with foghttp.AsyncClient(timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         response = await client.post(
             f"{http_server}{SECURITY_HEADERS_PATH}",
             data={"description": "avatar"},
@@ -54,7 +55,7 @@ async def test_async_client_sends_multipart_files_and_form_fields(http_server: s
 async def test_async_client_streams_async_multipart_part(http_server: str) -> None:
     stream = AsyncChunks((b"async-", b"part"))
 
-    async with foghttp.AsyncClient() as client:
+    async with foghttp.AsyncClient(timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         response = await client.post(
             f"{http_server}{SECURITY_HEADERS_PATH}",
             files={"stream": ("stream.bin", stream)},
@@ -80,7 +81,7 @@ async def test_async_client_streams_async_multipart_part(http_server: str) -> No
 async def test_async_client_streams_sync_file_multipart_without_closing_external_file(http_server: str) -> None:
     file_obj = ClosingBytesFile(b"file payload", name="reports/report.txt")
 
-    async with foghttp.AsyncClient() as client:
+    async with foghttp.AsyncClient(timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         response = await client.post(
             f"{http_server}{SECURITY_HEADERS_PATH}",
             files={"report": file_obj},
@@ -101,7 +102,7 @@ async def test_async_client_streams_sync_file_multipart_without_closing_external
 
 
 async def test_async_stream_multipart_rejects_method_preserving_redirect(http_server: str) -> None:
-    async with foghttp.AsyncClient(follow_redirects=True) as client:
+    async with foghttp.AsyncClient(follow_redirects=True, timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         with pytest.raises(foghttp.RequestError, match="non-replayable request body"):
             await client.post(
                 f"{http_server}/redirect/{TEMPORARY_REDIRECT}",
@@ -110,7 +111,7 @@ async def test_async_stream_multipart_rejects_method_preserving_redirect(http_se
 
 
 async def test_async_buffered_multipart_replays_method_preserving_redirect(http_server: str) -> None:
-    async with foghttp.AsyncClient(follow_redirects=True) as client:
+    async with foghttp.AsyncClient(follow_redirects=True, timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         response = await client.post(
             f"{http_server}/redirect/{TEMPORARY_REDIRECT}",
             files={"file": ("payload.txt", b"replayable")},
@@ -142,7 +143,7 @@ async def test_async_factory_multipart_replays_method_preserving_redirect(http_s
         sources.append(source)
         return source
 
-    async with foghttp.AsyncClient(follow_redirects=True) as client:
+    async with foghttp.AsyncClient(follow_redirects=True, timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         response = await client.post(
             f"{http_server}/redirect/{TEMPORARY_REDIRECT}",
             files={"file": ("factory.txt", content)},
@@ -170,7 +171,7 @@ async def test_async_factory_multipart_replays_method_preserving_redirect(http_s
 
 async def test_async_stream_response_accepts_multipart_upload(http_server: str) -> None:
     async with (
-        foghttp.AsyncClient() as client,
+        foghttp.AsyncClient(timeouts=FAST_MULTIPART_TIMEOUTS) as client,
         client.stream(
             POST,
             f"{http_server}{SECURITY_HEADERS_PATH}",
@@ -193,7 +194,7 @@ async def test_async_multipart_cancellation_closes_sync_source(http_server: str)
         loop.call_soon_threadsafe(source_created.set)
         return source
 
-    async with foghttp.AsyncClient() as client:
+    async with foghttp.AsyncClient(timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         task = asyncio.create_task(
             client.post(
                 f"{http_server}{SECURITY_HEADERS_PATH}",
@@ -220,7 +221,7 @@ async def test_async_multipart_cancellation_closes_sync_source(http_server: str)
 async def test_async_multipart_cancellation_keeps_direct_async_source_open(http_server: str) -> None:
     source = BlockingAsyncChunks((b"first", b"second"))
 
-    async with foghttp.AsyncClient() as client:
+    async with foghttp.AsyncClient(timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         task = asyncio.create_task(
             client.post(
                 f"{http_server}{SECURITY_HEADERS_PATH}",
@@ -252,7 +253,7 @@ async def test_async_multipart_cancellation_closes_factory_async_source(http_ser
         source_created.set()
         return source
 
-    async with foghttp.AsyncClient() as client:
+    async with foghttp.AsyncClient(timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         task = asyncio.create_task(
             client.post(
                 f"{http_server}{SECURITY_HEADERS_PATH}",
@@ -309,7 +310,7 @@ async def test_async_multipart_coroutine_factory_fails_cleanly(http_server: str)
     async def invalid_part() -> AsyncChunks:
         return AsyncChunks((b"invalid",))
 
-    async with foghttp.AsyncClient() as client:
+    async with foghttp.AsyncClient(timeouts=FAST_MULTIPART_TIMEOUTS) as client:
         with pytest.raises(TypeError, match=MULTIPART_FILES_UNSUPPORTED):
             await client.post(
                 f"{http_server}{SECURITY_HEADERS_PATH}",

--- a/tests/client_streaming/test_sync_streaming.py
+++ b/tests/client_streaming/test_sync_streaming.py
@@ -123,10 +123,12 @@ def test_sync_stream_read_timeout_aborts_body(
 def test_sync_stream_does_not_use_async_ready_frame_coalescing(
     sync_streaming_server: SyncStreamingServer,
 ) -> None:
+    timeout = foghttp.Timeouts(read=READ_TIMEOUT_SECONDS, total=2.0)
     with foghttp.Client() as client:
         with client.stream(
             GET,
             f"{sync_streaming_server.base_url}{BROKEN_READY_TAIL_STREAM_PATH}",
+            timeout=timeout,
         ) as response:
             byte_stream = response.iter_bytes()
             assert next_sync_stream_chunk(byte_stream) == FIRST_CHUNK

--- a/tests/client_streaming/test_sync_streaming_text_lines.py
+++ b/tests/client_streaming/test_sync_streaming_text_lines.py
@@ -7,6 +7,7 @@ from tests.client_streaming.constants import (
     FIRST_CHUNK,
     LATIN1_TEXT_STREAM_PATH,
     LATIN1_TEXT_VALUE,
+    READ_TIMEOUT_SECONDS,
     SECOND_CHUNK,
     TEXT_LINES,
     TEXT_LINES_BODY,
@@ -112,11 +113,13 @@ def test_sync_stream_iter_text_preserves_text_before_tail_error(
     sync_streaming_server: SyncStreamingServer,
 ) -> None:
     collected_text: list[str] = []
+    timeout = foghttp.Timeouts(read=READ_TIMEOUT_SECONDS, total=2.0)
     with (
         foghttp.Client() as client,
         client.stream(
             GET,
             f"{sync_streaming_server.base_url}{BROKEN_READY_TAIL_STREAM_PATH}",
+            timeout=timeout,
         ) as response,
         pytest.raises(foghttp.RequestError),
     ):
@@ -128,11 +131,13 @@ def test_sync_stream_iter_text_preserves_text_before_tail_error(
 def test_sync_stream_iter_lines_does_not_flush_partial_line_after_error(
     sync_streaming_server: SyncStreamingServer,
 ) -> None:
+    timeout = foghttp.Timeouts(read=READ_TIMEOUT_SECONDS, total=2.0)
     with (
         foghttp.Client() as client,
         client.stream(
             GET,
             f"{sync_streaming_server.base_url}{BROKEN_READY_TAIL_STREAM_PATH}",
+            timeout=timeout,
         ) as response,
         pytest.raises(foghttp.RequestError),
     ):

--- a/tests/request_builder/test_shortcuts.py
+++ b/tests/request_builder/test_shortcuts.py
@@ -14,6 +14,18 @@ SHORTCUT_METHODS = [
     ("delete", DELETE),
 ]
 
+BODYLESS_SHORTCUT_NAMES = [
+    "get",
+    "head",
+]
+
+BODY_KWARGS = [
+    pytest.param({"content": b"body"}, id="content"),
+    pytest.param({"data": {"field": "value"}}, id="data"),
+    pytest.param({"files": {"file": b"body"}}, id="files"),
+    pytest.param({"json": {"field": "value"}}, id="json"),
+]
+
 
 @pytest.mark.parametrize(
     ("shortcut_name", "expected_method"),
@@ -95,6 +107,100 @@ async def test_async_shortcuts_use_request_builder_pipeline_without_transport(
         expected_method=expected_method,
         expected_url=f"{url}&trace={trace_value}",
     )
+
+
+@pytest.mark.parametrize("shortcut_name", BODYLESS_SHORTCUT_NAMES)
+@pytest.mark.parametrize("body_kwargs", BODY_KWARGS)
+def test_sync_get_head_shortcuts_reject_body_parameters(
+    shortcut_name: str,
+    body_kwargs: dict[str, object],
+    faker: Faker,
+) -> None:
+    with foghttp.Client() as client:
+        shortcut = getattr(client, shortcut_name)
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            shortcut(faker.url(), **body_kwargs)
+
+
+@pytest.mark.parametrize("shortcut_name", BODYLESS_SHORTCUT_NAMES)
+@pytest.mark.parametrize("body_kwargs", BODY_KWARGS)
+async def test_async_get_head_shortcuts_reject_body_parameters(
+    shortcut_name: str,
+    body_kwargs: dict[str, object],
+    faker: Faker,
+) -> None:
+    async with foghttp.AsyncClient() as client:
+        shortcut = getattr(client, shortcut_name)
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            await shortcut(faker.url(), **body_kwargs)
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_method"),
+    [
+        pytest.param(GET, GET, id="get"),
+        pytest.param(HEAD, HEAD, id="head"),
+    ],
+)
+def test_sync_request_allows_explicit_get_head_body_without_transport(
+    method: str,
+    expected_method: str,
+    faker: Faker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_requests: list[foghttp.Request] = []
+    content = faker.sentence().encode()
+
+    def fake_send(
+        _client: foghttp.Client,
+        request: foghttp.Request,
+        *,
+        timeout: foghttp.Timeouts | None = None,
+    ) -> foghttp.Response:
+        captured_requests.append(request)
+        return _response_for(request)
+
+    monkeypatch.setattr(foghttp.Client, "send", fake_send)
+
+    with foghttp.Client() as client:
+        response = client.request(method, faker.url(), content=content)
+
+    assert response.request.method == expected_method
+    assert captured_requests[0].content == content
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_method"),
+    [
+        pytest.param(GET, GET, id="get"),
+        pytest.param(HEAD, HEAD, id="head"),
+    ],
+)
+async def test_async_request_allows_explicit_get_head_body_without_transport(
+    method: str,
+    expected_method: str,
+    faker: Faker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_requests: list[foghttp.Request] = []
+    content = faker.sentence().encode()
+
+    async def fake_send(
+        _client: foghttp.AsyncClient,
+        request: foghttp.Request,
+        *,
+        timeout: foghttp.Timeouts | None = None,
+    ) -> foghttp.Response:
+        captured_requests.append(request)
+        return _response_for(request)
+
+    monkeypatch.setattr(foghttp.AsyncClient, "send", fake_send)
+
+    async with foghttp.AsyncClient() as client:
+        response = await client.request(method, faker.url(), content=content)
+
+    assert response.request.method == expected_method
+    assert captured_requests[0].content == content
 
 
 def _base_url(faker: Faker) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -344,6 +344,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "trustme" },
 ]
@@ -358,6 +359,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4,<5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2,<3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15,<0.16" },
     { name = "trustme", marker = "extra == 'dev'", specifier = ">=1.2" },
 ]
@@ -709,6 +711,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Remove body/upload parameters from sync and async get()/head() convenience helpers while preserving explicit request(GET/HEAD, ...) body support.

Add sync/async shortcut contract tests and document the bodyless helper surface plus request() escape hatch.