### PR TITLE
feat(resources): add bounded FIFO acquire queue

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -447,7 +447,7 @@ Use `dump_pool_diagnostics()` when the question is specifically why requests are
 waiting for capacity. It reports the current pending queue, the oldest pending
 wait age in nanoseconds, whether another pending waiter can be admitted, and
 whether current waiters are blocked by the global active request limit, the
-per-origin active request limit, or both.
+per-origin active request limit, FIFO pending queue order, or a mixed reason.
 Like transport state, this is a diagnostic snapshot with `schema_version` and a
 Rust-side `snapshot_sequence`; it is useful for ordering incident observations,
 not as a lock-protected SLA transaction.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -639,7 +639,7 @@ the phase, elapsed time, configured budget, normalized origin, and redirect hop.
 `Limits.max_active_requests` caps active buffered requests for the whole client.
 `Limits.max_active_requests_per_origin` defaults to `None`; set it to cap active
 buffered requests for one normalized origin. `Limits.max_pending_requests` caps
-requests waiting for a free acquire permit. `Limits.max_response_body_size`
+requests waiting in the Rust-side FIFO acquire queue. `Limits.max_response_body_size`
 defaults to `10 * 1024 * 1024` bytes and protects one response.
 `Limits.max_buffered_response_bytes` defaults to `100 * 1024 * 1024` bytes and
 protects aggregate in-flight buffered response bodies across concurrent

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -115,8 +115,8 @@ acquire gates:
   client.
 - `Limits.max_active_requests_per_origin` optionally limits active request
   slots for one normalized origin.
-- `Limits.max_pending_requests` limits how many requests may wait for an active
-  slot.
+- `Limits.max_pending_requests` limits how many requests may wait in the
+  Rust-side FIFO pending queue for an active slot.
 
 If the pending queue is full, FogHTTP fails fast with `PoolTimeout` and the
 message `request acquire queue is full`.
@@ -127,14 +127,19 @@ If a request waits longer than `Timeouts.pool` for a slot, FogHTTP raises
 Both cases increment `TransportStats.pool_acquire_timeouts`. Waiting requests
 are not counted as `active_requests`. `PoolTimeout.diagnostic.phase` is
 `pool_acquire`; the diagnostic `timeout` value is the configured pool timeout.
+When a request cannot acquire immediately, it enters one bounded FIFO queue.
+Queued requests are woken in registration order; a later request does not bypass
+an earlier queued request even if its own origin currently has free capacity.
+With per-origin limits enabled, an earlier saturated origin can therefore delay
+later queued requests for other origins until capacity changes or their own pool
+timeout expires.
 
 FogHTTP also records Rust-side acquire pressure metrics:
 
 - `pool_acquire_attempts` counts acquire attempts for request slots.
 - `pool_acquire_immediate` counts successful acquires that did not enter the
   pending queue.
-- `pool_acquire_waited` counts requests that entered the pending queue at least
-  once.
+- `pool_acquire_waited` counts requests that entered the pending queue.
 - `peak_pending_requests` records the highest observed pending queue depth.
 - `pool_acquire_wait_time_total_ns`, `pool_acquire_wait_time_max_ns`, and
   `pool_acquire_wait_time_last_ns` record completed wait intervals in
@@ -167,6 +172,13 @@ updates. Historical acquire counters are compared with per-origin sums only
 while the origin registry still contains all historical origins; after idle
 origin pruning, the per-origin history can be incomplete. The snapshot remains
 diagnostic state rather than a lock-protected transport transaction.
+`dump_pool_diagnostics()["blocked_by"]` reports the current pressure reason as
+`none`, `global_active_requests`, `per_origin_active_requests`,
+`pending_queue_order`, or `mixed`. `pending_queue_order` means a request is
+waiting behind an earlier queued request rather than directly on an active-slot
+limit. `mixed` means current waiters have different pressure reasons or are
+blocked by both queue order and active-slot pressure.
+
 `TransportStats` and diagnostic snapshots include `schema_version` and a
 monotonic `snapshot_sequence` for ordering observations within one Rust
 transport lifetime. Use diagnostic snapshot sequence values for incident
