### PR TITLE
feat(client): add HTTP QUERY method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ async with foghttp.AsyncClient() as client:
 ## What Works Today
 
 - sync `Client` and async `AsyncClient`
-- `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
+- `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, and RFC 10008 `QUERY`
 - `base_url` for reusable API clients and relative request paths
 - default client headers and query params for reusable API clients
 - query params with repeated keys, JSON, form-urlencoded data, buffered
@@ -104,7 +104,7 @@ async with foghttp.AsyncClient() as client:
 - redacted repr/error surfaces for sensitive headers, URL credentials,
   token-like URL params, and buffered body bytes
 - normalized `URL` model with origin comparison and relative joins
-- GET/HEAD/POST redirects with final URL, history, and conservative replay policy
+- GET/HEAD/POST/QUERY redirects with final URL, history, and conservative replay policy
 - HTTP proxy routing and HTTPS proxy `CONNECT` tunnelling through explicit
   `proxy=` or `trust_env=True` when the proxy endpoint uses `http://`
 - HTTPS with default WebPKI roots, explicit custom CA certificates, and

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 ## Key Features
 
 - sync `Client` and async `AsyncClient`
-- `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
+- `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, and RFC 10008 `QUERY`
 - `base_url` for reusable API clients and relative request paths
 - default client headers and query params for reusable API clients
 - query params with repeated keys, JSON, form-urlencoded data, buffered
@@ -114,7 +114,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - redacted repr/error surfaces for sensitive headers, URL credentials,
   token-like URL params, and buffered body bytes
 - normalized `URL` model with origin comparison and relative joins
-- GET/HEAD/POST redirects with final URL, history, and conservative replay policy
+- GET/HEAD/POST/QUERY redirects with final URL, history, and conservative replay policy
 - HTTPS with default WebPKI roots, explicit custom CA certificates, and
   custom-only CA trust
 - documented lazy transport creation, graceful sync close, async request

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -15,7 +15,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 
 - sync `Client`
 - async `AsyncClient`
-- `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`
+- `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, and RFC 10008 `QUERY`
 - `base_url` for reusable API clients and relative request paths
 - default client headers with per-request overrides
 - default client query params with per-request params appended after defaults
@@ -38,7 +38,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - response header bytes exposed as Latin-1 strings, including obs-text values
 - normalized `URL` with origin comparison and relative joins
 - redirect history
-- GET/HEAD/POST redirects
+- GET/HEAD/POST/QUERY redirects
 - HTTPS with default WebPKI roots, explicit custom CA certificate files, and
   custom-only CA trust through `TLSConfig(trust_webpki_roots=False)`
 - plain HTTP proxy routing and HTTPS proxy `CONNECT` through explicit `proxy=`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -417,6 +417,24 @@ provider and multipart type aliases are documented in
 intentionally need a non-standard GET or HEAD body, use the explicit
 `request("GET", ..., content=...)` / `request("HEAD", ..., content=...)` form.
 
+RFC 10008 `QUERY` requests are body-capable. Use the `query()` helper or the
+explicit `request(QUERY, ...)` API when method constants fit shared code better:
+
+```python
+import foghttp
+
+
+with foghttp.Client() as client:
+    response = client.query(
+        "https://api.example.com/search",
+        json={"filter": {"active": True}},
+    )
+```
+
+For raw `content=` or raw `data=`, provide the query's `Content-Type`
+explicitly. JSON and encoded form data retain their normal automatic media
+types.
+
 ## Buffered Response Decoding
 
 Buffered responses with `content-encoding: gzip`, `deflate`, or `br` are
@@ -759,5 +777,5 @@ HTTP method constants are available through `foghttp.methods` for code that
 shares method names across prepared requests or helper layers.
 
 ```python
