### PR TITLE
build(packaging): adopt abi3 wheels for Python 3.11+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,68 @@ jobs:
       - name: Run Rust tests
         run: cargo test --all-targets
 
+  abi3-wheel:
+    name: Build and audit abi3 wheel
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          target: x86_64
+          args: --release --locked --out dist --interpreter python3.11
+          manylinux: "2014"
+          sccache: true
+
+      - name: Install abi3audit
+        run: python -m pip install --disable-pip-version-check "abi3audit==0.0.26"
+
+      - name: Audit stable ABI compatibility
+        run: python -m abi3audit --strict --summary dist/*.whl
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: abi3-wheel-linux-x86_64
+          path: dist/*.whl
+          if-no-files-found: error
+
+  abi3-wheel-smoke:
+    name: Smoke abi3 wheel (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    needs: abi3-wheel
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: abi3-wheel-linux-x86_64
+          path: dist
+
+      - name: Smoke test wheel install
+        run: python scripts/install_wheel_smoke.py --dist-dir dist
+
   tests:
     name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -91,7 +153,7 @@ jobs:
           cache-dependency-glob: uv.lock
 
       - name: Install editable package
-        run: uv run --extra dev --with "maturin>=1.7,<2" maturin develop
+        run: uv run --extra dev --with "maturin>=1.7,<2" maturin develop --locked
 
       - name: Run tests
         if: matrix.python-version != '3.14'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,14 +44,13 @@ jobs:
               raise SystemExit(f"release versions do not match: {versions}")
 
   linux-wheels:
-    name: Build Linux wheels (${{ matrix.python-version }}, ${{ matrix.target }})
+    name: Build Linux wheel (${{ matrix.target }})
     runs-on: ubuntu-latest
     needs: validate-version
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
         target: [x86_64, aarch64]
     steps:
       - name: Checkout
@@ -60,7 +59,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Set up QEMU
         if: matrix.target == 'aarch64'
@@ -73,32 +72,52 @@ jobs:
         with:
           command: build
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter python${{ matrix.python-version }}
+          args: --release --locked --out dist --interpreter python3.11
           manylinux: "2014"
           sccache: true
-
-      # Linux aarch64 wheels are cross-built on x86_64 runners, so only native
-      # Linux x86_64 wheels can be installed directly in this job.
-      - name: Smoke test wheel install
-        if: matrix.target == 'x86_64'
-        run: python scripts/install_wheel_smoke.py --dist-dir dist
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.target }}-py${{ matrix.python-version }}
+          name: wheels-linux-${{ matrix.target }}
           path: dist/*.whl
           if-no-files-found: error
 
+  linux-wheel-smoke:
+    name: Smoke Linux wheel (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    needs: linux-wheels
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download x86_64 wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels-linux-x86_64
+          path: dist
+
+      - name: Smoke test wheel install
+        run: python scripts/install_wheel_smoke.py --dist-dir dist
+
   macos-wheels:
-    name: Build macOS wheels (${{ matrix.python-version }}, ${{ matrix.platform.name }})
+    name: Build macOS wheel (${{ matrix.platform.name }})
     runs-on: ${{ matrix.platform.runner }}
     needs: validate-version
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
         platform:
           - name: x86_64
             runner: macos-15-intel
@@ -113,31 +132,89 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
           command: build
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter python
+          args: --release --locked --out dist --interpreter python
           sccache: true
-
-      - name: Smoke test wheel install
-        run: python scripts/install_wheel_smoke.py --dist-dir dist
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.platform.name }}-py${{ matrix.python-version }}
+          name: wheels-macos-${{ matrix.platform.name }}
           path: dist/*.whl
           if-no-files-found: error
 
+  macos-wheel-smoke:
+    name: Smoke macOS wheel (${{ matrix.platform.name }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.platform.runner }}
+    needs: macos-wheels
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        platform:
+          - name: x86_64
+            runner: macos-15-intel
+          - name: aarch64
+            runner: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.platform.name }}
+          path: dist
+
+      - name: Smoke test wheel install
+        run: python scripts/install_wheel_smoke.py --dist-dir dist
+
   windows-wheels:
-    name: Build Windows wheels (${{ matrix.python-version }}, x64)
+    name: Build Windows wheel (x64)
     runs-on: windows-latest
     needs: validate-version
     timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          architecture: x64
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --locked --out dist --interpreter python
+          sccache: true
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-x64
+          path: dist/*.whl
+          if-no-files-found: error
+
+  windows-wheel-smoke:
+    name: Smoke Windows wheel (Python ${{ matrix.python-version }})
+    runs-on: windows-latest
+    needs: windows-wheels
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -152,22 +229,39 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
-      - name: Build wheel
-        uses: PyO3/maturin-action@v1
+      - name: Download wheel
+        uses: actions/download-artifact@v4
         with:
-          command: build
-          args: --release --out dist --interpreter python
-          sccache: true
+          name: wheels-windows-x64
+          path: dist
 
       - name: Smoke test wheel install
         run: python scripts/install_wheel_smoke.py --dist-dir dist
 
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+  audit-wheels:
+    name: Audit stable ABI wheels
+    runs-on: ubuntu-latest
+    needs: [linux-wheels, macos-wheels, windows-wheels]
+    timeout-minutes: 15
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          name: wheels-windows-x64-py${{ matrix.python-version }}
-          path: dist/*.whl
-          if-no-files-found: error
+          python-version: "3.11"
+
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Install abi3audit
+        run: python -m pip install --disable-pip-version-check "abi3audit==0.0.26"
+
+      - name: Audit stable ABI compatibility
+        shell: bash
+        run: python -m abi3audit --strict --summary dist/*.whl
 
   sdist:
     name: Build source distribution
@@ -194,7 +288,12 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [linux-wheels, macos-wheels, windows-wheels, sdist]
+    needs:
+      - audit-wheels
+      - linux-wheel-smoke
+      - macos-wheel-smoke
+      - windows-wheel-smoke
+      - sdist
     environment: pypi
     timeout-minutes: 15
     permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "foghttp"
 version = "0.3.5"
+description = "Observable Rust-powered HTTP client for Python services."
 edition = "2021"
+homepage = "https://github.com/AmberFog/foghttp"
 license = "MIT"
+publish = false
+repository = "https://github.com/AmberFog/foghttp"
 
 [lib]
 name = "foghttp"
@@ -46,6 +50,7 @@ features = [
 
 [dependencies.pyo3]
 version = "0.29.0"
+features = ["abi3-py311"]
 
 [dependencies.rustls]
 version = "0.23.41"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Runtime requirements:
 - Python `>=3.11`
 - `orjson>=3.11,<4`
 
+Published CPython wheels use the stable `cp311-abi3` ABI: each supported
+OS/architecture pair has one wheel for Python 3.11 and newer. The release
+pipeline currently installs and exercises those wheels on GIL-enabled CPython
+3.11 through 3.14. See [Packaging and Python compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/packaging.md)
+for the complete wheel matrix and validation policy.
+
 ## Quick Start
 
 ```python
@@ -130,6 +136,7 @@ async with foghttp.AsyncClient() as client:
 - [Quickstart](https://github.com/AmberFog/foghttp/blob/main/docs/quickstart.md)
 - [Request builder compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/request-builder.md)
 - [Client lifecycle](https://github.com/AmberFog/foghttp/blob/main/docs/lifecycle.md)
+- [Packaging and Python compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/packaging.md)
 - [Timeout model](https://github.com/AmberFog/foghttp/blob/main/docs/timeouts.md)
 - [Upload typing contracts](https://github.com/AmberFog/foghttp/blob/main/docs/upload-types.md)
 - [Telemetry contract](https://github.com/AmberFog/foghttp/blob/main/docs/telemetry.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - [Quickstart](./quickstart.md)
 - [Request builder compatibility](./request-builder.md)
 - [Client lifecycle](./lifecycle.md)
+- [Packaging and Python compatibility](./packaging.md)
 - [Timeout model](./timeouts.md)
 - [Upload typing contracts](./upload-types.md)
 - [Telemetry contract](./telemetry.md)

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -67,6 +67,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 
 | Feature | Current behavior |
 |---|---|
+| CPython wheel ABI | Published wheels use `cp311-abi3`; the release pipeline validates the same native wheel on GIL-enabled CPython 3.11 through 3.14 for each natively runnable OS/architecture target |
+| Free-threaded CPython | Not supported by the current `abi3` wheels; PyO3's separate `abi3t` stable ABI starts at Python 3.15 and requires its own adoption and validation decision |
 | Streaming response decompression | Not available; buffered responses support transparent decoding |
 | Multipart uploads | Available through `files=` for bytes-like parts, binary file-like objects, direct byte streams, and byte-stream factories |
 | `files=` | Available; can be combined with mapping or repeated-pair `data=` form fields, but not with raw `data=`, `content=`, or `json=` |

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,55 @@
+# Packaging And Python Compatibility
+
+FogHTTP ships a Rust extension built with PyO3. Published CPython wheels target
+the stable `cp311-abi3` ABI, matching the package minimum of Python 3.11. One
+wheel per supported operating-system and architecture pair can therefore be
+installed by GIL-enabled CPython 3.11 and newer instead of building a separate
+wheel for every CPython minor version.
+
+## Release Matrix
+
+The release workflow builds these wheel artifacts once per release:
+
+| Platform | Architectures | Install smoke |
+|---|---|---|
+| Linux (`manylinux2014`) | `x86_64`, `aarch64` | The `x86_64` wheel is installed on CPython 3.11-3.14; `aarch64` is cross-built and ABI-audited |
+| macOS | `x86_64`, `aarch64` | Each wheel is installed on CPython 3.11-3.14 on its native runner |
+| Windows | `x64` | The wheel is installed on CPython 3.11-3.14 |
+
+A source distribution is published alongside the wheels. The supported
+OS/architecture set is independent from the stable-ABI decision.
+
+## Trade-offs
+
+The stable ABI reduces native release compilations from twenty to five and
+tests compatibility against the artifact users will actually install. It also
+constrains FogHTTP to PyO3's Python 3.11 Limited API surface. PyO3 cannot use
+every CPython-version-specific API or optimization in this mode, so FogHTTP
+does not treat abi3 itself as a performance improvement. Runtime performance
+claims remain subject to the project's benchmark suite and measured evidence.
+
+## Validation Policy
+
+The `abi3-py311` feature is enabled in the normal Cargo dependency graph, not
+only in the release command. Rust checks therefore reject use of a CPython API
+outside PyO3's Python 3.11 Limited API surface before release.
+
+Pull-request CI builds one Linux `cp311-abi3` wheel, audits it with
+`abi3audit --strict`, and installs that exact artifact on CPython 3.11-3.14.
+The release workflow repeats the ABI audit for every platform wheel and runs
+the install smoke described above. The smoke exercises imports, URL handling,
+and real sync and async requests against a local HTTP server. Native builds use
+`Cargo.lock` with `maturin --locked` so Rust dependency resolution cannot drift
+in CI or during a release.
+
+Python versions newer than the currently tested 3.11-3.14 range may be ABI
+compatible, but they are not part of the release compatibility claim until
+they enter the CI matrix.
+
+## Current Boundary
+
+The current wheels target the classic `abi3` ABI for GIL-enabled CPython. That
+ABI cannot be loaded by free-threaded CPython. PyO3 also supports the separate
+`abi3t` stable ABI starting at Python 3.15, but adopting it requires its own
+wheel strategy and validation matrix. FogHTTP does not publish `abi3t` wheels
+today.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ classifiers = [
     "Framework :: AsyncIO",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Rust",
     "Topic :: Internet :: WWW/HTTP",
 ]


### PR DESCRIPTION
Enable the PyO3 limited API, reduce native release builds to one wheel per platform and architecture, and validate shared wheels across CPython 3.11-3.14.

Add strict ABI auditing, locked native builds, packaging metadata, sdist verification, and compatibility documentation. Refs: #99