### PR TITLE
chore(release): prepare 0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "brotli",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foghttp"
-version = "0.3.5"
+version = "0.3.6"
 description = "Observable Rust-powered HTTP client for Python services."
 edition = "2021"
 homepage = "https://github.com/AmberFog/foghttp"

--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - sync and asyncio clients with the same request model
 - explicit `close()`/`aclose()` lifecycle for Rust transport resources
 - graceful sync `close()` for in-flight requests and cancellable async requests
-- global/per-origin request backpressure, per-origin acquire pressure stats, and
-  stuck request diagnostics
+- bounded global/per-origin request backpressure, FIFO pending-acquire limits,
+  explicit HTTP/1.1 connection caps, and per-origin pressure diagnostics
 - typed telemetry event hooks with redacted request/response lifecycle events
 - versioned telemetry snapshots that separate alert-oriented stats from
   diagnostic dump APIs
 - opt-in async lifecycle debug snapshots for staging and tests
-- shared Tokio runtime by default, with opt-in dedicated runtime worker tuning
+- lazy process-wide shared Tokio runtime by default, opt-in dedicated runtime
+  tuning, and fail-closed client ownership across `fork()`
 - focused HTTP surface for JSON, form, streaming upload, and multipart API
   workloads in internal services, workers, and benchmarks
 
@@ -117,8 +118,9 @@ async with foghttp.AsyncClient() as client:
   custom-only CA trust
 - graceful sync `close()` that waits for in-flight sync requests
 - async request cancellation that aborts the in-flight Rust request
-- global and per-origin request backpressure, per-origin acquire pressure
-  snapshots, stuck request diagnostics, and HTTP/1.1 over HTTP/HTTPS
+- bounded global and per-origin request slots with a bounded FIFO pending queue
+- opt-in global/per-origin HTTP/1.1 connection caps with separate connection
+  acquire pressure and idle lifecycle diagnostics
 - opt-in typed telemetry event hooks for request, redirect, response headers,
   response body, and request completion lifecycle
 - versioned telemetry snapshot metadata for `stats()`, `dump_transport_state()`,
@@ -160,7 +162,8 @@ available through `proxy=` and `trust_env=True` when the proxy endpoint itself
 uses `http://`.
 Cookies, auth helpers, HTTP/2, automatic `Accept-Encoding` negotiation,
 streaming decompression, and per-request connect timeout reconfiguration are
-planned for later versions.
+planned for later versions. Physical connection caps currently apply to the
+HTTP/1.1 connector path; HTTP/2 will require separate stream-level limits.
 Response body read timeout is available for buffered and streaming response
 bodies; request body write timeout is available for buffered and streaming
 request bodies. Socket lifecycle telemetry is available for the current HTTP/1

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ features:
     details: "Use Client in scripts and workers, or AsyncClient for high-concurrency asyncio workloads."
 
   - title: "Focused MVP"
-    details: "FogHTTP is intentionally small today: buffered responses with gzip/deflate/br decoding, sync and async bytes/text/line streaming, JSON, form-urlencoded data, streaming and multipart uploads, base URL clients, default headers and params, redirects, prepared requests, async cancellation, global and per-origin request limits, and request metadata."
+    details: "FogHTTP is intentionally small today: buffered responses with gzip/deflate/br decoding, sync and async bytes/text/line streaming, JSON, form-urlencoded data, streaming and multipart uploads, base URL clients, redirects, async cancellation, bounded request queues, explicit HTTP/1.1 connection caps, and transport diagnostics."
 ---
 
 # FogHTTP Documentation
@@ -44,7 +44,8 @@ FogHTTP is designed around a few engineering priorities:
 
 - one API shape for sync scripts, workers, and asyncio services
 - Rust-backed HTTP/1.1 transport with explicit lifecycle and runtime-mode control
-- shared Tokio runtime by default, with opt-in dedicated runtime worker tuning
+- lazy process-wide shared Tokio runtime by default, opt-in dedicated runtime
+  tuning, and fail-closed client ownership across `fork()`
 - buffered JSON, form, and bytes workflows that are simple to reason about
 - transparent `gzip`, `deflate`, and `br` decoding for buffered responses
 - sync and async bytes/text/line response streaming with explicit
@@ -54,8 +55,9 @@ FogHTTP is designed around a few engineering priorities:
 - redirect history and final request metadata for debugging
 - HTTPS with default WebPKI roots, explicit custom CA certificates, and
   custom-only CA trust
-- global and per-origin request backpressure with per-origin acquire pressure
-  snapshots and stuck request diagnostics for operational visibility
+- bounded global and per-origin request slots with a bounded FIFO pending queue
+- opt-in global/per-origin HTTP/1.1 connection caps with separate acquire
+  pressure, idle lifecycle snapshots, and stuck request diagnostics
 - opt-in typed telemetry event hooks with redacted request/response lifecycle
   events
 - versioned telemetry snapshots that separate alert-oriented stats from
@@ -121,9 +123,10 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - documented lazy transport creation, graceful sync close, async request
   cancellation, and explicit client lifecycle
 - documented buffered timeout model with pool and total deadline behavior
-- global active request limits, per-origin active request limits, pending
-  acquire limits, per-origin acquire pressure snapshots, and stuck request
-  diagnostics
+- global/per-origin active request limits, a bounded FIFO pending acquire queue,
+  per-origin pressure snapshots, and stuck request diagnostics
+- opt-in global/per-origin HTTP/1.1 connection caps with separate connection
+  acquire and idle lifecycle telemetry
 - opt-in typed telemetry event hooks for request, redirect, response headers,
   response body, and request completion lifecycle
 - versioned telemetry snapshot metadata for `stats()`, `dump_transport_state()`,

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -46,8 +46,10 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
   `SSL_CERT_FILE`; see
   [Proxy and trust_env](./proxies.md)
 - async request cancellation that aborts the in-flight Rust request
-- global active request limit, per-origin active request limit, pending acquire
-  limit, request stats, and stuck request pool diagnostics
+- global/per-origin active request limits, a bounded FIFO pending acquire queue,
+  request-slot pressure stats, and stuck request pool diagnostics
+- opt-in global/per-origin HTTP/1.1 physical connection caps with separate
+  connection-acquire pressure and idle lifecycle diagnostics
 - opt-in typed telemetry event hooks for request, redirect, response headers,
   response body, and request completion lifecycle
 - opt-in async lifecycle debug snapshots for active async request handles,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "foghttp"
-version = "0.3.5"
+version = "0.3.6"
 description = "Observable Rust-powered HTTP client for Python services."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
- bump Python and Rust package metadata to 0.3.6
- refresh resource control, lifecycle, and limitations documentation
- document runtime, connection limits, QUERY, and abi3 release changes
- regenerate Python and Rust lock files