@@ -178,9 +190,9 @@ For incident diagnostics, `dump_pool_diagnostics()` returns an on-demand snapsho
 focused on current acquire waits: active holders, pending waiters, the oldest
 pending wait age, whether another pending waiter can be admitted, and whether
 progress is blocked by the global active request limit or the per-origin active
-request limit. `blocked_by` is one of `none`, `global_active_requests`,
-`per_origin_active_requests`, or `mixed`; `mixed` means current waiters are
-blocked by more than one acquire limit. Origin keys are normalized origins only;
+request limit. `blocked_by` uses the same `none`, `global_active_requests`,
+`per_origin_active_requests`, `pending_queue_order`, or `mixed` values described
+above. Origin keys are normalized origins only;
 paths, queries, userinfo, headers, and bodies are not included.
 For alert-oriented metrics, prefer `stats()` and the field guarantees described
 in [Telemetry contract](./telemetry.md).

--- a/foghttp/pool_diagnostics.py
+++ b/foghttp/pool_diagnostics.py
@@ -11,6 +11,7 @@ PoolBlockingReason = Literal[
     "none",
     "global_active_requests",
     "per_origin_active_requests",
+    "pending_queue_order",
     "mixed",
 ]
 

--- a/src/core/metrics/counters.rs
+++ b/src/core/metrics/counters.rs
@@ -29,26 +29,9 @@ impl Metrics {
         self.active_requests.fetch_sub(1, Ordering::Relaxed);
     }
 