-from foghttp.methods import GET, POST
+from foghttp.methods import GET, POST, QUERY
 ```

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -101,6 +101,31 @@ print(response.request.method)
 
 :::
 
+## QUERY Method Rules
+
+FogHTTP follows the redirect semantics for `QUERY` defined by
+[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html):
+
+| Status | Method behavior |
+|---|---|
+| `301` | `QUERY` and a replayable body are preserved for same-origin redirects |
+| `302` | `QUERY` and a replayable body are preserved for same-origin redirects |
+| `303` | `QUERY` becomes `GET`; body and body-specific headers are dropped |
+| `307` | `QUERY` and a replayable body are preserved for same-origin redirects |
+| `308` | `QUERY` and a replayable body are preserved for same-origin redirects |
+
+Unlike POST, QUERY does not become GET after `301` or `302`. Direct streams and
+other non-replayable bodies fail closed when a same-origin redirect would need
+to resend the query content. Factory-backed streams remain replayable because
+FogHTTP can request a fresh provider for each attempt.
+
+For cross-origin `301`, `302`, `307`, and `308`, FogHTTP preserves the QUERY
+method but does not forward the request content, sensitive headers, or
+body-specific headers to the new origin. A destination that requires a query
+body and `Content-Type` can therefore reject that sanitized request. This is a
+deliberate data-boundary rule rather than an attempt to recreate the original
+query at a different origin.
+
 ## Security Policy
 
 FogHTTP applies a conservative redirect security policy on every redirect hop.
@@ -122,8 +147,8 @@ cookies, origin metadata, and referrer metadata from being forwarded to a
 different origin by a redirect response. `Host` is transport-managed and cannot
 be set manually through the safe API.
 
-When a redirect rewrites `POST` to `GET`, FogHTTP drops the request body and
-strips body-specific headers:
+When a redirect rewrites `POST` or `QUERY` to `GET`, FogHTTP drops the request
+body and strips body-specific headers:
 
 - `Content-Encoding`
 - `Content-Length`
@@ -133,19 +158,21 @@ strips body-specific headers:
 `Content-Length` and `Transfer-Encoding` are transport-managed and cannot be set
 manually through the safe API.
 
-For same-origin `307` and `308`, FogHTTP preserves the method and resends the
-current buffered body. For cross-origin `307` and `308`, FogHTTP preserves the
-method but drops the body and body-specific headers before the next request.
-This prevents JSON payloads, tokens, form data, and other request bodies from
-being forwarded to a different origin by a redirect response.
+For same-origin method-preserving POST and QUERY redirects, FogHTTP resends a
+replayable body. For cross-origin method-preserving POST and QUERY redirects,
+FogHTTP preserves the method but drops the body and body-specific headers
+before the next request. This prevents JSON payloads, tokens, form data, and
+other request bodies from being forwarded to a different origin by a redirect
+response.
 
 FogHTTP also blocks `https -> http` redirects. Scheme downgrade redirects are
 too easy to misuse once credentials, cookies, body replay, or future auth helpers
 are involved, so the safe default is to fail the request instead of silently
 following the downgrade.
 
-Future streaming bodies will use an explicit replayability model because
-non-replayable streams must not be resent automatically.
+Direct streaming bodies use the explicit non-replayable path and are not resent
+automatically. Factory-backed streams are replayable because each attempt gets
+a fresh provider.
 
 ## Proxy Policy
 

--- a/docs/request-builder.md
+++ b/docs/request-builder.md
@@ -27,7 +27,7 @@ the current FogHTTP API. The same flow is available as a runnable example in
 | cookies/session jar | Planned | `cookies=True` is rejected today. |
 | proxy / `trust_env` | Supported | HTTP proxy routing and HTTPS `CONNECT` tunnelling through client-level `proxy=` or `trust_env=True` when the proxy endpoint uses `http://`. |
 | `timeout` | Partly supported | Per-request `pool`, `read`, `write`, and `total` timeouts are supported. Per-request `connect` does not reconfigure the connector. |
-| `follow_redirects` | Supported | Client-level setting. GET/HEAD/POST redirects use conservative security rules. |
+| `follow_redirects` | Supported | Client-level setting. GET/HEAD/POST/QUERY redirects use conservative security rules. |
 | prepared request | Supported | Use `build_request()` and `send()`. Building a request does not create transport state. |
 
 `get()` and `head()` are bodyless convenience helpers: they expose `headers`,
@@ -35,6 +35,40 @@ the current FogHTTP API. The same flow is available as a runnable example in
 If application code intentionally needs an unusual GET or HEAD request body,
 use the explicit `request("GET", ..., content=...)` or
 `request("HEAD", ..., content=...)` form.
+
+## HTTP QUERY
+
+FogHTTP supports the safe, idempotent `QUERY` method defined by
+[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html). Use `query(...)`,
+`request(QUERY, ...)`, `stream(QUERY, ...)`, `build_request(QUERY, ...)`, or a
+prepared request with `send()`. The sync and async `query()` helpers expose the
+same body-capable parameters as other body-capable method helpers.
+
+```python
+import foghttp
+
+
+with foghttp.Client() as client:
+    response = client.query(
+        "https://api.example.com/catalog",
+        json={"filter": {"available": True}},
+    )
+    response.raise_for_status()
+```
+
+The request content and its media type define a QUERY. `json=` and encoded
+mapping/pair `data=` add their normal semantic `Content-Type`. For opaque
+`content=` and raw `data=`, set `Content-Type` explicitly; FogHTTP does not
+sniff the body or invent a media type. `Accept-Query` response headers are
+available through the normal case-insensitive `response.headers` interface;
+FogHTTP does not yet parse that Structured Field value.
+
+RFC 10008 classifies QUERY as safe and idempotent. FogHTTP records the method
+name in request metadata and telemetry, but does not currently provide an
+automatic retry policy or an HTTP cache. RFC 10008 permits QUERY responses to
+be cached, but a QUERY cache key must incorporate the request content and
+related metadata, including `Content-Type`; a URL-only GET-style cache key is
+not valid for QUERY.
 
 ## Merge Order
 
@@ -218,8 +252,8 @@ Rust client, or consume pool/request slots.
 | iterator `data=` | `TypeError` |
 
 Body parameters are part of `request()`, `stream()`, and body-capable method
-helpers such as `post()`, `put()`, `patch()`, and `delete()`. The `get()` and
-`head()` helpers intentionally do not expose body parameters.
+helpers such as `post()`, `query()`, `put()`, `patch()`, and `delete()`. The
+`get()` and `head()` helpers intentionally do not expose body parameters.
 
 `Content-Length` and `Transfer-Encoding` are transport-managed framing headers
 and cannot be set manually. `Content-Type` is semantic and can be set by the

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -154,8 +154,9 @@ Streaming decompression is planned separately.
 
 ### Redirect-Aware APIs
 
