### PR TITLE
chore(release): prepare 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "brotli",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foghttp"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
   diagnostic dump APIs
 - opt-in async lifecycle debug snapshots for staging and tests
 - advanced per-client Tokio runtime worker tuning
-- focused buffered HTTP surface for JSON and form APIs, internal services,
-  workers, and benchmarks
+- focused HTTP surface for JSON, form, streaming upload, and multipart API
+  workloads in internal services, workers, and benchmarks
 
 ## Install
 
@@ -88,8 +88,11 @@ async with foghttp.AsyncClient() as client:
 - `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
 - `base_url` for reusable API clients and relative request paths
 - default client headers and query params for reusable API clients
-- query params with repeated keys, JSON, form-urlencoded data, and buffered
-  bytes/text bodies
+- query params with repeated keys, JSON, form-urlencoded data, buffered
+  bytes/text bodies, binary file-like request bodies, and streaming
+  bytes-like upload providers
+- multipart `files=` uploads with bytes-like parts, binary file-like objects,
+  direct byte streams, and replayable byte-stream factories
 - buffered `Response` with status flags, charset-aware `text`, `json()`,
   `raise_for_status()`, and request metadata
 - transparent `gzip`, `deflate`, and `br` decoding for buffered responses
@@ -142,10 +145,12 @@ async with foghttp.AsyncClient() as client:
 ## Current Limitations
 
 FogHTTP is currently focused on controlled HTTP workloads. Buffered responses
-are the broadest supported path; sync and async response streaming are available
-as bytes/text/line context-managed APIs. HTTP proxy routing and HTTPS proxy
-`CONNECT` tunnelling are available through `proxy=` and `trust_env=True` when
-the proxy endpoint itself uses `http://`.
+are the broadest supported response path; sync and async response streaming are
+available as bytes/text/line context-managed APIs. Streaming `content=` uploads
+and multipart `files=` uploads are available with explicit replayability and
+cleanup rules. HTTP proxy routing and HTTPS proxy `CONNECT` tunnelling are
+available through `proxy=` and `trust_env=True` when the proxy endpoint itself
+uses `http://`.
 Cookies, auth helpers, HTTP/2, automatic `Accept-Encoding` negotiation,
 streaming decompression, strict connection-level pool limits, and per-request
 connect timeout reconfiguration are planned for later versions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: "home"
 hero:
   name: "FogHTTP"
   text: "Rust-powered HTTP client for Python"
-  tagline: "Buffered JSON and form requests, sync and async response streaming, transparent response decoding, base URL clients, default headers and params, sync and async APIs, redirects, custom CA certificates, cancellation, and observable request limits with pool diagnostics."
+  tagline: "Buffered JSON and form requests, streaming and multipart uploads, sync and async response streaming, transparent response decoding, base URL clients, default headers and params, sync and async APIs, redirects, custom CA certificates, cancellation, and observable request limits with pool diagnostics."
 
 features:
   - title: "Rust transport"
@@ -14,14 +14,14 @@ features:
     details: "Use Client in scripts and workers, or AsyncClient for high-concurrency asyncio workloads."
 
   - title: "Focused MVP"
-    details: "FogHTTP is intentionally small today: buffered responses with gzip/deflate/br decoding, sync and async bytes/text/line streaming, JSON, form-urlencoded data, base URL clients, default headers and params, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
+    details: "FogHTTP is intentionally small today: buffered responses with gzip/deflate/br decoding, sync and async bytes/text/line streaming, JSON, form-urlencoded data, streaming and multipart uploads, base URL clients, default headers and params, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
 ---
 
 # FogHTTP Documentation
 
 FogHTTP is currently an MVP. It is already useful for controlled HTTP workloads
-that use buffered request/response bodies, JSON and form APIs, explicit client
-lifecycle, and predictable redirect behavior.
+that use buffered request/response bodies, JSON and form APIs, streaming or
+multipart uploads, explicit client lifecycle, and predictable redirect behavior.
 
 ## Positioning
 
@@ -100,7 +100,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - `base_url` for reusable API clients and relative request paths
 - default client headers and query params for reusable API clients
 - query params with repeated keys, JSON, form-urlencoded data, buffered
-  bytes/text bodies, file-like bodies, and streaming bytes-like iterables
+  bytes/text bodies, file-like bodies, streaming bytes-like iterables, and
+  multipart `files=` uploads
 - transparent `gzip`, `deflate`, and `br` decoding for buffered responses
 - sync and async bytes/text/line response streaming with context-managed cleanup
 - response status flags for success, redirects, and client/server errors

--- a/foghttp/_multipart/file_parts.py
+++ b/foghttp/_multipart/file_parts.py
@@ -1,12 +1,13 @@
 from collections.abc import Mapping, Sequence
 from typing import TypeAlias, cast
 
+from .._upload_body.chunks import body_chunk
 from .._upload_body.file_source import FileUploadSource, file_content_length
 from .._upload_body.predicates import is_async_stream, is_binary_file, is_sync_stream
 from ..messages import MULTIPART_FILES_UNSUPPORTED
 from .constants import DEFAULT_FILE_CONTENT_TYPE
 from .models import MultipartFile
