### PR TITLE
refactor(client): centralize transport snapshot mapping

### DIFF
--- a/foghttp/_client/core.py
+++ b/foghttp/_client/core.py
@@ -13,7 +13,7 @@ from ..messages import CLIENT_CLOSED, UNCLOSED_CLIENT
 from ..pool_diagnostics import OriginPoolDiagnostics, PoolBlockingReason, PoolDiagnostics
 from ..request import Request
 from ..timeouts import Timeouts
-from ..transport_state import OriginPressureState, TransportState
+from ..transport_state import TransportState
 from ..transport_stats import TransportStats
 from ..types import AsyncMultipartFiles, QueryParams, RequestData, SyncMultipartFiles
 from ..url import URL
@@ -26,6 +26,7 @@ from .request_builder.merge import RequestMergeContract
 from .request_builder.models import RequestBuildOptions
 from .stats import stats_from_raw
 from .telemetry import TelemetryDispatcher
+from .transport_snapshot_mapping import empty_transport_state, transport_state_from_raw
 
 
 if TYPE_CHECKING:
@@ -100,41 +101,8 @@ class ClientCore:
             raw_state = None if raw_client is None else raw_client.transport_state()
 
         if raw_state is None:
-            return _empty_transport_state()
-        return {
-            "schema_version": raw_state.schema_version,
-            "snapshot_sequence": raw_state.snapshot_sequence,
-            "active_requests": raw_state.active_requests,
-            "pending_requests": raw_state.pending_requests,
-            "peak_pending_requests": raw_state.peak_pending_requests,
-            "pool_acquire_attempts": raw_state.pool_acquire_attempts,
-            "pool_acquire_immediate": raw_state.pool_acquire_immediate,
-            "pool_acquire_waited": raw_state.pool_acquire_waited,
-            "pool_acquire_timeouts": raw_state.pool_acquire_timeouts,
-            "pool_acquire_wait_time_total_ns": raw_state.pool_acquire_wait_time_total_ns,
-            "pool_acquire_wait_time_max_ns": raw_state.pool_acquire_wait_time_max_ns,
-            "pool_acquire_wait_time_last_ns": raw_state.pool_acquire_wait_time_last_ns,
-            "connection_acquire_attempts": raw_state.connection_acquire_attempts,
-            "connection_acquire_immediate": raw_state.connection_acquire_immediate,
-            "connection_acquire_waited": raw_state.connection_acquire_waited,
-            "connection_acquire_timeouts": raw_state.connection_acquire_timeouts,
-            "connection_acquire_wait_time_total_ns": raw_state.connection_acquire_wait_time_total_ns,
-            "connection_acquire_wait_time_max_ns": raw_state.connection_acquire_wait_time_max_ns,
-            "connection_acquire_wait_time_last_ns": raw_state.connection_acquire_wait_time_last_ns,
-            "response_body_reuse_eligible": raw_state.response_body_reuse_eligible,
-            "response_body_closed": raw_state.response_body_closed,
-            "response_body_aborted": raw_state.response_body_aborted,
-            "active_connections": raw_state.active_connections,
-            "idle_connections": raw_state.idle_connections,
-            "connections_opened": raw_state.connections_opened,
-            "connections_open_failed": raw_state.connections_open_failed,
-            "connections_closed": raw_state.connections_closed,
-            "connections_reused": raw_state.connections_reused,
-            "connections_aborted": raw_state.connections_aborted,
-            "buffered_response_bytes": raw_state.buffered_response_bytes,
-            "buffered_response_budget_rejections": raw_state.buffered_response_budget_rejections,
-            "origins": {origin.origin: _origin_pressure_state(origin) for origin in raw_state.origins},
-        }
+            return empty_transport_state()
+        return transport_state_from_raw(raw_state)
 
     def dump_pool_diagnostics(self) -> PoolDiagnostics:
         self._ensure_open()
@@ -175,76 +143,6 @@ class ClientCore:
 
     def _unclosed_client_message(self) -> str:
         return UNCLOSED_CLIENT