-FogHTTP can follow GET, HEAD, and POST redirects, preserve redirect history, and
-apply conservative cross-origin header stripping and body replay protection.
+FogHTTP can follow GET, HEAD, POST, and RFC 10008 QUERY redirects, preserve
+redirect history, and apply conservative cross-origin header stripping and
+body replay protection.
 
 ```python
 import foghttp

--- a/foghttp/async_client.py
+++ b/foghttp/async_client.py
@@ -35,7 +35,7 @@ from .lifecycle_debug import (
     AsyncLifecycleDebugSnapshot,
 )
 from .limits import Limits
-from .methods import DELETE, GET, HEAD, PATCH, POST, PUT
+from .methods import DELETE, GET, HEAD, PATCH, POST, PUT, QUERY
 from .request import Request
 from .response import Response
 from .stream_response import AsyncStreamResponse
@@ -240,6 +240,30 @@ class AsyncClient(ClientCore):
     ) -> Response:
         return await self.request(
             POST,
+            url,
+            headers=headers,
+            params=params,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            timeout=timeout,
+        )
+
+    async def query(
+        self,
+        url: str | URL,
+        *,
+        headers: HeaderSource = None,
+        params: QueryParams = None,
+        content: AsyncRequestContent | None = None,
+        data: RequestData = None,
+        files: AsyncMultipartFiles | None = None,
+        json: Any = None,
+        timeout: Timeouts | None = None,
+    ) -> Response:
+        return await self.request(
+            QUERY,
             url,
             headers=headers,
             params=params,

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -22,7 +22,7 @@ from ._client.transport import RawSyncTransport, SyncTransport
 from ._upload_body import SyncRequestContent
 from .headers import HeaderSource
 from .limits import Limits
-from .methods import DELETE, GET, HEAD, PATCH, POST, PUT
+from .methods import DELETE, GET, HEAD, PATCH, POST, PUT, QUERY
 from .request import Request
 from .response import Response
 from .stream_response import StreamResponse
@@ -250,6 +250,30 @@ class Client(ClientCore):
     ) -> Response:
         return self.request(
             POST,
+            url,
+            headers=headers,
+            params=params,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            timeout=timeout,
+        )
+
+    def query(
+        self,
+        url: str | URL,
+        *,
+        headers: HeaderSource = None,
+        params: QueryParams = None,
+        content: SyncRequestContent | None = None,
+        data: RequestData = None,
+        files: SyncMultipartFiles | None = None,
+        json: Any = None,
+        timeout: Timeouts | None = None,
+    ) -> Response:
+        return self.request(
+            QUERY,
             url,
             headers=headers,
             params=params,

--- a/foghttp/methods.py
+++ b/foghttp/methods.py
@@ -8,6 +8,7 @@ __all__ = (
     "PATCH",
     "POST",
     "PUT",
+    "QUERY",
     "TRACE",
 )
 
@@ -18,6 +19,7 @@ POST = "POST"
 PUT = "PUT"
 PATCH = "PATCH"
 DELETE = "DELETE"
+QUERY = "QUERY"
 OPTIONS = "OPTIONS"
 CONNECT = "CONNECT"
 TRACE = "TRACE"
@@ -29,6 +31,7 @@ HTTP_METHODS = (
     PUT,
     PATCH,
     DELETE,
+    QUERY,
     OPTIONS,
     CONNECT,
     TRACE,

--- a/src/core/method.rs
+++ b/src/core/method.rs
@@ -1,3 +1,4 @@
 pub const GET: &str = "GET";
 pub const HEAD: &str = "HEAD";
 pub const POST: &str = "POST";
+pub const QUERY: &str = "QUERY";

--- a/src/py/client/redirects/method.rs
+++ b/src/py/client/redirects/method.rs
@@ -1,4 +1,4 @@
-use crate::core::method::{GET, HEAD, POST};
+use crate::core::method::{GET, HEAD, POST, QUERY};
 use hyper::StatusCode;
 
 pub fn redirect_method(method: &str, status_code: StatusCode) -> Option<(&'static str, bool)> {
@@ -11,6 +11,14 @@ pub fn redirect_method(method: &str, status_code: StatusCode) -> Option<(&'stati
         (POST, StatusCode::TEMPORARY_REDIRECT | StatusCode::PERMANENT_REDIRECT) => {
             Some((POST, true))
         }
+        (
+            QUERY,
+            StatusCode::MOVED_PERMANENTLY
+            | StatusCode::FOUND
+            | StatusCode::TEMPORARY_REDIRECT
+            | StatusCode::PERMANENT_REDIRECT,
+        ) => Some((QUERY, true)),
+        (QUERY, StatusCode::SEE_OTHER) => Some((GET, false)),
         _ => None,
     }
 }

--- a/src/py/client/redirects/tests.rs
+++ b/src/py/client/redirects/tests.rs
@@ -2,7 +2,7 @@ use super::{
     redirect_decision, redirect_headers, RedirectAction, RedirectDecision, RedirectHeaderPolicy,
 };
 use crate::core::headers::HeaderPairs;
-use crate::core::method::{GET, POST};
+use crate::core::method::{GET, POST, QUERY};
 use crate::messages::HTTPS_TO_HTTP_REDIRECT_BLOCKED;
 use hyper::StatusCode;
 
@@ -132,6 +132,36 @@ fn method_preserving_redirect_keeps_body_headers() {
         header_names(&headers),
         vec!["Content-Type", "Content-Length"]
     );
+}
+
+#[test]
+fn query_redirects_preserve_method_except_for_see_other() {
+    for status_code in [
+        StatusCode::MOVED_PERMANENTLY,
+        StatusCode::FOUND,
+        StatusCode::TEMPORARY_REDIRECT,
+        StatusCode::PERMANENT_REDIRECT,
+    ] {
+        let action = follow_action(redirect_decision(
+            QUERY,
+            "https://example.com/search",
+            status_code.as_u16(),
+            &[("location".to_owned(), "/results".to_owned())],
+        ));
+
+        assert_eq!(action.method, QUERY);
+        assert!(action.preserve_body);
+    }
+
+    let action = follow_action(redirect_decision(
+        QUERY,
+        "https://example.com/search",
+        StatusCode::SEE_OTHER.as_u16(),
+        &[("location".to_owned(), "/results".to_owned())],
+    ));
+
+    assert_eq!(action.method, GET);
+    assert!(!action.preserve_body);
 }
 
 #[test]

--- a/tests/client_query/assertions.py
+++ b/tests/client_query/assertions.py
@@ -1,0 +1,103 @@
+__all__ = (
+    "assert_cross_origin_query_is_sanitized",
+    "assert_query_echo",
+    "assert_query_redirect",
+)
+
+from typing import Any
+
+from foghttp.methods import QUERY
+from foghttp.response import Response
+from foghttp.status_codes.success import OK
+from tests.redirect_helpers import SECURITY_HEADERS_PATH, header_values
+
+
+def assert_query_echo(
+    response: Response,
+    *,
+    body: str,
+    content_type: str,
+) -> None:
+    payload = response.json()
+    actual_values = {
+        "request_line": payload["request_line"],
+        "body": payload["body"],
+        "content_type": header_values(payload, "content-type"),
+    }
+    expected_values = {
+        "request_line": f"{QUERY} {SECURITY_HEADERS_PATH} HTTP/1.1",
+        "body": body,
+        "content_type": [content_type],
+    }
+    if actual_values != expected_values:
+        raise AssertionError(actual_values)
+
+
+def assert_query_redirect(
+    response: Response,
+    *,
+    base_url: str,
+    status_code: int,
+    body: str,
+) -> None:
+    payload = response.json()
+    history_item = response.history[0] if response.history else None
+    actual_values = {
+        "status_code": response.status_code,
+        "url": response.url,
+        "request_method": response.request.method,
+        "request_url": response.request.url,
+        "request_line": payload["request_line"],
+        "body": payload["body"],
+        "history_length": len(response.history),
+        "history_status_code": None if history_item is None else history_item.status_code,
+        "history_method": None if history_item is None else history_item.request.method,
+    }
+    expected_values = {
+        "status_code": OK,
+        "url": f"{base_url}/final",
+        "request_method": QUERY,
+        "request_url": f"{base_url}/final",
+        "request_line": f"{QUERY} /final HTTP/1.1",
+        "body": body,
+        "history_length": 1,
+        "history_status_code": status_code,
+        "history_method": QUERY,
+    }
+    if actual_values != expected_values:
+        raise AssertionError(actual_values)
+
+
+def assert_cross_origin_query_is_sanitized(
+    payload: dict[str, Any],
+    *,
+    host: str,
+) -> None:
+    actual_values = {
+        "request_line": payload["request_line"],
+        "body": payload["body"],
+        "accept": header_values(payload, "accept"),
+        "authorization": header_values(payload, "authorization"),
+        "content_encoding": header_values(payload, "content-encoding"),
+        "content_type": header_values(payload, "content-type"),
+        "cookie": header_values(payload, "cookie"),
+        "host": header_values(payload, "host"),
+        "origin": header_values(payload, "origin"),
+        "proxy_authorization": header_values(payload, "proxy-authorization"),
+        "referer": header_values(payload, "referer"),
+    }
+    expected_values = {
+        "request_line": f"{QUERY} {SECURITY_HEADERS_PATH} HTTP/1.1",
+        "body": "",
+        "accept": ["application/json"],
+        "authorization": [],
+        "content_encoding": [],
+        "content_type": [],
+        "cookie": [],
+        "host": [host],
+        "origin": [],
+        "proxy_authorization": [],
+        "referer": [],
+    }
+    if actual_values != expected_values:
+        raise AssertionError(actual_values)

--- a/tests/client_query/constants.py
+++ b/tests/client_query/constants.py
@@ -1,0 +1,18 @@
+__all__ = ("QUERY_PRESERVING_REDIRECT_PARAMS",)
+
+import pytest
+
+from foghttp.status_codes.redirect import (
+    FOUND,
+    MOVED_PERMANENTLY,
+    PERMANENT_REDIRECT,
+    TEMPORARY_REDIRECT,
+)
+
+
+QUERY_PRESERVING_REDIRECT_PARAMS = (
+    pytest.param(MOVED_PERMANENTLY, id="301-moved-permanently"),
+    pytest.param(FOUND, id="302-found"),
+    pytest.param(TEMPORARY_REDIRECT, id="307-temporary-redirect"),
+    pytest.param(PERMANENT_REDIRECT, id="308-permanent-redirect"),
+)

--- a/tests/client_query/test_async_query.py
+++ b/tests/client_query/test_async_query.py
@@ -1,0 +1,159 @@
+from urllib.parse import urlencode
+
+from faker import Faker
+import orjson
+import pytest
+
+import foghttp
+from foghttp.methods import QUERY
+from foghttp.status_codes.client_error import NOT_FOUND
+from foghttp.status_codes.redirect import TEMPORARY_REDIRECT
+from foghttp.status_codes.success import OK
+from foghttp.telemetry import TelemetryConfig
+from tests.client_query.assertions import assert_query_echo
+from tests.client_telemetry.models import RecordingTelemetrySink
+from tests.redirect_helpers import SECURITY_HEADERS_PATH
+
+
+async def test_async_query_supports_json_body(
+    http_server: str,
+    faker: Faker,
+) -> None:
+    body = {"filter": faker.sentence()}
+
+    async with foghttp.AsyncClient() as client:
+        response = await client.query(
+            f"{http_server}{SECURITY_HEADERS_PATH}",
+            json=body,
+        )
+
+    assert_query_echo(
+        response,
+        body=orjson.dumps(body).decode(),
+        content_type="application/json",
+    )
+
+
+async def test_async_query_supports_form_body(
+    http_server: str,
+    faker: Faker,
+) -> None:
+    body = {"filter": faker.word(), "page": faker.random_int(min=1, max=100)}
+
+    async with foghttp.AsyncClient() as client:
+        response = await client.query(
+            f"{http_server}{SECURITY_HEADERS_PATH}",
+            data=body,
+        )
+
+    assert_query_echo(
+        response,
+        body=urlencode(body),
+        content_type="application/x-www-form-urlencoded",
+    )
+
+
+async def test_async_query_supports_text_body(
+    http_server: str,
+    faker: Faker,
+) -> None:
+    body = faker.sentence()
+
+    async with foghttp.AsyncClient() as client:
+        response = await client.query(
+            f"{http_server}{SECURITY_HEADERS_PATH}",
+            headers={"content-type": "text/plain"},
+            content=body,
+        )
+
+    assert_query_echo(response, body=body, content_type="text/plain")
+
+
+async def test_async_query_supports_bytes_body(
+    http_server: str,
+    faker: Faker,
+) -> None:
+    body = faker.word().encode()
+
+    async with foghttp.AsyncClient() as client:
+        response = await client.query(
+            f"{http_server}{SECURITY_HEADERS_PATH}",
+            headers={"content-type": "application/octet-stream"},
+            content=body,
+        )
+
+    assert_query_echo(
+        response,
+        body=body.decode(),
+        content_type="application/octet-stream",
+    )
+
+
+async def test_async_query_preserves_metadata_and_telemetry(
+    http_server: str,
+    faker: Faker,
+) -> None:
+    url_secret = faker.sha256()
+    body_secret = faker.sha256()
+    sink = RecordingTelemetrySink()
+
+    async with foghttp.AsyncClient(telemetry=TelemetryConfig(sink=sink)) as client:
+        request = client.build_request(
+            QUERY.lower(),
+            f"{http_server}/status/{OK}?token={url_secret}",
+            json={"filter": body_secret},
+        )
+        representation = repr(request)
+        response = await client.send(request)
+
+    assert request.method == QUERY
+    assert response.request.method == QUERY
+    assert QUERY in representation
+    assert url_secret not in representation
+    assert body_secret not in representation
+    assert sink.events
+    assert {event.method for event in sink.events} == {QUERY}
+    assert body_secret not in repr(sink.events)
+    assert all(url_secret not in (event.redacted_url or "") for event in sink.events)
+
+
+async def test_async_query_status_error_preserves_method_and_redacts_sensitive_data(
+    http_server: str,
+    faker: Faker,
+) -> None:
+    url_secret = faker.sha256()
+    body_secret = faker.sha256()
+
+    async with foghttp.AsyncClient() as client:
+        response = await client.request(
+            QUERY,
+            f"{http_server}/status/{NOT_FOUND}?token={url_secret}",
+            headers={"content-type": "text/plain"},
+            content=body_secret,
+        )
+
+    with pytest.raises(foghttp.HTTPStatusError) as exc_info:
+        response.raise_for_status()
+
+    assert str(exc_info.value).startswith(f"{QUERY} ")
+    assert url_secret not in str(exc_info.value)
+    assert body_secret not in str(exc_info.value)
+
+
+async def test_async_query_works_with_stream_api(http_server: str, faker: Faker) -> None:
+    body = faker.sentence()
+
+    async with (
+        foghttp.AsyncClient(follow_redirects=True) as client,
+        client.stream(
+            QUERY,
+            f"{http_server}/redirect/{TEMPORARY_REDIRECT}",
+            headers={"content-type": "text/plain"},
+            content=body,
+        ) as response,
+    ):
+        payload = orjson.loads(b"".join([chunk async for chunk in response.aiter_bytes()]))
+
+    assert response.request.method == QUERY
+    assert payload["request_line"] == f"{QUERY} /final HTTP/1.1"
+    assert payload["body"] == body

--- a/tests/client_query/test_async_query_redirects.py
+++ b/tests/client_query/test_async_query_redirects.py
@@ -1,0 +1,143 @@
+from urllib.parse import urlsplit
+
+from faker import Faker
+import pytest
+
+import foghttp
+from foghttp.methods import GET, QUERY
+from foghttp.status_codes.redirect import SEE_OTHER
+from tests.client_query.assertions import (
+    assert_cross_origin_query_is_sanitized,
+    assert_query_redirect,
+)
+from tests.client_query.constants import QUERY_PRESERVING_REDIRECT_PARAMS
+from tests.redirect_helpers import (
+    REDIRECT_SECURITY_HEADERS,
+    SECURITY_HEADERS_PATH,
+    header_values,
+    redirect_to_location_url,
+)
+
+
+@pytest.mark.parametrize("status_code", QUERY_PRESERVING_REDIRECT_PARAMS)
+async def test_async_query_redirect_preserves_method_and_body(
+    http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    body = faker.sentence()
+
+    async with foghttp.AsyncClient(follow_redirects=True) as client:
+        response = await client.request(
+            QUERY,
+            f"{http_server}/redirect/{status_code}",
+            headers={"content-type": "text/plain"},
+            content=body,
+        )
+
+    assert_query_redirect(
+        response,
+        base_url=http_server,
+        status_code=status_code,
+        body=body,
+    )
+
+
+async def test_async_query_see_other_rewrites_to_get(
+    http_server: str,
+    faker: Faker,
+) -> None:
+    location = f"{http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(http_server, status_code=SEE_OTHER, location=location)
+    authorization = f"Bearer {faker.sha256()}"
+
+    async with foghttp.AsyncClient(follow_redirects=True) as client:
+        response = await client.request(
+            QUERY,
+            url,
+            headers={
+                "authorization": authorization,
+                "content-encoding": "identity",
+                "content-type": "text/plain",
+            },
+            content=faker.sentence(),
+        )
+
+    payload = response.json()
+    assert response.request.method == GET
+    assert response.history[0].status_code == SEE_OTHER
+    assert response.history[0].request.method == QUERY
+    assert payload["request_line"] == f"{GET} {SECURITY_HEADERS_PATH} HTTP/1.1"
+    assert payload["body"] == ""
+    assert header_values(payload, "authorization") == [authorization]
+    assert header_values(payload, "content-encoding") == []
+    assert header_values(payload, "content-type") == []
+
+
+async def test_async_query_see_other_drops_non_replayable_body(
+    http_server: str,
+    faker: Faker,
+) -> None:
+    async with foghttp.AsyncClient(follow_redirects=True) as client:
+        response = await client.request(
+            QUERY,
+            f"{http_server}/redirect/{SEE_OTHER}",
+            headers={"content-type": "application/octet-stream"},
+            content=iter((faker.word().encode(),)),
+        )
+
+    assert response.request.method == GET
+    assert response.history[0].status_code == SEE_OTHER
+    assert response.history[0].request.method == QUERY
+    assert response.json()["request_line"] == f"{GET} /final HTTP/1.1"
+    assert response.json()["body"] == ""
+
+
+@pytest.mark.parametrize("status_code", QUERY_PRESERVING_REDIRECT_PARAMS)
+async def test_async_query_redirect_rejects_non_replayable_body(
+    http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    async with foghttp.AsyncClient(follow_redirects=True) as client:
+        with pytest.raises(foghttp.RequestError, match="non-replayable request body"):
+            await client.request(
+                QUERY,
+                f"{http_server}/redirect/{status_code}",
+                headers={"content-type": "application/octet-stream"},
+                content=iter((faker.word().encode(),)),
+            )
+
+        stats = client.stats()
+
+    assert stats.total_requests == 1
+    assert stats.failed_requests == 1
+    assert stats.active_requests == 0
+
+
+@pytest.mark.parametrize("status_code", QUERY_PRESERVING_REDIRECT_PARAMS)
+async def test_cross_origin_async_query_redirect_is_sanitized(
+    http_server: str,
+    secondary_http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    location = f"{secondary_http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(http_server, status_code=status_code, location=location)
+
+    async with foghttp.AsyncClient(follow_redirects=True) as client:
+        response = await client.request(
+            QUERY,
+            url,
+            headers={
+                **REDIRECT_SECURITY_HEADERS,
+                "content-encoding": "identity",
+                "content-type": "text/plain",
+            },
+            content=faker.sentence(),
+        )
+
+    assert_cross_origin_query_is_sanitized(
+        response.json(),
+        host=urlsplit(secondary_http_server).netloc,
+    )

--- a/tests/client_query/test_request_builder.py
+++ b/tests/client_query/test_request_builder.py
@@ -1,0 +1,31 @@
+from faker import Faker
+import orjson
+
+import foghttp
+from foghttp.methods import QUERY
+
+
+async def test_sync_and_async_build_query_with_same_body(faker: Faker) -> None:
+    payload = {"filter": faker.sentence()}
+    url = faker.url()
+
+    with foghttp.Client() as sync_client:
+        sync_request = sync_client.build_request(QUERY.lower(), url, json=payload)
+
+    async with foghttp.AsyncClient() as async_client:
+        async_request = async_client.build_request(QUERY.lower(), url, json=payload)
+
+    expected_body = orjson.dumps(payload)
+    assert sync_request.method == QUERY
+    assert async_request.method == QUERY
+    assert sync_request.headers["content-type"] == "application/json"
+    assert async_request.headers["content-type"] == "application/json"
+    assert sync_request.content == expected_body
+    assert async_request.content == expected_body
+
+
+def test_query_raw_content_does_not_invent_media_type(faker: Faker) -> None:
+    with foghttp.Client() as client:
+        request = client.build_request(QUERY, faker.url(), content=faker.sentence())
+
+    assert "content-type" not in request.headers

--- a/tests/client_query/test_sync_query.py
+++ b/tests/client_query/test_sync_query.py
@@ -1,0 +1,159 @@
+from urllib.parse import urlencode
+
+from faker import Faker
+import orjson
+import pytest
+
+import foghttp
+from foghttp.methods import QUERY
+from foghttp.status_codes.client_error import NOT_FOUND
+from foghttp.status_codes.redirect import TEMPORARY_REDIRECT
+from foghttp.status_codes.success import OK
+from foghttp.telemetry import TelemetryConfig
+from tests.client_query.assertions import assert_query_echo
+from tests.client_telemetry.models import RecordingTelemetrySink
+from tests.redirect_helpers import SECURITY_HEADERS_PATH
+
+
+def test_sync_query_supports_json_body(
+    sync_http_server: str,
+    faker: Faker,
+) -> None:
+    body = {"filter": faker.sentence()}
+
+    with foghttp.Client() as client:
+        response = client.query(
+            f"{sync_http_server}{SECURITY_HEADERS_PATH}",
+            json=body,
+        )
+
+    assert_query_echo(
+        response,
+        body=orjson.dumps(body).decode(),
+        content_type="application/json",
+    )
+
+
+def test_sync_query_supports_form_body(
+    sync_http_server: str,
+    faker: Faker,
+) -> None:
+    body = {"filter": faker.word(), "page": faker.random_int(min=1, max=100)}
+
+    with foghttp.Client() as client:
+        response = client.query(
+            f"{sync_http_server}{SECURITY_HEADERS_PATH}",
+            data=body,
+        )
+
+    assert_query_echo(
+        response,
+        body=urlencode(body),
+        content_type="application/x-www-form-urlencoded",
+    )
+
+
+def test_sync_query_supports_text_body(
+    sync_http_server: str,
+    faker: Faker,
+) -> None:
+    body = faker.sentence()
+
+    with foghttp.Client() as client:
+        response = client.query(
+            f"{sync_http_server}{SECURITY_HEADERS_PATH}",
+            headers={"content-type": "text/plain"},
+            content=body,
+        )
+
+    assert_query_echo(response, body=body, content_type="text/plain")
+
+
+def test_sync_query_supports_bytes_body(
+    sync_http_server: str,
+    faker: Faker,
+) -> None:
+    body = faker.word().encode()
+
+    with foghttp.Client() as client:
+        response = client.query(
+            f"{sync_http_server}{SECURITY_HEADERS_PATH}",
+            headers={"content-type": "application/octet-stream"},
+            content=body,
+        )
+
+    assert_query_echo(
+        response,
+        body=body.decode(),
+        content_type="application/octet-stream",
+    )
+
+
+def test_sync_query_preserves_metadata_and_telemetry(
+    sync_http_server: str,
+    faker: Faker,
+) -> None:
+    url_secret = faker.sha256()
+    body_secret = faker.sha256()
+    sink = RecordingTelemetrySink()
+
+    with foghttp.Client(telemetry=TelemetryConfig(sink=sink)) as client:
+        request = client.build_request(
+            QUERY.lower(),
+            f"{sync_http_server}/status/{OK}?token={url_secret}",
+            json={"filter": body_secret},
+        )
+        representation = repr(request)
+        response = client.send(request)
+
+    assert request.method == QUERY
+    assert response.request.method == QUERY
+    assert QUERY in representation
+    assert url_secret not in representation
+    assert body_secret not in representation
+    assert sink.events
+    assert {event.method for event in sink.events} == {QUERY}
+    assert body_secret not in repr(sink.events)
+    assert all(url_secret not in (event.redacted_url or "") for event in sink.events)
+
+
+def test_sync_query_status_error_preserves_method_and_redacts_sensitive_data(
+    sync_http_server: str,
+    faker: Faker,
+) -> None:
+    url_secret = faker.sha256()
+    body_secret = faker.sha256()
+
+    with foghttp.Client() as client:
+        response = client.request(
+            QUERY,
+            f"{sync_http_server}/status/{NOT_FOUND}?token={url_secret}",
+            headers={"content-type": "text/plain"},
+            content=body_secret,
+        )
+
+    with pytest.raises(foghttp.HTTPStatusError) as exc_info:
+        response.raise_for_status()
+
+    assert str(exc_info.value).startswith(f"{QUERY} ")
+    assert url_secret not in str(exc_info.value)
+    assert body_secret not in str(exc_info.value)
+
+
+def test_sync_query_works_with_stream_api(sync_http_server: str, faker: Faker) -> None:
+    body = faker.sentence()
+
+    with (
+        foghttp.Client(follow_redirects=True) as client,
+        client.stream(
+            QUERY,
+            f"{sync_http_server}/redirect/{TEMPORARY_REDIRECT}",
+            headers={"content-type": "text/plain"},
+            content=body,
+        ) as response,
+    ):
+        payload = orjson.loads(b"".join(response.iter_bytes()))
+
+    assert response.request.method == QUERY
+    assert payload["request_line"] == f"{QUERY} /final HTTP/1.1"
+    assert payload["body"] == body

--- a/tests/client_query/test_sync_query_redirects.py
+++ b/tests/client_query/test_sync_query_redirects.py
@@ -1,0 +1,143 @@
+from urllib.parse import urlsplit
+
+from faker import Faker
+import pytest
+
+import foghttp
+from foghttp.methods import GET, QUERY
+from foghttp.status_codes.redirect import SEE_OTHER
+from tests.client_query.assertions import (
+    assert_cross_origin_query_is_sanitized,
+    assert_query_redirect,
+)
+from tests.client_query.constants import QUERY_PRESERVING_REDIRECT_PARAMS
+from tests.redirect_helpers import (
+    REDIRECT_SECURITY_HEADERS,
+    SECURITY_HEADERS_PATH,
+    header_values,
+    redirect_to_location_url,
+)
+
+
+@pytest.mark.parametrize("status_code", QUERY_PRESERVING_REDIRECT_PARAMS)
+def test_sync_query_redirect_preserves_method_and_body(
+    sync_http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    body = faker.sentence()
+
+    with foghttp.Client(follow_redirects=True) as client:
+        response = client.request(
+            QUERY,
+            f"{sync_http_server}/redirect/{status_code}",
+            headers={"content-type": "text/plain"},
+            content=body,
+        )
+
+    assert_query_redirect(
+        response,
+        base_url=sync_http_server,
+        status_code=status_code,
+        body=body,
+    )
+
+
+def test_sync_query_see_other_rewrites_to_get(
+    sync_http_server: str,
+    faker: Faker,
+) -> None:
+    location = f"{sync_http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(sync_http_server, status_code=SEE_OTHER, location=location)
+    authorization = f"Bearer {faker.sha256()}"
+
+    with foghttp.Client(follow_redirects=True) as client:
+        response = client.request(
+            QUERY,
+            url,
+            headers={
+                "authorization": authorization,
+                "content-encoding": "identity",
+                "content-type": "text/plain",
+            },
+            content=faker.sentence(),
+        )
+
+    payload = response.json()
+    assert response.request.method == GET
+    assert response.history[0].status_code == SEE_OTHER
+    assert response.history[0].request.method == QUERY
+    assert payload["request_line"] == f"{GET} {SECURITY_HEADERS_PATH} HTTP/1.1"
+    assert payload["body"] == ""
+    assert header_values(payload, "authorization") == [authorization]
+    assert header_values(payload, "content-encoding") == []
+    assert header_values(payload, "content-type") == []
+
+
+def test_sync_query_see_other_drops_non_replayable_body(
+    sync_http_server: str,
+    faker: Faker,
+) -> None:
+    with foghttp.Client(follow_redirects=True) as client:
+        response = client.request(
+            QUERY,
+            f"{sync_http_server}/redirect/{SEE_OTHER}",
+            headers={"content-type": "application/octet-stream"},
+            content=iter((faker.word().encode(),)),
+        )
+
+    assert response.request.method == GET
+    assert response.history[0].status_code == SEE_OTHER
+    assert response.history[0].request.method == QUERY
+    assert response.json()["request_line"] == f"{GET} /final HTTP/1.1"
+    assert response.json()["body"] == ""
+
+
+@pytest.mark.parametrize("status_code", QUERY_PRESERVING_REDIRECT_PARAMS)
+def test_sync_query_redirect_rejects_non_replayable_body(
+    sync_http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    with foghttp.Client(follow_redirects=True) as client:
+        with pytest.raises(foghttp.RequestError, match="non-replayable request body"):
+            client.request(
+                QUERY,
+                f"{sync_http_server}/redirect/{status_code}",
+                headers={"content-type": "application/octet-stream"},
+                content=iter((faker.word().encode(),)),
+            )
+
+        stats = client.stats()
+
+    assert stats.total_requests == 1
+    assert stats.failed_requests == 1
+    assert stats.active_requests == 0
+
+
+@pytest.mark.parametrize("status_code", QUERY_PRESERVING_REDIRECT_PARAMS)
+def test_cross_origin_sync_query_redirect_is_sanitized(
+    sync_http_server: str,
+    secondary_sync_http_server: str,
+    faker: Faker,
+    status_code: int,
+) -> None:
+    location = f"{secondary_sync_http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(sync_http_server, status_code=status_code, location=location)
+
+    with foghttp.Client(follow_redirects=True) as client:
+        response = client.request(
+            QUERY,
+            url,
+            headers={
+                **REDIRECT_SECURITY_HEADERS,
+                "content-encoding": "identity",
+                "content-type": "text/plain",
+            },
+            content=faker.sentence(),
+        )
+
+    assert_cross_origin_query_is_sanitized(
+        response.json(),
+        host=urlsplit(secondary_sync_http_server).netloc,
+    )

--- a/tests/request_builder/test_shortcuts.py
+++ b/tests/request_builder/test_shortcuts.py
@@ -2,13 +2,14 @@ from faker import Faker
 import pytest
 
 import foghttp
-from foghttp.methods import DELETE, GET, HEAD, PATCH, POST, PUT
+from foghttp.methods import DELETE, GET, HEAD, PATCH, POST, PUT, QUERY
 
 
 SHORTCUT_METHODS = [
     ("get", GET),
     ("head", HEAD),
     ("post", POST),
+    ("query", QUERY),
     ("put", PUT),
     ("patch", PATCH),
     ("delete", DELETE),

--- a/tests/support/sync_http_server.py
+++ b/tests/support/sync_http_server.py
@@ -43,6 +43,9 @@ class SyncHTTPHandler(BaseHTTPRequestHandler):
     def do_PUT(self) -> None:
         self._write_response()
 
+    def do_QUERY(self) -> None:
+        self._write_response()
+
     def do_PATCH(self) -> None:
         self._write_response()
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,4 +1,6 @@
 import foghttp
+import foghttp.methods
+from foghttp.methods import QUERY
 import foghttp.models
 import foghttp.stats
 
@@ -42,3 +44,10 @@ def test_compatibility_modules_reexport_models() -> None:
     assert foghttp.models.Timeouts is foghttp.Timeouts
     assert foghttp.models.URL is foghttp.URL
     assert foghttp.stats.TransportStats is foghttp.TransportStats
+
+
+def test_query_method_is_exported() -> None:
+    assert QUERY == "QUERY"
+    assert QUERY in foghttp.methods.HTTP_METHODS
+    assert foghttp.methods.HTTP_METHODS.count(QUERY) == 1
+    assert "QUERY" in foghttp.methods.__all__

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,6 +1,5 @@
 import foghttp
 import foghttp.methods
-from foghttp.methods import QUERY
 import foghttp.models
 import foghttp.stats
 
@@ -47,7 +46,7 @@ def test_compatibility_modules_reexport_models() -> None:
 
 
 def test_query_method_is_exported() -> None:
-    assert QUERY == "QUERY"
-    assert QUERY in foghttp.methods.HTTP_METHODS
-    assert foghttp.methods.HTTP_METHODS.count(QUERY) == 1
+    assert foghttp.methods.QUERY == "QUERY"
+    assert foghttp.methods.QUERY in foghttp.methods.HTTP_METHODS
+    assert foghttp.methods.HTTP_METHODS.count(foghttp.methods.QUERY) == 1
     assert "QUERY" in foghttp.methods.__all__


### PR DESCRIPTION
- expose QUERY constants and sync/async query helpers
- implement RFC 10008 redirect semantics
- add body, replayability, telemetry, and redaction coverage
- document QUERY usage and caching constraints