-    pub fn pending_request_started(&self, max_pending_requests: usize) -> bool {
-        let mut current = self.pending_requests.load(Ordering::Acquire);
-        loop {
-            if current >= max_pending_requests {
-                return false;
-            }
-
-            match self.pending_requests.compare_exchange_weak(
-                current,
-                current + 1,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_previous) => {
-                    update_atomic_usize_max(&self.peak_pending_requests, current + 1);
-                    return true;
-                }
-                Err(actual) => current = actual,
-            }
-        }
+    pub fn pending_request_registered(&self) {
+        let current = self.pending_requests.fetch_add(1, Ordering::AcqRel) + 1;
+        update_atomic_usize_max(&self.peak_pending_requests, current);
     }
 
     pub fn pending_request_finished(&self) {

--- a/src/core/metrics/origin/blocking.rs
+++ b/src/core/metrics/origin/blocking.rs
@@ -3,5 +3,6 @@ pub enum PendingRequestBlockingReason {
     None,
     GlobalActiveRequests,
     PerOriginActiveRequests,
+    PendingQueueOrder,
     Mixed,
 }

--- a/src/core/metrics/tests.rs
+++ b/src/core/metrics/tests.rs
@@ -35,7 +35,7 @@ fn buffered_response_release_does_not_underflow_reserved_bytes() {
 fn acquire_wait_metrics_track_duration_without_underflowing_pending() {
     let metrics = Metrics::default();
 
-    assert!(metrics.pending_request_started(1));
+    metrics.pending_request_registered();
     metrics.pool_acquire_started();
     metrics.pool_acquire_waited();
     metrics.pool_acquire_wait_finished(Duration::from_nanos(10));

--- a/src/py/client/acquire/diagnostics.rs
+++ b/src/py/client/acquire/diagnostics.rs
@@ -61,6 +61,7 @@ pub fn blocking_reason_name(reason: PendingRequestBlockingReason) -> &'static st
         PendingRequestBlockingReason::None => "none",
         PendingRequestBlockingReason::GlobalActiveRequests => "global_active_requests",
         PendingRequestBlockingReason::PerOriginActiveRequests => "per_origin_active_requests",
+        PendingRequestBlockingReason::PendingQueueOrder => "pending_queue_order",
         PendingRequestBlockingReason::Mixed => "mixed",
     }
 }

--- a/src/py/client/acquire/gate.rs
+++ b/src/py/client/acquire/gate.rs
@@ -1,18 +1,17 @@
 use super::diagnostics::PoolDiagnosticsSnapshot;
 use super::origin::OriginGates;
-use super::pending::PendingAcquire;
+use super::pending::{AcquiredPermits, ImmediateAcquire, PendingQueue};
 use super::permit::AcquirePermit;
 use super::telemetry::AcquireTelemetry;
 use crate::core::metrics::{Metrics, OriginMetrics, PendingRequestBlockingReason};
-use crate::errors::FogHttpError;
 use crate::messages::{POOL_ACQUIRE_QUEUE_FULL, POOL_ACQUIRE_TIMEOUT};
 use crate::py::client::timeout_diagnostics::{
     pool_timeout_error, remaining_duration, TimeoutContext, TimeoutPhase,
 };
 use pyo3::prelude::*;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
+use std::time::Instant;
+use tokio::sync::Semaphore;
 
 #[derive(Clone)]
 pub struct AcquireGate {
@@ -22,6 +21,7 @@ pub struct AcquireGate {
     max_pending_requests: usize,
     metrics: Arc<Metrics>,
     origin_gates: Option<OriginGates>,
+    pending_queue: Arc<PendingQueue>,
 }
 
 impl AcquireGate {
@@ -38,6 +38,7 @@ impl AcquireGate {
             max_pending_requests,
             metrics,
             origin_gates: max_active_requests_per_origin.map(OriginGates::new),
+            pending_queue: Arc::new(PendingQueue::default()),
         }
     }
 
@@ -58,97 +59,91 @@ impl AcquireGate {
         let origin_metrics = self.metrics.origin_metrics(origin);
         let mut telemetry =
             AcquireTelemetry::start(Arc::clone(&self.metrics), Arc::clone(&origin_metrics));
-        let origin_permit = self
-            .acquire_origin_permit(
-                origin,
-                &timeout_context,
-                &mut telemetry,
-                Arc::clone(&origin_metrics),
-            )
-            .await?;
-        let global_permit = self
-            .acquire_semaphore(
-                Arc::clone(&self.global_semaphore),
-                remaining_duration("Timeouts.pool", &timeout_context)?,
-                &mut telemetry,
-                Arc::clone(&origin_metrics),
-                &timeout_context,
-                PendingRequestBlockingReason::GlobalActiveRequests,
-            )
-            .await?;
-        telemetry.finish_success();
-
-        Ok(AcquirePermit::new(
-            global_permit,
-            origin_permit,
-            Arc::clone(&self.metrics),
-            origin_metrics,
-        ))
-    }
-
-    async fn acquire_origin_permit(
-        &self,
-        origin: &str,
-        timeout_context: &TimeoutContext<'_>,
-        telemetry: &mut AcquireTelemetry,
-        origin_metrics: Arc<OriginMetrics>,
-    ) -> PyResult<Option<OwnedSemaphorePermit>> {
-        let Some(origin_gates) = &self.origin_gates else {
-            return Ok(None);
+        let origin_semaphore = self.origin_semaphore(origin);
+        let queue_was_empty = match self
+            .pending_queue
+            .try_acquire_immediate(Arc::clone(&self.global_semaphore), origin_semaphore.clone())?
+        {
+            ImmediateAcquire::Acquired(permits) => {
+                telemetry.finish_success();
+                return Ok(self.acquire_permit_from(permits, origin_metrics));
+            }
+            ImmediateAcquire::Queue { queue_was_empty } => queue_was_empty,
         };
 
-        let semaphore = origin_gates.semaphore(origin);
-        self.acquire_semaphore(
-            semaphore,
-            remaining_duration("Timeouts.pool", timeout_context)?,
-            telemetry,
-            origin_metrics,
-            timeout_context,
-            PendingRequestBlockingReason::PerOriginActiveRequests,
-        )
-        .await
-        .map(Some)
-    }
-
-    async fn acquire_semaphore(
-        &self,
-        semaphore: Arc<Semaphore>,
-        timeout: Duration,
-        telemetry: &mut AcquireTelemetry,
-        origin_metrics: Arc<OriginMetrics>,
-        timeout_context: &TimeoutContext<'_>,
-        blocked_by: PendingRequestBlockingReason,
-    ) -> PyResult<OwnedSemaphorePermit> {
-        match Arc::clone(&semaphore).try_acquire_owned() {
-            Ok(permit) => {
-                return Ok(permit);
-            }
-            Err(TryAcquireError::NoPermits) => {}
-            Err(TryAcquireError::Closed) => {
-                return Err(FogHttpError::new_err("acquire gate is closed"));
-            }
-        }
-
-        let pending = PendingAcquire::try_start(
-            Arc::clone(&self.metrics),
-            Arc::clone(&origin_metrics),
-            self.max_pending_requests,
-            blocked_by,
-        )
-        .map_err(|_err| pool_timeout_error(timeout_context, POOL_ACQUIRE_QUEUE_FULL))?;
+        let timeout = remaining_duration("Timeouts.pool", &timeout_context)?;
+        let blocked_by = self.pending_blocking_reason(queue_was_empty, origin_semaphore.as_ref());
+        let mut waiter = self
+            .pending_queue
+            .try_register(
+                Arc::clone(&self.metrics),
+                Arc::clone(&origin_metrics),
+                self.max_pending_requests,
+                blocked_by,
+            )
+            .map_err(|_err| pool_timeout_error(&timeout_context, POOL_ACQUIRE_QUEUE_FULL))?;
         telemetry.mark_waited();
-        let acquire_result = tokio::time::timeout(timeout, semaphore.acquire_owned()).await;
-        drop(pending);
+        let acquire_result = tokio::time::timeout(
+            timeout,
+            waiter.acquire_permits(Arc::clone(&self.global_semaphore), origin_semaphore),
+        )
+        .await;
 
         match acquire_result {
-            Ok(Ok(permit)) => Ok(permit),
-            Ok(Err(err)) => Err(FogHttpError::new_err(err.to_string())),
+            Ok(Ok(permits)) => {
+                drop(waiter);
+                Ok(self.acquire_permit_from(permits, origin_metrics))
+            }
+            Ok(Err(err)) => {
+                drop(waiter);
+                Err(err)
+            }
             Err(_elapsed) => {
+                drop(waiter);
                 self.metrics.pool_acquire_timeout();
                 origin_metrics.pool_acquire_timeout();
-                Err(pool_timeout_error(timeout_context, POOL_ACQUIRE_TIMEOUT))
+                Err(pool_timeout_error(&timeout_context, POOL_ACQUIRE_TIMEOUT))
             }
         }
+    }
+
+    fn origin_semaphore(&self, origin: &str) -> Option<Arc<Semaphore>> {
+        self.origin_gates
+            .as_ref()
+            .map(|origin_gates| origin_gates.semaphore(origin))
+    }
+
+    fn pending_blocking_reason(
+        &self,
+        queue_was_empty: bool,
+        origin_semaphore: Option<&Arc<Semaphore>>,
+    ) -> PendingRequestBlockingReason {
+        let global_blocked = self.global_semaphore.available_permits() == 0;
+        let origin_blocked =
+            origin_semaphore.is_some_and(|semaphore| semaphore.available_permits() == 0);
+
+        match (queue_was_empty, global_blocked, origin_blocked) {
+            (false, false, false) => PendingRequestBlockingReason::PendingQueueOrder,
+            (false, _, _) | (true, false, false) | (true, true, true) => {
+                PendingRequestBlockingReason::Mixed
+            }
+            (true, true, false) => PendingRequestBlockingReason::GlobalActiveRequests,
+            (true, false, true) => PendingRequestBlockingReason::PerOriginActiveRequests,
+        }
+    }
+
+    fn acquire_permit_from(
+        &self,
+        permits: AcquiredPermits,
+        origin_metrics: Arc<OriginMetrics>,
+    ) -> AcquirePermit {
+        AcquirePermit::new(
+            permits.global,
+            permits.origin,
+            Arc::clone(&self.metrics),
+            origin_metrics,
+            Arc::clone(&self.pending_queue),
+        )
     }
 
     pub fn diagnostics(&self) -> PoolDiagnosticsSnapshot {

--- a/src/py/client/acquire/pending.rs
+++ b/src/py/client/acquire/pending.rs
@@ -1,35 +1,219 @@
 use crate::core::metrics::{Metrics, OriginMetrics, PendingRequestBlockingReason};
-use std::sync::Arc;
+use crate::errors::FogHttpError;
+use pyo3::prelude::*;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Instant;
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 
 pub struct PendingAcquireRejected;
 
-pub struct PendingAcquire {
+pub struct AcquiredPermits {
+    pub global: OwnedSemaphorePermit,
+    pub origin: Option<OwnedSemaphorePermit>,
+}
+
+pub enum ImmediateAcquire {
+    Acquired(AcquiredPermits),
+    Queue { queue_was_empty: bool },
+}
+
+pub struct PendingQueue {
+    state: Mutex<PendingQueueState>,
+}
+
+struct PendingQueueState {
+    next_waiter_id: u64,
+    waiters: VecDeque<Arc<PendingQueueEntry>>,
+}
+
+struct PendingQueueEntry {
+    waiter_id: u64,
+    notify: Notify,
+}
+
+pub struct PendingQueueWaiter {
+    queue: Arc<PendingQueue>,
+    entry: Arc<PendingQueueEntry>,
+    pending: Option<PendingAcquire>,
+    queued: bool,
+}
+
+struct PendingAcquire {
     metrics: Arc<Metrics>,
     origin_metrics: Arc<OriginMetrics>,
     started: Instant,
     origin_waiter_id: u64,
 }
 
-impl PendingAcquire {
-    pub fn try_start(
+impl Default for PendingQueue {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(PendingQueueState::default()),
+        }
+    }
+}
+
+impl Default for PendingQueueState {
+    fn default() -> Self {
+        Self {
+            next_waiter_id: 1,
+            waiters: VecDeque::new(),
+        }
+    }
+}
+
+impl PendingQueue {
+    pub fn try_acquire_immediate(
+        &self,
+        global_semaphore: Arc<Semaphore>,
+        origin_semaphore: Option<Arc<Semaphore>>,
+    ) -> PyResult<ImmediateAcquire> {
+        let state = self.lock_state();
+        if !state.waiters.is_empty() {
+            return Ok(ImmediateAcquire::Queue {
+                queue_was_empty: false,
+            });
+        }
+
+        match try_acquire_permits(global_semaphore, origin_semaphore)? {
+            Some(permits) => Ok(ImmediateAcquire::Acquired(permits)),
+            None => Ok(ImmediateAcquire::Queue {
+                queue_was_empty: true,
+            }),
+        }
+    }
+
+    pub fn try_register(
+        self: &Arc<Self>,
         metrics: Arc<Metrics>,
         origin_metrics: Arc<OriginMetrics>,
         max_pending_requests: usize,
         blocked_by: PendingRequestBlockingReason,
-    ) -> Result<Self, PendingAcquireRejected> {
-        if metrics.pending_request_started(max_pending_requests) {
-            let origin_waiter_id = origin_metrics.pending_request_started(blocked_by);
-            Ok(Self {
-                metrics,
-                origin_metrics,
-                started: Instant::now(),
-                origin_waiter_id,
-            })
-        } else {
+    ) -> Result<PendingQueueWaiter, PendingAcquireRejected> {
+        let mut state = self.lock_state();
+        if state.waiters.len() >= max_pending_requests {
             metrics.pool_acquire_timeout();
             origin_metrics.pool_acquire_timeout();
-            Err(PendingAcquireRejected)
+            return Err(PendingAcquireRejected);
+        }
+
+        let waiter_id = state.next_waiter_id;
+        state.next_waiter_id = state.next_waiter_id.saturating_add(1);
+        let entry = Arc::new(PendingQueueEntry {
+            waiter_id,
+            notify: Notify::new(),
+        });
+        state.waiters.push_back(Arc::clone(&entry));
+        let pending = PendingAcquire::start(metrics, origin_metrics, blocked_by);
+
+        Ok(PendingQueueWaiter {
+            queue: Arc::clone(self),
+            entry,
+            pending: Some(pending),
+            queued: true,
+        })
+    }
+
+    pub fn notify_capacity(&self) {
+        self.notify_head();
+    }
+
+    fn try_acquire_for_waiter(
+        &self,
+        waiter_id: u64,
+        global_semaphore: Arc<Semaphore>,
+        origin_semaphore: Option<Arc<Semaphore>>,
+    ) -> PyResult<Option<AcquiredPermits>> {
+        let mut state = self.lock_state();
+        if state
+            .waiters
+            .front()
+            .is_none_or(|entry| entry.waiter_id != waiter_id)
+        {
+            return Ok(None);
+        }
+
+        let Some(permits) = try_acquire_permits(global_semaphore, origin_semaphore)? else {
+            return Ok(None);
+        };
+        state.waiters.pop_front();
+        Ok(Some(permits))
+    }
+
+    fn remove_waiter(&self, waiter_id: u64) -> bool {
+        let mut state = self.lock_state();
+        let Some(position) = state
+            .waiters
+            .iter()
+            .position(|queued_waiter| queued_waiter.waiter_id == waiter_id)
+        else {
+            return false;
+        };
+
+        state.waiters.remove(position);
+        true
+    }
+
+    fn notify_head(&self) {
+        let notify = self.lock_state().waiters.front().map(Arc::clone);
+        if let Some(entry) = notify {
+            entry.notify.notify_one();
+        }
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, PendingQueueState> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+impl PendingQueueWaiter {
+    pub async fn acquire_permits(
+        &mut self,
+        global_semaphore: Arc<Semaphore>,
+        origin_semaphore: Option<Arc<Semaphore>>,
+    ) -> PyResult<AcquiredPermits> {
+        loop {
+            let notified = self.entry.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if let Some(permits) = self.queue.try_acquire_for_waiter(
+                self.entry.waiter_id,
+                Arc::clone(&global_semaphore),
+                origin_semaphore.clone(),
+            )? {
+                self.queued = false;
+                self.pending.take();
+                self.queue.notify_capacity();
+                return Ok(permits);
+            }
+            notified.await;
+        }
+    }
+}
+
+impl Drop for PendingQueueWaiter {
+    fn drop(&mut self) {
+        if self.queued && self.queue.remove_waiter(self.entry.waiter_id) {
+            self.pending.take();
+            self.queue.notify_capacity();
+        }
+    }
+}
+
+impl PendingAcquire {
+    fn start(
+        metrics: Arc<Metrics>,
+        origin_metrics: Arc<OriginMetrics>,
+        blocked_by: PendingRequestBlockingReason,
+    ) -> Self {
+        metrics.pending_request_registered();
+        let origin_waiter_id = origin_metrics.pending_request_started(blocked_by);
+        Self {
+            metrics,
+            origin_metrics,
+            started: Instant::now(),
+            origin_waiter_id,
         }
     }
 }
@@ -44,4 +228,29 @@ impl Drop for PendingAcquire {
             .pending_request_finished(self.origin_waiter_id);
         self.origin_metrics.pool_acquire_wait_finished(elapsed);
     }
+}
+
+fn try_acquire_permits(
+    global_semaphore: Arc<Semaphore>,
+    origin_semaphore: Option<Arc<Semaphore>>,
+) -> PyResult<Option<AcquiredPermits>> {
+    let origin = match origin_semaphore {
+        Some(semaphore) => match semaphore.try_acquire_owned() {
+            Ok(permit) => Some(permit),
+            Err(TryAcquireError::NoPermits) => return Ok(None),
+            Err(TryAcquireError::Closed) => {
+                return Err(FogHttpError::new_err("origin acquire gate is closed"));
+            }
+        },
+        None => None,
+    };
+    let global = match global_semaphore.try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(TryAcquireError::NoPermits) => return Ok(None),
+        Err(TryAcquireError::Closed) => {
+            return Err(FogHttpError::new_err("acquire gate is closed"))
+        }
+    };
+
+    Ok(Some(AcquiredPermits { global, origin }))
 }

--- a/src/py/client/acquire/permit.rs
+++ b/src/py/client/acquire/permit.rs
@@ -1,3 +1,4 @@
+use super::pending::PendingQueue;
 use crate::core::metrics::{Metrics, OriginMetrics};
 use std::sync::Arc;
 use tokio::sync::OwnedSemaphorePermit;
@@ -5,8 +6,9 @@ use tokio::sync::OwnedSemaphorePermit;
 pub struct AcquirePermit {
     metrics: Arc<Metrics>,
     origin_metrics: Arc<OriginMetrics>,
-    _global_permit: OwnedSemaphorePermit,
-    _origin_permit: Option<OwnedSemaphorePermit>,
+    global_permit: Option<OwnedSemaphorePermit>,
+    origin_permit: Option<OwnedSemaphorePermit>,
+    pending_queue: Arc<PendingQueue>,
 }
 
 impl AcquirePermit {
@@ -15,14 +17,16 @@ impl AcquirePermit {
         origin_permit: Option<OwnedSemaphorePermit>,
         metrics: Arc<Metrics>,
         origin_metrics: Arc<OriginMetrics>,
+        pending_queue: Arc<PendingQueue>,
     ) -> Self {
         metrics.active_request_started();
         origin_metrics.active_request_started();
         Self {
             metrics,
             origin_metrics,
-            _global_permit: global_permit,
-            _origin_permit: origin_permit,
+            global_permit: Some(global_permit),
+            origin_permit,
+            pending_queue,
         }
     }
 
@@ -35,5 +39,8 @@ impl Drop for AcquirePermit {
     fn drop(&mut self) {
         self.metrics.active_request_finished();
         self.origin_metrics.active_request_finished();
+        self.origin_permit.take();
+        self.global_permit.take();
+        self.pending_queue.notify_capacity();
     }
 }

--- a/src/py/client/acquire/tests.rs
+++ b/src/py/client/acquire/tests.rs
@@ -1,4 +1,4 @@
-use super::AcquireGate;
+use super::{blocking_reason_name, AcquireGate};
 use crate::core::metrics::{
     Metrics, MetricsSnapshot, OriginMetricsSnapshot, PendingRequestBlockingReason,
 };
@@ -79,6 +79,30 @@ fn assert_origin_pressure(
     assert_eq!(snapshot.active_requests, active);
     assert_eq!(snapshot.pending_requests, pending);
     snapshot
+}
+
+#[test]
+fn blocking_reason_names_cover_public_diagnostic_values() {
+    let cases = [
+        (PendingRequestBlockingReason::None, "none"),
+        (
+            PendingRequestBlockingReason::GlobalActiveRequests,
+            "global_active_requests",
+        ),
+        (
+            PendingRequestBlockingReason::PerOriginActiveRequests,
+            "per_origin_active_requests",
+        ),
+        (
+            PendingRequestBlockingReason::PendingQueueOrder,
+            "pending_queue_order",
+        ),
+        (PendingRequestBlockingReason::Mixed, "mixed"),
+    ];
+
+    for (reason, expected_name) in cases {
+        assert_eq!(blocking_reason_name(reason), expected_name);
+    }
 }
 
 #[test]
@@ -514,6 +538,96 @@ fn origin_then_global_order_preserves_same_origin_queue_position() {
         drop(second_permit);
         assert_request_pressure(&metrics, 0, 0);
         assert_origin_pressure(&metrics, ORIGIN, 0, 0);
+    });
+}
+
+#[test]
+fn pending_queue_order_is_reported_for_fifo_head_of_line_waiter() {
+    let metrics = Arc::new(Metrics::default());
+    let gate = AcquireGate::new(2, Some(1), 2, Arc::clone(&metrics));
+    let runtime = test_runtime();
+
+    runtime.block_on(async {
+        let origin_blocker = gate.acquire(ORIGIN, 0.1, 0).await.unwrap();
+
+        let origin_waiter = gate.acquire(ORIGIN, 60.0, 0);
+        tokio::pin!(origin_waiter);
+        assert_acquire_waits(origin_waiter.as_mut());
+
+        let secondary_waiter = gate.acquire(SECONDARY_ORIGIN, 60.0, 0);
+        tokio::pin!(secondary_waiter);
+        assert_acquire_waits(secondary_waiter.as_mut());
+
+        let diagnostics = gate.diagnostics();
+        assert_eq!(diagnostics.blocked_by, PendingRequestBlockingReason::Mixed);
+        let origin_diagnostics = find_origin_diagnostics(&gate, ORIGIN);
+        assert_eq!(
+            origin_diagnostics.blocked_by,
+            PendingRequestBlockingReason::PerOriginActiveRequests
+        );
+        let secondary_diagnostics = find_origin_diagnostics(&gate, SECONDARY_ORIGIN);
+        assert_eq!(
+            secondary_diagnostics.blocked_by,
+            PendingRequestBlockingReason::PendingQueueOrder
+        );
+        assert_eq!(secondary_diagnostics.active_requests, 0);
+        assert_eq!(secondary_diagnostics.pending_requests, 1);
+
+        drop(origin_blocker);
+
+        let origin_permit = acquire_before_deadline(origin_waiter.as_mut())
+            .await
+            .unwrap();
+        assert_request_pressure(&metrics, 1, 1);
+
+        let secondary_permit = acquire_before_deadline(secondary_waiter.as_mut())
+            .await
+            .unwrap();
+        assert_request_pressure(&metrics, 2, 0);
+
+        drop(origin_permit);
+        drop(secondary_permit);
+        assert_request_pressure(&metrics, 0, 0);
+    });
+}
+
+#[test]
+fn full_pending_queue_rejects_new_waiter_without_dropping_existing_waiter() {
+    initialize_python();
+
+    let metrics = Arc::new(Metrics::default());
+    let gate = AcquireGate::new(1, None, 1, Arc::clone(&metrics));
+    let runtime = test_runtime();
+
+    runtime.block_on(async {
+        let blocker = gate.acquire(ORIGIN, 0.1, 0).await.unwrap();
+
+        let waiter = gate.acquire(ORIGIN, 60.0, 0);
+        tokio::pin!(waiter);
+        assert_acquire_waits(waiter.as_mut());
+
+        let error = match gate.acquire(SECONDARY_ORIGIN, 0.1, 0).await {
+            Ok(_permit) => panic!("acquire unexpectedly succeeded"),
+            Err(err) => err,
+        };
+        assert!(error.to_string().contains("request acquire queue is full"));
+
+        let snapshot = assert_request_pressure(&metrics, 1, 1);
+        assert_eq!(snapshot.peak_pending_requests, 1);
+        assert_eq!(snapshot.pool_acquire_timeouts, 1);
+        assert_origin_pressure(&metrics, ORIGIN, 1, 1);
+        let secondary_snapshot = find_origin_snapshot(&metrics, SECONDARY_ORIGIN);
+        assert_eq!(secondary_snapshot.active_requests, 0);
+        assert_eq!(secondary_snapshot.pending_requests, 0);
+        assert_eq!(secondary_snapshot.pool_acquire_timeouts, 1);
+
+        drop(blocker);
+
+        let permit = acquire_before_deadline(waiter.as_mut()).await.unwrap();
+        assert_request_pressure(&metrics, 1, 0);
+
+        drop(permit);
+        assert_request_pressure(&metrics, 0, 0);
     });
 }
 


### PR DESCRIPTION
Implement an explicit Rust-side pending acquire queue for request slots with bounded registration, FIFO ordering, queue-full PoolTimeout behavior, and RAII cleanup for cancelled or timed-out waiters.

Use per-waiter notifications to wake only the current queue head, preserve honest active/pending metrics, expose pending_queue_order diagnostics, and document the FIFO/per-origin behavior.

Refs: #74