-from .values import body_chunk, filename_from_content, filename_value, text_value
+from .values import filename_from_content, filename_value, text_value
 
 
 FileItems: TypeAlias = Mapping[str, object] | Sequence[tuple[str, object]]

--- a/foghttp/_multipart/iterators.py
+++ b/foghttp/_multipart/iterators.py
@@ -2,11 +2,11 @@ import asyncio
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from typing import cast
 
+from .._upload_body.chunks import body_chunk
 from ..messages import MULTIPART_FILES_UNSUPPORTED
 from .constants import CRLF
 from .encoding import field_header
 from .models import MultipartField, MultipartFile
-from .values import body_chunk
 
 
 _ITER_DONE = object()

--- a/foghttp/_multipart/values.py
+++ b/foghttp/_multipart/values.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from ..messages import MULTIPART_HEADER_VALUE_UNSUPPORTED, STREAMING_BODY_CHUNK_UNSUPPORTED
+from ..messages import MULTIPART_HEADER_VALUE_UNSUPPORTED
 
 
 BACKSLASH = "\\"
@@ -12,16 +12,6 @@ _DEL = 0x7F
 def _is_header_value_char(char: str) -> bool:
     codepoint = ord(char)
     return _PRINTABLE_ASCII_START <= codepoint < _DEL
-
-
-def body_chunk(content: object) -> bytes:
-    if isinstance(content, bytes):
-        return content
-    if isinstance(content, bytearray):
-        return bytes(content)
-    if isinstance(content, memoryview):
-        return content.tobytes()
-    raise TypeError(STREAMING_BODY_CHUNK_UNSUPPORTED)
 
 
 def header_value(value: str) -> str:

--- a/foghttp/_upload_body/chunks.py
+++ b/foghttp/_upload_body/chunks.py
@@ -1,0 +1,11 @@
+from ..messages import STREAMING_BODY_CHUNK_UNSUPPORTED
+
+
+def body_chunk(content: object) -> bytes:
+    if isinstance(content, bytes):
+        return content
+    if isinstance(content, bytearray):
+        return bytes(content)
+    if isinstance(content, memoryview):
+        return content.tobytes()
+    raise TypeError(STREAMING_BODY_CHUNK_UNSUPPORTED)

--- a/foghttp/_upload_body/feeders.py
+++ b/foghttp/_upload_body/feeders.py
@@ -9,8 +9,8 @@ if TYPE_CHECKING:
 
     from foghttp import _foghttp
 
-from ..messages import STREAMING_BODY_CHUNK_UNSUPPORTED
 from .async_sending import fail_async_upload_body, send_async_upload_chunk
+from .chunks import body_chunk
 from .file_source import FileUploadSource
 from .predicates import is_async_stream
 from .thread_bridge import run_sync_upload_feeder
@@ -26,7 +26,7 @@ def feed_sync_upload_body(
         for chunk in cast("Iterable[object]", source):
             if is_cancelled():
                 return
-            if not raw_body.send(_validate_upload_chunk(chunk)):
+            if not raw_body.send(body_chunk(chunk)):
                 return
     except Exception as exc:  # noqa: BLE001
         if not is_cancelled():
@@ -57,7 +57,7 @@ async def feed_async_upload_body(
             if not await send_async_upload_chunk(
                 raw_body,
                 ready,
-                _validate_upload_chunk(chunk),
+                body_chunk(chunk),
             ):
                 return
     except asyncio.CancelledError:
@@ -97,16 +97,6 @@ async def close_async_source(source: object) -> None:
             await aclose()
         return
     await asyncio.to_thread(close_sync_source, source)
-
-
-def _validate_upload_chunk(chunk: object) -> bytes:
-    if isinstance(chunk, bytes):
-        return chunk
-    if isinstance(chunk, bytearray):
-        return bytes(chunk)
-    if isinstance(chunk, memoryview):
-        return chunk.tobytes()
-    raise TypeError(STREAMING_BODY_CHUNK_UNSUPPORTED)
 
 
 def _upload_source_error(error: BaseException) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "foghttp"
-version = "0.3.4"
+version = "0.3.5"
 description = "Observable Rust-powered HTTP client for Python services."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/client_multipart/test_multipart_internals.py
+++ b/tests/client_multipart/test_multipart_internals.py
@@ -11,7 +11,7 @@ from foghttp._multipart.stream import (
     MultipartStream,
     MultipartStreamFactory,
 )
-from foghttp._multipart.values import body_chunk
+from foghttp._upload_body.chunks import body_chunk
 from foghttp.messages import (
     MULTIPART_CONTENT_TYPE_UNSUPPORTED,
     MULTIPART_FILES_UNSUPPORTED,

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
- bump Python and Rust package metadata to 0.3.5
- refresh README and docs index for streaming and multipart uploads
- centralize upload chunk validation across content= and files=