-
-
-def _origin_pressure_state(origin: "_foghttp.RawOriginPressure") -> OriginPressureState:
-    return {
-        "active_requests": origin.active_requests,
-        "pending_requests": origin.pending_requests,
-        "peak_pending_requests": origin.peak_pending_requests,
-        "pool_acquire_attempts": origin.pool_acquire_attempts,
-        "pool_acquire_immediate": origin.pool_acquire_immediate,
-        "pool_acquire_waited": origin.pool_acquire_waited,
-        "pool_acquire_timeouts": origin.pool_acquire_timeouts,
-        "pool_acquire_wait_time_total_ns": origin.pool_acquire_wait_time_total_ns,
-        "pool_acquire_wait_time_max_ns": origin.pool_acquire_wait_time_max_ns,
-        "pool_acquire_wait_time_last_ns": origin.pool_acquire_wait_time_last_ns,
-        "connection_acquire_attempts": origin.connection_acquire_attempts,
-        "connection_acquire_immediate": origin.connection_acquire_immediate,
-        "connection_acquire_waited": origin.connection_acquire_waited,
-        "connection_acquire_timeouts": origin.connection_acquire_timeouts,
-        "connection_acquire_wait_time_total_ns": origin.connection_acquire_wait_time_total_ns,
-        "connection_acquire_wait_time_max_ns": origin.connection_acquire_wait_time_max_ns,
-        "connection_acquire_wait_time_last_ns": origin.connection_acquire_wait_time_last_ns,
-        "response_body_reuse_eligible": origin.response_body_reuse_eligible,
-        "response_body_closed": origin.response_body_closed,
-        "response_body_aborted": origin.response_body_aborted,
-        "active_connections": origin.active_connections,
-        "idle_connections": origin.idle_connections,
-        "connections_opened": origin.connections_opened,
-        "connections_open_failed": origin.connections_open_failed,
-        "connections_closed": origin.connections_closed,
-        "connections_reused": origin.connections_reused,
-        "connections_aborted": origin.connections_aborted,
-        "last_activity_at_ns": origin.last_activity_at_ns,
-    }
-
-
-def _empty_transport_state() -> TransportState:
-    return {
-        "schema_version": TELEMETRY_SNAPSHOT_SCHEMA_VERSION,
-        "snapshot_sequence": SYNTHETIC_TELEMETRY_SNAPSHOT_SEQUENCE,
-        "active_requests": 0,
-        "pending_requests": 0,
-        "peak_pending_requests": 0,
-        "pool_acquire_attempts": 0,
-        "pool_acquire_immediate": 0,
-        "pool_acquire_waited": 0,
-        "pool_acquire_timeouts": 0,
-        "pool_acquire_wait_time_total_ns": 0,
-        "pool_acquire_wait_time_max_ns": 0,
-        "pool_acquire_wait_time_last_ns": 0,
-        "connection_acquire_attempts": 0,
-        "connection_acquire_immediate": 0,
-        "connection_acquire_waited": 0,
-        "connection_acquire_timeouts": 0,
-        "connection_acquire_wait_time_total_ns": 0,
-        "connection_acquire_wait_time_max_ns": 0,
-        "connection_acquire_wait_time_last_ns": 0,
-        "response_body_reuse_eligible": 0,
-        "response_body_closed": 0,
-        "response_body_aborted": 0,
-        "active_connections": 0,
-        "idle_connections": 0,
-        "connections_opened": 0,
-        "connections_open_failed": 0,
-        "connections_closed": 0,
-        "connections_reused": 0,
-        "connections_aborted": 0,
-        "buffered_response_bytes": 0,
-        "buffered_response_budget_rejections": 0,
-        "origins": {},
-    }
 
 
 def _empty_pool_diagnostics(limits: Limits) -> PoolDiagnostics:

--- a/foghttp/_client/transport_snapshot_mapping.py
+++ b/foghttp/_client/transport_snapshot_mapping.py
@@ -1,0 +1,83 @@
+from typing import TYPE_CHECKING, cast
+
+from .._telemetry import SYNTHETIC_TELEMETRY_SNAPSHOT_SEQUENCE, TELEMETRY_SNAPSHOT_SCHEMA_VERSION
+from ..transport_state import OriginPressureState, TransportState
+
+
+if TYPE_CHECKING:
+    from foghttp import _foghttp
+
+
+_TRANSPORT_PRESSURE_FIELDS = (
+    "active_requests",
+    "pending_requests",
+    "peak_pending_requests",
+    "pool_acquire_attempts",
+    "pool_acquire_immediate",
+    "pool_acquire_waited",
+    "pool_acquire_timeouts",
+    "pool_acquire_wait_time_total_ns",
+    "pool_acquire_wait_time_max_ns",
+    "pool_acquire_wait_time_last_ns",
+    "connection_acquire_attempts",
+    "connection_acquire_immediate",
+    "connection_acquire_waited",
+    "connection_acquire_timeouts",
+    "connection_acquire_wait_time_total_ns",
+    "connection_acquire_wait_time_max_ns",
+    "connection_acquire_wait_time_last_ns",
+    "response_body_reuse_eligible",
+    "response_body_closed",
+    "response_body_aborted",
+    "active_connections",
+    "idle_connections",
+    "connections_opened",
+    "connections_open_failed",
+    "connections_closed",
+    "connections_reused",
+    "connections_aborted",
+)
+_TRANSPORT_BUFFER_FIELDS = (
+    "buffered_response_bytes",
+    "buffered_response_budget_rejections",
+)
+_ORIGIN_PRESSURE_FIELDS = (
+    *_TRANSPORT_PRESSURE_FIELDS,
+    "last_activity_at_ns",
+)
+_TRANSPORT_STATE_FIELDS = (
+    *_TRANSPORT_PRESSURE_FIELDS,
+    *_TRANSPORT_BUFFER_FIELDS,
+)
+
+
+def empty_transport_state() -> TransportState:
+    return cast(
+        "TransportState",
+        {
+            "schema_version": TELEMETRY_SNAPSHOT_SCHEMA_VERSION,
+            "snapshot_sequence": SYNTHETIC_TELEMETRY_SNAPSHOT_SEQUENCE,
+            **dict.fromkeys(_TRANSPORT_STATE_FIELDS, 0),
+            "origins": {},
+        },
+    )
+
+
+def transport_state_from_raw(raw_state: "_foghttp.RawTransportState") -> TransportState:
+    return cast(
+        "TransportState",
+        {
+            "schema_version": raw_state.schema_version,
+            "snapshot_sequence": raw_state.snapshot_sequence,
+            **_snapshot_fields(raw_state, _TRANSPORT_STATE_FIELDS),
+            "origins": {origin.origin: _origin_pressure_state(origin) for origin in raw_state.origins},
+        },
+    )
+
+
+def _origin_pressure_state(origin: "_foghttp.RawOriginPressure") -> OriginPressureState:
+    return cast("OriginPressureState", _snapshot_fields(origin, _ORIGIN_PRESSURE_FIELDS))
+
+
+def _snapshot_fields(snapshot: object, fields: tuple[str, ...]) -> dict[str, int]:
+    return {field_name: cast("int", getattr(snapshot, field_name)) for field_name in fields}

--- a/tests/client_resources/test_diagnostic_snapshot_contract.py
+++ b/tests/client_resources/test_diagnostic_snapshot_contract.py
@@ -50,6 +50,23 @@ def test_sync_synthetic_schema_version_matches_rust_schema_version(
     assert synthetic_diagnostics["schema_version"] == real_diagnostics["schema_version"]
 
 
+def test_sync_transport_state_contract_covers_synthetic_real_and_origin_fields(
+    sync_resource_http_server: str,
+) -> None:
+    with foghttp.Client() as client:
+        synthetic_state = client.dump_transport_state()
+        response = client.get(sync_resource_http_server)
+        real_state = client.dump_transport_state()
+
+    origin_state = real_state["origins"][sync_resource_http_server]
+
+    assert response.status_code == OK
+    assert set(synthetic_state) == _transport_state_contract_fields()
+    assert set(real_state) == _transport_state_contract_fields()
+    assert set(synthetic_state) == set(real_state)
+    assert set(origin_state) == _origin_pressure_contract_fields()
+
+
 def test_sync_diagnostic_snapshot_sequence_is_monotonic(
     sync_resource_http_server: str,
 ) -> None:
@@ -129,3 +146,11 @@ def _snapshot_sequence(snapshot: Snapshot) -> int:
     if isinstance(snapshot, foghttp.TransportStats):
         return snapshot.snapshot_sequence
     return snapshot["snapshot_sequence"]
+
+
+def _transport_state_contract_fields() -> set[str]:
+    return set(foghttp.TransportState.__annotations__)
+
+
+def _origin_pressure_contract_fields() -> set[str]:
+    return set(foghttp.OriginPressureState.__annotations__)


### PR DESCRIPTION
- move transport state mapping out of ClientCore
- add a dedicated internal snapshot mapping module
- verify synthetic, raw, and per-origin transport state contracts
- avoid private/public transport_state module name collision