### PR TITLE
feat(policy): add lightweight transport policy hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ async with foghttp.AsyncClient() as client:
   acquire pressure and idle lifecycle diagnostics
 - opt-in typed telemetry event hooks for request, redirect, response headers,
   response body, and request completion lifecycle
+- opt-in typed transport policy hooks for lightweight request admission and
+  response-head checks without default-path Python callbacks
 - versioned telemetry snapshot metadata for `stats()`, `dump_transport_state()`,
   and `dump_pool_diagnostics()`
 - opt-in async lifecycle debug mode for active request snapshots, strict leak
@@ -141,6 +143,7 @@ async with foghttp.AsyncClient() as client:
 - [Packaging and Python compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/packaging.md)
 - [Timeout model](https://github.com/AmberFog/foghttp/blob/main/docs/timeouts.md)
 - [Upload typing contracts](https://github.com/AmberFog/foghttp/blob/main/docs/upload-types.md)
+- [Transport policy hooks](https://github.com/AmberFog/foghttp/blob/main/docs/policy-hooks.md)
 - [Telemetry contract](https://github.com/AmberFog/foghttp/blob/main/docs/telemetry.md)
 - [Response streaming](https://github.com/AmberFog/foghttp/blob/main/docs/streaming.md)
 - [Proxy and trust_env](https://github.com/AmberFog/foghttp/blob/main/docs/proxies.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,8 @@ FogHTTP is designed around a few engineering priorities:
   pressure, idle lifecycle snapshots, and stuck request diagnostics
 - opt-in typed telemetry event hooks with redacted request/response lifecycle
   events
+- opt-in typed transport policy hooks for lightweight request admission and
+  response-head checks, with Rust-owned redirect safety
 - versioned telemetry snapshots that separate alert-oriented stats from
   diagnostic dump APIs
 - opt-in async lifecycle debug snapshots for tests, staging, and incident
@@ -76,6 +78,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - [Packaging and Python compatibility](./packaging.md)
 - [Timeout model](./timeouts.md)
 - [Upload typing contracts](./upload-types.md)
+- [Transport policy hooks](./policy-hooks.md)
 - [Telemetry contract](./telemetry.md)
 - [Response streaming](./streaming.md)
 - [TLS trust](./tls.md)
@@ -129,6 +132,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
   acquire and idle lifecycle telemetry
 - opt-in typed telemetry event hooks for request, redirect, response headers,
   response body, and request completion lifecycle
+- opt-in typed transport policy hooks with immutable request/response views and
+  no default-path Python callback
 - versioned telemetry snapshot metadata for `stats()`, `dump_transport_state()`,
   and `dump_pool_diagnostics()`
 - opt-in async lifecycle debug mode for active request snapshots and strict

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -52,6 +52,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
   connection-acquire pressure and idle lifecycle diagnostics
 - opt-in typed telemetry event hooks for request, redirect, response headers,
   response body, and request completion lifecycle
+- opt-in synchronous transport policy hooks with immutable request/response
+  snapshots and Rust-owned redirect safety
 - opt-in async lifecycle debug snapshots for active async request handles,
   pending transport pressure, strict test checks, and unclosed-client context
 - default per-response and aggregate buffered response memory limits
@@ -95,6 +97,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | separate read/write timeout semantics | `Timeouts.read` is implemented as a buffered and streamed response body progress timeout; `Timeouts.write` is implemented for buffered request body write progress and streaming upload chunk/write progress |
 | socket lifecycle telemetry granularity | `TransportStats` and `dump_transport_state()["origins"]` expose opened, open-failed, closed, reused, aborted, idle-timeout eviction, active, and idle tracked connection counters for the current HTTP/1 path; dedicated failed-reuse and close-reason taxonomy are not exposed yet because current connector hooks do not provide a stable reason signal |
 | telemetry hook granularity | `TelemetryConfig` currently dispatches Python-level request/response lifecycle events; lower-level Rust pool acquire and connection lifecycle event delivery is planned before Prometheus/OpenTelemetry exporters |
+| transport policy hook execution | `TransportPolicyHooks` callbacks are synchronous, inline, non-reentrant, and may run on Rust transport worker threads; `after_response_body` observes only redirect bodies consumed internally, not the final response body returned to the caller |
 | diagnostic snapshot transactionality | `stats()`, `dump_transport_state()`, and `dump_pool_diagnostics()` include `schema_version` and a monotonic `snapshot_sequence`, but the `dump_*` APIs remain diagnostic snapshots rather than lock-protected SLA transactions; use `stats()` for alert-oriented low-cardinality metrics |
 
 ## Practical Guidance

--- a/docs/policy-hooks.md
+++ b/docs/policy-hooks.md
@@ -1,0 +1,102 @@
+# Transport Policy Hooks
+
+FogHTTP exposes a small opt-in Python edge around its Rust-owned transport
+policy stages. It is intended for trusted, lightweight request admission and
+response-head policy checks. It is not a middleware framework and does not
+expose the internal transport adapter.
+
+The default is `policy_hooks=None`. In that mode the Rust bridge does not
+resolve callback or view objects, allocate hook snapshots, call Python, or
+build a runtime list of policies. Built-in proxy and redirect policies remain
+statically dispatched in Rust.
+
+## Configuration
+
+Hooks are configured per client and have the same contract for `Client` and
+`AsyncClient`, including buffered and streaming requests:
+
+```python
+import foghttp
+
+
+def allow_service_origins(request: foghttp.TransportPolicyRequest) -> None:
+    if foghttp.URL(request.url).origin != "https://api.example.com":
+        raise PermissionError("transport target is outside the service boundary")
+
+
+def reject_server_errors(response: foghttp.TransportPolicyResponse) -> None:
+    if response.status_code >= 500:
+        raise RuntimeError("upstream response rejected by transport policy")
+
+
+hooks = foghttp.TransportPolicyHooks(
+    before_send=allow_service_origins,
+    on_response_headers=reject_server_errors,
+)
+
+with foghttp.Client(policy_hooks=hooks) as client:
+    response = client.get("https://api.example.com/resource")
+```
+
+All callbacks are synchronous and must return `None`. Raising an exception
+rejects the current request and preserves that exception for the caller.
+Returning any other value raises `TypeError`; hook return values cannot mutate
+or replace transport state.
+
+## Stage Order
+
+| Hook | Ordering and scope |
+|---|---|
+| `before_send` | Runs for the initial request and every redirect hop after Rust has selected and validated the transport route, but before request-slot acquire. |
+| `on_response_headers` | Runs for every response after Rust has classified any redirect action and before FogHTTP consumes or returns the response body. |
+| `after_response_body` | Runs only for redirect response bodies consumed internally by FogHTTP. Rust first validates the redirect limit, replayability, scheme downgrade, header policy, and proxy boundary; the hook runs before the already validated mutation is applied. It does not run for the final body returned to the caller. |
+
+There is deliberately no error, timeout, or cancellation hook. Those stages
+remain unavailable until FogHTTP has a Rust-owned failure taxonomy and a real
+retry-policy consumer.
+
+## Snapshot Contract
+
+`TransportPolicyRequest` is an immutable snapshot with:
+
+- normalized uppercase `method`;
+- full normalized `url`;
+- `body` as `"empty"`, `"replayable"`, or `"non_replayable"`;
+- zero-based `redirect_hop`.
+
+`TransportPolicyResponse` contains the request snapshot, `status_code`, and an
+immutable tuple of response header pairs. Repeated values for the same header
+retain their order.
+
+The full URL and header values are available because trusted policy code may
+need them to make a decision. They can contain credentials or tokens and are
+not telemetry-safe data. Their `repr()` surfaces redact URL secrets and omit
+header values, but hook code must still avoid logging the raw attributes. Use
+[`TelemetryConfig`](./telemetry.md) when the goal is observability through
+redacted events rather than request admission.
+
+Snapshots contain no socket, permit, response body, cancellation handle, pool,
+or runtime reference. They are copies: changing them through Python escape
+hatches cannot alter the request or bypass Rust redirect and replayability
+checks.
+
+## Execution And Lifecycle
+
+Hooks run inline with transport policy evaluation. They may execute on FogHTTP
+transport worker threads and may be invoked concurrently by concurrent
+requests. A hook must therefore be fast, thread-safe, and independent of an
+asyncio event loop, thread-local state, or `contextvars` propagation.
+
+Do not perform blocking I/O, call back into FogHTTP, or re-enter the same client
+from a hook. Hook execution advances the wall clock used by later total-time
+checks, but a running Python callback is not preempted or independently bounded
+by FogHTTP timeouts. Callback failure unwinds through the normal request path
+so permits, response bodies, connections, upload providers, and request metrics
+retain their existing owners and cleanup behavior.
+
+## Stability Boundary
+
+`TransportPolicyHooks` and its immutable views are the deliberate public
+surface. `src/core/policy/`, PyO3 bridge classes, raw clients, connector types,
+and internal transport adapter Protocols remain implementation details and are
+not extension points.

--- a/docs/pyo3-boundary.md
+++ b/docs/pyo3-boundary.md
@@ -47,9 +47,11 @@ buffered requests:
 ## Internal Request/Response Policy Seam
 
 `src/core/policy/` is an internal, unstable seam for built-in transport
-policies. It is not a public middleware API and does not expose Python hooks.
-The default request path performs no Python callback, dynamic dispatch, or
-policy-list allocation.
+policies. It is not a public middleware API. The optional
+`TransportPolicyHooks` bridge observes typed copies at selected stage edges;
+it does not expose the core pipeline or transport adapter. The default request
+path performs no Python callback, dynamic dispatch, policy-list allocation, or
+hook-snapshot construction.
 
 Policy stages run in this order:
 
@@ -74,6 +76,13 @@ userinfo, path, query parameters, or fragments.
 Error and timeout policy stages are intentionally absent until the retry work
 defines a Rust-owned failure taxonomy. Core policy code must not accept or
 return `PyErr` merely to reserve a future hook.
+
+The PyO3 bridge lives outside `src/core/policy/`. It invokes only callbacks
+resolved when `RawClient` is created, rejects non-`None` callback returns, and
+passes immutable Python snapshots without transport resources. Built-in
+validation runs before a Python hook can veto a redirect mutation. See
+[Transport policy hooks](./policy-hooks.md) for the public execution and
+threading contract.
 
 ## Review Checklist
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -713,6 +713,28 @@ monotonic `snapshot_sequence` within one Rust transport lifetime. Use
 `TransportStats` for dashboards and alert-oriented metrics; see
 [Telemetry contract](./telemetry.md) for the current guarantees.
 
+For trusted lightweight admission checks, configure synchronous transport
+policy hooks. The hook receives the full normalized target, may reject by
+raising, and cannot mutate transport state:
+
+```python
+def require_https(request: foghttp.TransportPolicyRequest) -> None:
+    if foghttp.URL(request.url).scheme != "https":
+        raise PermissionError("HTTPS is required")
+
+
+hooks = foghttp.TransportPolicyHooks(before_send=require_https)
+
+with foghttp.Client(policy_hooks=hooks) as client:
+    response = client.get("https://httpbin.org/get")
+```
+
+Hooks run inline and can execute on transport worker threads, so they must be
+fast, synchronous, thread-safe, and non-reentrant. Their snapshots are not
+telemetry-safe: full URLs and response header values may contain secrets. See
+[Transport policy hooks](./policy-hooks.md) for stage ordering, redirect-body
+scope, error propagation, and lifecycle constraints.
+
 For opt-in event hooks, pass a typed telemetry config. Hooks receive redacted
 `TelemetryEvent` objects and are intended for logging/tracing bridges, not for
 mutating requests or responses. Hooks run inline, so keep sinks fast and

--- a/foghttp/__init__.py
+++ b/foghttp/__init__.py
@@ -43,6 +43,10 @@ __all__ = (
     "TimeoutError",
     "TimeoutPhase",
     "Timeouts",
+    "TransportPolicyBodyState",
+    "TransportPolicyHooks",
+    "TransportPolicyRequest",
+    "TransportPolicyResponse",
     "TransportState",
     "TransportStats",
     "UnclosedClientError",
@@ -81,6 +85,12 @@ from .lifecycle_debug import (
     AsyncLifecycleDebugSnapshot,
 )
 from .limits import Limits
+from .policy import (
+    TransportPolicyBodyState,
+    TransportPolicyHooks,
+    TransportPolicyRequest,
+    TransportPolicyResponse,
+)
 from .pool_diagnostics import OriginPoolDiagnostics, PoolBlockingReason, PoolDiagnostics
 from .request import Request
 from .request_info import RequestInfo

--- a/foghttp/_client/config.py
+++ b/foghttp/_client/config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from ..lifecycle_debug import AsyncLifecycleDebugConfig
 from ..limits import Limits
+from ..policy import TransportPolicyHooks
 from ..telemetry import TelemetryConfig
 from ..timeouts import Timeouts
 from ..tls import TLSConfig
@@ -37,6 +38,7 @@ class ClientConfig:
     https_proxy: ProxyUrl | None
     runtime: RuntimeMode
     runtime_workers: int | None
+    policy_hooks: TransportPolicyHooks | None
     telemetry: TelemetryConfig | None
     lifecycle_debug: AsyncLifecycleDebugConfig | None
     request_defaults: RequestBuildDefaults
@@ -69,6 +71,9 @@ class ClientConfig:
             https_proxy=proxy_resolver.routing_proxy("https"),
             runtime=runtime_mode(options.runtime, options.runtime_workers),
             runtime_workers=options.runtime_workers,
+            policy_hooks=(
+                options.policy_hooks if options.policy_hooks is not None and options.policy_hooks.enabled else None
+            ),
             telemetry=options.telemetry,
             lifecycle_debug=options.lifecycle_debug,
             request_defaults=(

--- a/foghttp/_client/options.py
+++ b/foghttp/_client/options.py
@@ -10,6 +10,7 @@ from ..messages import (
     HTTP_VERSION_UNSUPPORTED,
     MAX_REDIRECTS_INVALID,
 )
+from ..policy import TransportPolicyHooks
 from ..telemetry import TelemetryConfig
 from ..timeouts import Timeouts
 from ..tls import TLSConfig
@@ -34,6 +35,7 @@ class ClientOptions:
     tls: TLSConfig | None
     runtime: str | None
     runtime_workers: int | None
+    policy_hooks: TransportPolicyHooks | None
     telemetry: TelemetryConfig | None
     lifecycle_debug: AsyncLifecycleDebugConfig | None
 

--- a/foghttp/_client/raw/lifecycle.py
+++ b/foghttp/_client/raw/lifecycle.py
@@ -39,6 +39,7 @@ def create_raw_client(
             http_proxy_authorization=basic_proxy_authorization(config.http_proxy),
             https_proxy_url=None if config.https_proxy is None else config.https_proxy.endpoint_url,
             https_proxy_authorization=basic_proxy_authorization(config.https_proxy),
+            policy_hooks=config.policy_hooks,
         )
     except _foghttp.FogHttpError as exc:
         raise ValueError(str(exc)) from exc

--- a/foghttp/_foghttp.pyi
+++ b/foghttp/_foghttp.pyi
@@ -367,6 +367,7 @@ class RawClient:
         http_proxy_authorization: str | None,
         https_proxy_url: str | None,
         https_proxy_authorization: str | None,
+        policy_hooks: object | None,
     ) -> None: ...
     def request(
         self,

--- a/foghttp/async_client.py
+++ b/foghttp/async_client.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 
 import foghttp._foghttp as _foghttp  # noqa: PLR0402
 
+from ._client import transport
 from ._client.config import ClientConfig
 from ._client.constants import DEFAULT_MAX_REDIRECTS
 from ._client.core import ClientCore
@@ -25,7 +26,6 @@ from ._client.telemetry import (
     emit_stream_response_headers_telemetry,
     start_request_telemetry,
 )
-from ._client.transport import AsyncTransport, RawAsyncTransport
 from ._upload_body import AsyncRequestContent
 from .errors import LifecycleError
 from .headers import HeaderSource
@@ -36,6 +36,7 @@ from .lifecycle_debug import (
 )
 from .limits import Limits
 from .methods import DELETE, GET, HEAD, PATCH, POST, PUT, QUERY
+from .policy import TransportPolicyHooks
 from .request import Request
 from .response import Response
 from .stream_response import AsyncStreamResponse
@@ -48,7 +49,7 @@ from .url import URL
 
 
 class AsyncClient(ClientCore):
-    _transport: AsyncTransport
+    _transport: transport.AsyncTransport
 
     def __init__(
         self,
@@ -67,6 +68,7 @@ class AsyncClient(ClientCore):
         tls: TLSConfig | None = None,
         runtime: Literal["shared", "dedicated"] | None = None,
         runtime_workers: int | None = None,
+        policy_hooks: TransportPolicyHooks | None = None,
         telemetry: TelemetryConfig | None = None,
         lifecycle_debug: AsyncLifecycleDebugConfig | None = None,
     ) -> None:
@@ -87,6 +89,7 @@ class AsyncClient(ClientCore):
                     tls=tls,
                     runtime=runtime,
                     runtime_workers=runtime_workers,
+                    policy_hooks=policy_hooks,
                     telemetry=telemetry,
                     lifecycle_debug=lifecycle_debug,
                 ),
@@ -346,8 +349,11 @@ class AsyncClient(ClientCore):
             timeout=timeout,
         )
 
-    def _create_transport(self) -> AsyncTransport:
-        return RawAsyncTransport(self._raw_client, proxy_resolver=self._config.proxy_resolver)
+    def _create_transport(self) -> transport.AsyncTransport:
+        return transport.RawAsyncTransport(
+            self._raw_client,
+            proxy_resolver=self._config.proxy_resolver,
+        )
 
     def _close(self, *, raise_strict_lifecycle_errors: bool) -> None:
         if not self._is_current_process():

--- a/foghttp/client.py
+++ b/foghttp/client.py
@@ -23,6 +23,7 @@ from ._upload_body import SyncRequestContent
 from .headers import HeaderSource
 from .limits import Limits
 from .methods import DELETE, GET, HEAD, PATCH, POST, PUT, QUERY
+from .policy import TransportPolicyHooks
 from .request import Request
 from .response import Response
 from .stream_response import StreamResponse
@@ -58,6 +59,7 @@ class Client(ClientCore):
         tls: TLSConfig | None = None,
         runtime: Literal["shared", "dedicated"] | None = None,
         runtime_workers: int | None = None,
+        policy_hooks: TransportPolicyHooks | None = None,
         telemetry: TelemetryConfig | None = None,
     ) -> None:
         super().__init__(
@@ -77,6 +79,7 @@ class Client(ClientCore):
                     tls=tls,
                     runtime=runtime,
                     runtime_workers=runtime_workers,
+                    policy_hooks=policy_hooks,
                     telemetry=telemetry,
                     lifecycle_debug=None,
                 ),

--- a/foghttp/policy.py
+++ b/foghttp/policy.py
@@ -1,0 +1,100 @@
+__all__ = (
+    "TransportPolicyBodyState",
+    "TransportPolicyHooks",
+    "TransportPolicyRequest",
+    "TransportPolicyResponse",
+)
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from inspect import isasyncgenfunction, iscoroutinefunction
+from typing import Literal, TypeAlias
+
+from ._redaction import redact_url
+
+
+TransportPolicyBodyState: TypeAlias = Literal[
+    "empty",
+    "replayable",
+    "non_replayable",
+]
+
+
+@dataclass(frozen=True, repr=False, slots=True)
+class TransportPolicyRequest:
+    """Immutable request snapshot passed to an enabled transport policy hook."""
+
+    method: str
+    url: str
+    body: TransportPolicyBodyState
+    redirect_hop: int
+
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        method = self.method
+        url = redact_url(self.url)
+        body = self.body
+        redirect_hop = self.redirect_hop
+        return f"{class_name}(method={method!r}, url={url!r}, body={body!r}, redirect_hop={redirect_hop!r})"
+
+
+@dataclass(frozen=True, repr=False, slots=True)
+class TransportPolicyResponse:
+    """Immutable response-head snapshot passed to an enabled policy hook."""
+
+    request: TransportPolicyRequest
+    status_code: int
+    headers: tuple[tuple[str, str], ...]
+
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        request = self.request
+        status_code = self.status_code
+        header_count = len(self.headers)
+        return f"{class_name}(request={request!r}, status_code={status_code!r}, headers=<{header_count} headers>)"
+
+
+@dataclass(frozen=True, slots=True)
+class TransportPolicyHooks:
+    """Opt-in synchronous transport policy observers.
+
+    Hooks may reject a request by raising an exception. They must return
+    ``None`` and cannot mutate requests, responses, or transport resources.
+    """
+
+    before_send: Callable[[TransportPolicyRequest], None] | None = field(default=None, repr=False)
+    on_response_headers: Callable[[TransportPolicyResponse], None] | None = field(default=None, repr=False)
+    after_response_body: Callable[[TransportPolicyResponse], None] | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        _validate_hook("before_send", self.before_send)
+        _validate_hook("on_response_headers", self.on_response_headers)
+        _validate_hook("after_response_body", self.after_response_body)
+
+    @property
+    def enabled(self) -> bool:
+        return any(
+            hook is not None
+            for hook in (
+                self.before_send,
+                self.on_response_headers,
+                self.after_response_body,
+            )
+        )
+
+
+def _validate_hook(name: str, hook: object | None) -> None:
+    if hook is None:
+        return
+    if not callable(hook):
+        message = f"{name} transport policy hook must be callable or None"
+        raise TypeError(message)
+    hook_call = type(hook).__call__
+    if (
+        iscoroutinefunction(hook)
+        or isasyncgenfunction(hook)
+        or iscoroutinefunction(hook_call)
+        or isasyncgenfunction(hook_call)
+    ):
+        message = f"{name} transport policy hook must be synchronous"
+        raise TypeError(message)

--- a/src/py/client/mod.rs
+++ b/src/py/client/mod.rs
@@ -3,6 +3,7 @@ mod async_requests;
 mod future;
 mod lifecycle;
 mod options;
+mod policy_hooks;
 mod process;
 mod runtime;
 mod streams;
@@ -27,6 +28,7 @@ use crate::py::client::future::PythonFutureSetters;
 use crate::py::client::options::{
     validate_numeric_client_options, validate_request_timeouts, NumericClientOptions,
 };
+use crate::py::client::policy_hooks::PythonPolicyHooks;
 use crate::py::client::process::{client_used_after_fork, current_process_id, ProcessId};
 use crate::py::client::runtime::{parse_runtime_mode, ClientRuntime};
 use crate::py::client::streams::StreamRegistry;
@@ -57,6 +59,7 @@ pub struct RawClient {
     follow_redirects: bool,
     max_redirects: usize,
     proxy_authorization: Option<String>,
+    policy_hooks: Option<Arc<PythonPolicyHooks>>,
     process_id: ProcessId,
 }
 
@@ -85,13 +88,15 @@ impl RawClient {
         http_proxy_url,
         http_proxy_authorization,
         https_proxy_url,
-        https_proxy_authorization
+        https_proxy_authorization,
+        policy_hooks
     ))]
     #[allow(
         clippy::fn_params_excessive_bools,
         clippy::too_many_arguments,
+        clippy::too_many_lines,
         clippy::similar_names,
-        reason = "PyO3 constructor mirrors Python client options before transport grouping."
+        reason = "PyO3 constructor mirrors Python client options and resource construction."
     )]
     fn new(
         py: Python<'_>,
@@ -116,6 +121,7 @@ impl RawClient {
         http_proxy_authorization: Option<String>,
         https_proxy_url: Option<String>,
         https_proxy_authorization: Option<String>,
+        policy_hooks: Option<Py<PyAny>>,
     ) -> PyResult<Self> {
         validate_numeric_client_options(NumericClientOptions {
             max_active_requests,
@@ -129,6 +135,7 @@ impl RawClient {
             idle_timeout,
             connect_timeout,
         })?;
+        let policy_hooks = PythonPolicyHooks::from_config(py, policy_hooks)?;
 
         let runtime_mode = parse_runtime_mode(runtime)?;
         let metrics = Arc::new(Metrics::default());
@@ -217,6 +224,7 @@ impl RawClient {
             follow_redirects,
             max_redirects,
             proxy_authorization: http_proxy_authorization,
+            policy_hooks,
             process_id: current_process_id(),
         })
     }
@@ -265,6 +273,7 @@ impl RawClient {
         let follow_redirects = self.follow_redirects;
         let max_redirects = self.max_redirects;
         let proxy_authorization = self.proxy_authorization.clone();
+        let policy_hooks = self.policy_hooks.clone();
         self.metrics.request_started();
 
         let result = py.detach(|| {
@@ -291,6 +300,7 @@ impl RawClient {
                         buffered_body_budget,
                         follow_redirects,
                         max_redirects,
+                        policy_hooks,
                     },
                 )
                 .await
@@ -343,6 +353,7 @@ impl RawClient {
         let follow_redirects = self.follow_redirects;
         let max_redirects = self.max_redirects;
         let proxy_authorization = self.proxy_authorization.clone();
+        let policy_hooks = self.policy_hooks.clone();
         spawn_async_request(
             py,
             runtime,
@@ -370,6 +381,7 @@ impl RawClient {
                     buffered_body_budget,
                     follow_redirects,
                     max_redirects,
+                    policy_hooks,
                 },
             },
         )
@@ -421,6 +433,7 @@ impl RawClient {
         let follow_redirects = self.follow_redirects;
         let max_redirects = self.max_redirects;
         let proxy_authorization = self.proxy_authorization.clone();
+        let policy_hooks = self.policy_hooks.clone();
         let completion = RequestCompletion::default();
         let request_completion = completion.clone();
         let future_setters = self.future_setters.clone_ref(py);
@@ -453,6 +466,7 @@ impl RawClient {
                         buffered_body_budget,
                         follow_redirects,
                         max_redirects,
+                        policy_hooks,
                     },
                     request_completion,
                 )
@@ -508,6 +522,7 @@ impl RawClient {
         let follow_redirects = self.follow_redirects;
         let max_redirects = self.max_redirects;
         let proxy_authorization = self.proxy_authorization.clone();
+        let policy_hooks = self.policy_hooks.clone();
         spawn_async_stream_request(
             py,
             runtime,
@@ -536,6 +551,7 @@ impl RawClient {
                     buffered_body_budget,
                     follow_redirects,
                     max_redirects,
+                    policy_hooks,
                 },
             },
         )

--- a/src/py/client/policy_hooks.rs
+++ b/src/py/client/policy_hooks.rs
@@ -1,0 +1,160 @@
+use crate::core::policy::{PolicyRequest, RequestBodyPolicy, ResponseHead};
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyTuple};
+use std::sync::Arc;
+
+const POLICY_MODULE: &str = "foghttp.policy";
+const REQUEST_VIEW: &str = "TransportPolicyRequest";
+const RESPONSE_VIEW: &str = "TransportPolicyResponse";
+const HOOK_RETURN_ERROR: &str = "transport policy hooks must return None";
+
+pub(crate) struct PythonPolicyHooks {
+    before_send: Option<Py<PyAny>>,
+    on_response_headers: Option<Py<PyAny>>,
+    after_response_body: Option<Py<PyAny>>,
+    request_view: Py<PyAny>,
+    response_view: Py<PyAny>,
+}
+
+impl PythonPolicyHooks {
+    pub(crate) fn from_config(
+        py: Python<'_>,
+        config: Option<Py<PyAny>>,
+    ) -> PyResult<Option<Arc<Self>>> {
+        let Some(config) = config else {
+            return Ok(None);
+        };
+        let config = config.bind(py);
+        let before_send = optional_hook(config, "before_send")?;
+        let on_response_headers = optional_hook(config, "on_response_headers")?;
+        let after_response_body = optional_hook(config, "after_response_body")?;
+        if before_send.is_none() && on_response_headers.is_none() && after_response_body.is_none() {
+            return Ok(None);
+        }
+
+        let policy_module = py.import(POLICY_MODULE)?;
+        Ok(Some(Arc::new(Self {
+            before_send,
+            on_response_headers,
+            after_response_body,
+            request_view: policy_module.getattr(REQUEST_VIEW)?.unbind(),
+            response_view: policy_module.getattr(RESPONSE_VIEW)?.unbind(),
+        })))
+    }
+
+    pub(crate) fn before_send(
+        &self,
+        request: PolicyRequest<'_>,
+        redirect_hop: usize,
+    ) -> PyResult<()> {
+        let Some(callback) = self.before_send.as_ref() else {
+            return Ok(());
+        };
+        Python::attach(|py| {
+            let request = self.request_snapshot(py, request, redirect_hop)?;
+            call_hook(py, callback, request)
+        })
+    }
+
+    pub(crate) fn on_response_headers(
+        &self,
+        request: PolicyRequest<'_>,
+        response: ResponseHead<'_>,
+        redirect_hop: usize,
+    ) -> PyResult<()> {
+        let Some(callback) = self.on_response_headers.as_ref() else {
+            return Ok(());
+        };
+        Python::attach(|py| {
+            let response = self.response_snapshot(py, request, response, redirect_hop)?;
+            call_hook(py, callback, response)
+        })
+    }
+
+    pub(crate) fn after_response_body(
+        &self,
+        request: PolicyRequest<'_>,
+        response: ResponseHead<'_>,
+        redirect_hop: usize,
+    ) -> PyResult<()> {
+        let Some(callback) = self.after_response_body.as_ref() else {
+            return Ok(());
+        };
+        Python::attach(|py| {
+            let response = self.response_snapshot(py, request, response, redirect_hop)?;
+            call_hook(py, callback, response)
+        })
+    }
+
+    pub(crate) fn observes_response_body(&self) -> bool {
+        self.after_response_body.is_some()
+    }
+
+    fn request_snapshot(
+        &self,
+        py: Python<'_>,
+        request: PolicyRequest<'_>,
+        redirect_hop: usize,
+    ) -> PyResult<Py<PyAny>> {
+        self.request_view
+            .bind(py)
+            .call1((
+                request.method(),
+                request.url().as_str(),
+                request_body_state(request.body()),
+                redirect_hop,
+            ))
+            .map(Bound::unbind)
+    }
+
+    fn response_snapshot(
+        &self,
+        py: Python<'_>,
+        request: PolicyRequest<'_>,
+        response: ResponseHead<'_>,
+        redirect_hop: usize,
+    ) -> PyResult<Py<PyAny>> {
+        let request = self.request_snapshot(py, request, redirect_hop)?;
+        let headers = PyTuple::new(
+            py,
+            response
+                .headers()
+                .iter()
+                .map(|(name, value)| (name.as_str(), value.as_str())),
+        )?;
+        self.response_view
+            .bind(py)
+            .call1((request, response.status_code(), headers))
+            .map(Bound::unbind)
+    }
+}
+
+fn optional_hook(config: &Bound<'_, PyAny>, name: &str) -> PyResult<Option<Py<PyAny>>> {
+    let hook = config.getattr(name)?;
+    if hook.is_none() {
+        return Ok(None);
+    }
+    if !hook.is_callable() {
+        return Err(PyTypeError::new_err(format!(
+            "{name} transport policy hook must be callable or None",
+        )));
+    }
+    Ok(Some(hook.unbind()))
+}
+
+fn call_hook(py: Python<'_>, callback: &Py<PyAny>, view: Py<PyAny>) -> PyResult<()> {
+    let result = callback.bind(py).call1((view,))?;
+    if result.is_none() {
+        return Ok(());
+    }
+    Err(PyTypeError::new_err(HOOK_RETURN_ERROR))
+}
+
+fn request_body_state(body: RequestBodyPolicy) -> &'static str {
+    match body {
+        RequestBodyPolicy::Empty => "empty",
+        RequestBodyPolicy::NonReplayable => "non_replayable",
+        RequestBodyPolicy::Replayable => "replayable",
+    }
+}

--- a/src/py/client/transport/buffered.rs
+++ b/src/py/client/transport/buffered.rs
@@ -2,7 +2,7 @@ use super::client::TransportClients;
 use super::context::RawResponseContext;
 use super::errors::transport_error;
 use super::request::{RequestState, TransportRequest};
-use super::response::raw_response;
+use super::response::{raw_response, ResponseLifecycleGuards};
 use crate::core::client::{with_connection_limit_timeout, with_request_write_timeout};
 use crate::core::headers::response_headers;
 use crate::core::metrics::Metrics;
@@ -31,6 +31,7 @@ pub async fn send_request(
     loop {
         let (mut raw, response_action) = {
             let redirect_hop = history.len();
+            let route = state.transport_route(redirect_hop)?;
             let origin = state.origin();
             let acquire_timeout_context = TimeoutContext::new(
                 TimeoutPhase::PoolAcquire,
@@ -46,7 +47,6 @@ pub async fn send_request(
             .await
             .map_err(|_| timeout_error(&acquire_timeout_context, REQUEST_TOTAL_TIMEOUT))??;
             let origin_metrics = permit.origin_metrics();
-            let route = state.transport_route()?;
             let request_info = state.request_info();
 
             let response_headers_timeout_context = TimeoutContext::new(
@@ -74,12 +74,16 @@ pub async fn send_request(
             .map_err(|_| timeout_error(&response_headers_timeout_context, REQUEST_TOTAL_TIMEOUT))?
             .map_err(|err| transport_error(&err))?;
 
+            let response_lifecycle =
+                ResponseLifecycleGuards::new(&response, &metrics, &origin_metrics);
             let headers = response_headers(response.headers());
-            let response_action = state.on_response_headers(response.status().as_u16(), &headers);
+            let response_action =
+                state.on_response_headers(response.status().as_u16(), &headers, redirect_hop)?;
             let raw = raw_response(
                 response,
                 request_info,
                 headers,
+                response_lifecycle,
                 RawResponseContext {
                     started,
                     total_timeout: state.total_timeout,
@@ -87,8 +91,6 @@ pub async fn send_request(
                     max_response_body_size: state.max_response_body_size,
                     buffered_body_budget: state.buffered_body_budget.clone(),
                     origin: &origin,
-                    metrics: Arc::clone(&metrics),
-                    origin_metrics,
                     redirect_hop,
                 },
             )

--- a/src/py/client/transport/context.rs
+++ b/src/py/client/transport/context.rs
@@ -1,4 +1,4 @@
-use crate::core::metrics::{Metrics, OriginMetrics};
+use crate::core::metrics::Metrics;
 use crate::core::response::BufferedBodyBudget;
 use crate::py::client::acquire::AcquirePermit;
 use crate::py::client::async_requests::RequestCompletion;
@@ -16,8 +16,6 @@ pub(super) struct RawResponseContext<'a> {
     pub(super) max_response_body_size: Option<usize>,
     pub(super) buffered_body_budget: BufferedBodyBudget,
     pub(super) origin: &'a str,
-    pub(super) metrics: Arc<Metrics>,
-    pub(super) origin_metrics: Arc<OriginMetrics>,
     pub(super) redirect_hop: usize,
 }
 
@@ -25,7 +23,6 @@ pub(super) struct RawStreamResponseContext {
     pub(super) started: Instant,
     pub(super) read_timeout: f64,
     pub(super) origin: String,
-    pub(super) origin_metrics: Arc<OriginMetrics>,
     pub(super) metrics: Arc<Metrics>,
     pub(super) active_streams: StreamRegistry,
     pub(super) runtime_handle: Handle,

--- a/src/py/client/transport/request.rs
+++ b/src/py/client/transport/request.rs
@@ -10,9 +10,11 @@ use crate::core::request::{RequestBodyParts, RequestParts};
 use crate::core::response::BufferedBodyBudget;
 use crate::core::url::HttpUrl;
 use crate::errors::FogHttpError;
+use crate::py::client::policy_hooks::PythonPolicyHooks;
 use crate::py::client::upload_body::RawUploadBody;
 use crate::py::response::RawRequestInfo;
 use pyo3::prelude::*;
+use std::sync::Arc;
 use std::time::Duration;
 
 pub struct TransportRequest {
@@ -32,6 +34,7 @@ pub struct TransportRequest {
     pub buffered_body_budget: BufferedBodyBudget,
     pub follow_redirects: bool,
     pub max_redirects: usize,
+    pub policy_hooks: Option<Arc<PythonPolicyHooks>>,
 }
 
 pub(super) struct RequestState {
@@ -41,6 +44,7 @@ pub(super) struct RequestState {
     pub(super) body: RequestBodyState,
     pub(super) body_policy: RequestBodyPolicy,
     policy: PolicyPipeline,
+    policy_hooks: Option<Arc<PythonPolicyHooks>>,
     pub(super) proxy_authorization: Option<String>,
     pub(super) total_timeout: f64,
     pub(super) read_timeout: f64,
@@ -115,34 +119,66 @@ impl RequestState {
         ))
     }
 
-    pub(super) fn transport_route(&self) -> PyResult<TransportRoute> {
-        self.policy
-            .before_send(self.policy_request())
-            .map_err(|error| policy_error(&error))
+    pub(super) fn transport_route(&self, redirect_hop: usize) -> PyResult<TransportRoute> {
+        let request = self.policy_request();
+        let route = self
+            .policy
+            .before_send(request)
+            .map_err(|error| policy_error(&error))?;
+        if let Some(hooks) = self.policy_hooks.as_ref() {
+            hooks.before_send(request, redirect_hop)?;
+        }
+        Ok(route)
     }
 
     pub(super) fn on_response_headers(
         &self,
         status_code: u16,
         headers: &HeaderPairs,
-    ) -> Option<ResponsePolicyAction> {
-        self.policy.on_response_headers(
-            self.policy_request(),
-            ResponseHead::new(status_code, headers),
-        )
+        redirect_hop: usize,
+    ) -> PyResult<Option<PendingResponsePolicyAction>> {
+        let request = self.policy_request();
+        let response = ResponseHead::new(status_code, headers);
+        let action = self.policy.on_response_headers(request, response);
+        if let Some(hooks) = self.policy_hooks.as_ref() {
+            hooks.on_response_headers(request, response, redirect_hop)?;
+        }
+        Ok(action.map(|action| PendingResponsePolicyAction {
+            action,
+            response: self.response_body_snapshot(status_code, headers),
+        }))
     }
 
     pub(super) fn after_response_body(
         &mut self,
-        action: ResponsePolicyAction,
+        pending: PendingResponsePolicyAction,
         completed_redirects: usize,
     ) -> PyResult<()> {
+        let PendingResponsePolicyAction { action, response } = pending;
+        let request = self.policy_request();
         let mutation = self
             .policy
-            .after_response_body(self.policy_request(), action, completed_redirects)
+            .after_response_body(request, action, completed_redirects)
             .map_err(|error| policy_error(&error))?;
+        if let (Some(hooks), Some(response)) = (self.policy_hooks.as_ref(), response.as_ref()) {
+            hooks.after_response_body(request, response.as_view(), completed_redirects)?;
+        }
         self.apply_policy_mutation(mutation);
         Ok(())
+    }
+
+    fn response_body_snapshot(
+        &self,
+        status_code: u16,
+        headers: &HeaderPairs,
+    ) -> Option<ResponseSnapshot> {
+        self.policy_hooks
+            .as_ref()
+            .filter(|hooks| hooks.observes_response_body())
+            .map(|_| ResponseSnapshot {
+                headers: headers.clone(),
+                status_code,
+            })
     }
 
     fn policy_request(&self) -> PolicyRequest<'_> {
@@ -194,6 +230,7 @@ impl RequestState {
             body,
             body_policy,
             policy,
+            policy_hooks: parts.policy_hooks,
             proxy_authorization: parts.proxy_authorization,
             total_timeout: parts.total_timeout,
             read_timeout: parts.read_timeout,
@@ -202,6 +239,22 @@ impl RequestState {
             max_response_body_size: parts.max_response_body_size,
             buffered_body_budget: parts.buffered_body_budget,
         })
+    }
+}
+
+pub(super) struct PendingResponsePolicyAction {
+    action: ResponsePolicyAction,
+    response: Option<ResponseSnapshot>,
+}
+
+struct ResponseSnapshot {
+    headers: HeaderPairs,
+    status_code: u16,
+}
+
+impl ResponseSnapshot {
+    fn as_view(&self) -> ResponseHead<'_> {
+        ResponseHead::new(self.status_code, &self.headers)
     }
 }
 

--- a/src/py/client/transport/response.rs
+++ b/src/py/client/transport/response.rs
@@ -1,7 +1,8 @@
 use super::body::{collect_response_body, response_body_can_be_decoded};
 use super::context::{RawResponseContext, RawStreamResponseContext};
-use crate::core::client::ConnectionTelemetry;
+use crate::core::client::{ConnectionTelemetry, ConnectionUseGuard};
 use crate::core::headers::HeaderPairs;
+use crate::core::metrics::{Metrics, OriginMetrics, ResponseBodyLifecycleOutcome};
 use crate::core::numeric::duration_from_secs;
 use crate::core::response::{decode_body, decoded_response_headers, response_body_decoding_plan};
 use crate::py::client::lifecycle::{successful_response_body_outcome, ResponseBodyLifecycle};
@@ -12,33 +13,58 @@ use hyper::Response;
 use pyo3::prelude::*;
 use std::sync::Arc;
 
+pub(super) struct ResponseLifecycleGuards {
+    body: ResponseBodyLifecycle,
+    connection_use: Option<ConnectionUseGuard>,
+    successful_body_outcome: ResponseBodyLifecycleOutcome,
+}
+
+impl ResponseLifecycleGuards {
+    pub(super) fn new(
+        response: &Response<Incoming>,
+        metrics: &Arc<Metrics>,
+        origin_metrics: &Arc<OriginMetrics>,
+    ) -> Self {
+        Self {
+            body: ResponseBodyLifecycle::new(Arc::clone(metrics), Arc::clone(origin_metrics)),
+            connection_use: response
+                .extensions()
+                .get::<ConnectionTelemetry>()
+                .map(ConnectionTelemetry::response_started),
+            successful_body_outcome: successful_response_body_outcome(
+                response.version(),
+                response.headers(),
+            ),
+        }
+    }
+
+    fn finish_connection(&mut self) {
+        if let Some(connection_use) = self.connection_use.take() {
+            connection_use.finish(self.successful_body_outcome);
+        }
+    }
+
+    fn finish_body(&mut self) {
+        self.body.finish(self.successful_body_outcome);
+    }
+}
+
 pub(super) async fn raw_response(
     response: Response<Incoming>,
     request: RawRequestInfo,
     headers: HeaderPairs,
+    mut lifecycle: ResponseLifecycleGuards,
     context: RawResponseContext<'_>,
 ) -> PyResult<RawResponse> {
     let status = response.status();
     let status_code = status.as_u16();
     let http_version = format!("{:?}", response.version());
-    let successful_body_outcome =
-        successful_response_body_outcome(response.version(), response.headers());
     let decoding_plan = response_body_can_be_decoded(&request.method, status)
         .then(|| response_body_decoding_plan(response.headers()));
-    let mut connection_use = response
-        .extensions()
-        .get::<ConnectionTelemetry>()
-        .map(ConnectionTelemetry::response_started);
-    let mut lifecycle = ResponseBodyLifecycle::new(
-        Arc::clone(&context.metrics),
-        Arc::clone(&context.origin_metrics),
-    );
     let read_timeout = duration_from_secs("Timeouts.read", context.read_timeout)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
     let collected = collect_response_body(response.into_body(), &context, read_timeout).await?;
-    if let Some(connection_use) = connection_use.take() {
-        connection_use.finish(successful_body_outcome);
-    }
+    lifecycle.finish_connection();
     let (headers, response_content, body_reservation) = if let Some(decoding_plan) = decoding_plan {
         let body = decode_body(collected, decoding_plan, context.max_response_body_size)?;
         (
@@ -49,7 +75,7 @@ pub(super) async fn raw_response(
     } else {
         (headers, collected.content, collected.reservation)
     };
-    lifecycle.finish(successful_body_outcome);
+    lifecycle.finish_body();
     let url = request.url.clone();
 
     Ok(RawResponse::from_parts(RawResponseParts {
@@ -69,20 +95,16 @@ pub(super) fn raw_stream_response(
     response: Response<Incoming>,
     request: RawRequestInfo,
     headers: HeaderPairs,
+    lifecycle: ResponseLifecycleGuards,
     context: RawStreamResponseContext,
 ) -> PyResult<RawStreamResponse> {
     let status_code = response.status().as_u16();
     let http_version = format!("{:?}", response.version());
-    let successful_body_outcome =
-        successful_response_body_outcome(response.version(), response.headers());
-    let connection_use = response
-        .extensions()
-        .get::<ConnectionTelemetry>()
-        .map(ConnectionTelemetry::response_started);
-    let lifecycle = ResponseBodyLifecycle::new(
-        Arc::clone(&context.metrics),
-        Arc::clone(&context.origin_metrics),
-    );
+    let ResponseLifecycleGuards {
+        body: lifecycle,
+        connection_use,
+        successful_body_outcome,
+    } = lifecycle;
     let read_timeout = duration_from_secs("Timeouts.read", context.read_timeout)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;
     let url = request.url.clone();

--- a/src/py/client/transport/streaming.rs
+++ b/src/py/client/transport/streaming.rs
@@ -2,7 +2,7 @@ use super::client::TransportClients;
 use super::context::{RawResponseContext, RawStreamResponseContext};
 use super::errors::transport_error;
 use super::request::{RequestState, TransportRequest};
-use super::response::{raw_response, raw_stream_response};
+use super::response::{raw_response, raw_stream_response, ResponseLifecycleGuards};
 use crate::core::client::{with_connection_limit_timeout, with_request_write_timeout};
 use crate::core::headers::response_headers;
 use crate::core::metrics::Metrics;
@@ -40,6 +40,7 @@ pub async fn send_stream_request(
 
     loop {
         let redirect_hop = history.len();
+        let route = state.transport_route(redirect_hop)?;
         let origin = state.origin();
         let acquire_timeout_context = TimeoutContext::new(
             TimeoutPhase::PoolAcquire,
@@ -62,22 +63,25 @@ pub async fn send_stream_request(
             redirect_hop,
             pool_timeout,
             started,
+            route,
         )
         .await?;
 
+        let response_lifecycle = ResponseLifecycleGuards::new(&response, &metrics, &origin_metrics);
         let headers = response_headers(response.headers());
-        let response_action = state.on_response_headers(response.status().as_u16(), &headers);
+        let response_action =
+            state.on_response_headers(response.status().as_u16(), &headers, redirect_hop)?;
 
         let Some(response_action) = response_action else {
             return raw_stream_response(
                 response,
                 request_info,
                 headers,
+                response_lifecycle,
                 RawStreamResponseContext {
                     started,
                     read_timeout: state.read_timeout,
                     origin,
-                    origin_metrics,
                     metrics,
                     active_streams,
                     runtime_handle,
@@ -94,6 +98,7 @@ pub async fn send_stream_request(
             response,
             request_info,
             headers,
+            response_lifecycle,
             RawResponseContext {
                 started,
                 total_timeout: state.total_timeout,
@@ -101,8 +106,6 @@ pub async fn send_stream_request(
                 max_response_body_size: state.max_response_body_size,
                 buffered_body_budget: state.buffered_body_budget.clone(),
                 origin: &origin,
-                metrics: Arc::clone(&metrics),
-                origin_metrics,
                 redirect_hop,
             },
         )
@@ -121,8 +124,8 @@ async fn send_current_hop(
     redirect_hop: usize,
     pool_timeout: f64,
     started: Instant,
+    route: crate::core::policy::TransportRoute,
 ) -> PyResult<(Response<Incoming>, crate::py::response::RawRequestInfo)> {
-    let route = state.transport_route()?;
     let request_info = state.request_info();
     let response_headers_timeout_context = TimeoutContext::new(
         TimeoutPhase::ResponseHeaders,

--- a/src/py/client/transport/tests.rs
+++ b/src/py/client/transport/tests.rs
@@ -1,8 +1,8 @@
-use super::request::{RequestState, TransportRequest};
+use super::request::{PendingResponsePolicyAction, RequestState, TransportRequest};
 use crate::core::headers::HeaderPairs;
 use crate::core::method::{GET, POST};
 use crate::core::metrics::Metrics;
-use crate::core::policy::{ResponsePolicyAction, TransportRoute};
+use crate::core::policy::TransportRoute;
 use crate::core::response::BufferedBodyBudget;
 use crate::messages::{
     NON_REPLAYABLE_REQUEST_BODY_REDIRECT, PROXY_REDIRECT_POLICY_RECOMPUTE_UNSUPPORTED,
@@ -110,7 +110,7 @@ fn explicit_proxy_tunnels_https_redirect_via_connect() {
     assert_eq!(state.url.as_str(), "https://example.com/secure");
     assert_eq!(
         state
-            .transport_route()
+            .transport_route(1)
             .expect("explicit proxy routes https targets through the proxy"),
         TransportRoute::Proxy
     );
@@ -164,6 +164,7 @@ fn transport_request(body: Option<Vec<u8>>, body_replayable: bool) -> TransportR
         buffered_body_budget: BufferedBodyBudget::new(None, Arc::new(Metrics::default())),
         follow_redirects: true,
         max_redirects: 20,
+        policy_hooks: None,
     }
 }
 
@@ -171,9 +172,10 @@ fn response_action(
     state: &RequestState,
     status: StatusCode,
     location: &str,
-) -> ResponsePolicyAction {
+) -> PendingResponsePolicyAction {
     let headers = vec![("location".to_owned(), location.to_owned())];
     state
-        .on_response_headers(status.as_u16(), &headers)
+        .on_response_headers(status.as_u16(), &headers, 0)
+        .expect("valid response policy evaluation")
         .expect("redirect action")
 }

--- a/tests/client_lifecycle/helpers.py
+++ b/tests/client_lifecycle/helpers.py
@@ -84,6 +84,7 @@ def create_test_raw_client() -> "_foghttp.RawClient":
             tls=None,
             runtime="dedicated",
             runtime_workers=1,
+            policy_hooks=None,
             telemetry=None,
             lifecycle_debug=None,
         ),

--- a/tests/client_options/test_raw_numeric_boundary.py
+++ b/tests/client_options/test_raw_numeric_boundary.py
@@ -1,4 +1,5 @@
 import math
+from types import SimpleNamespace
 
 from faker import Faker
 import pytest
@@ -127,6 +128,20 @@ def test_raw_client_accepts_unbounded_connection_limit_without_panic() -> None:
     raw_client.close()
 
 
+def test_raw_client_rejects_non_callable_policy_hook_without_panic() -> None:
+    policy_hooks = SimpleNamespace(
+        before_send=object(),
+        on_response_headers=None,
+        after_response_body=None,
+    )
+
+    with pytest.raises(
+        TypeError,
+        match="before_send transport policy hook must be callable or None",
+    ):
+        _foghttp.RawClient(**_raw_client_options(policy_hooks=policy_hooks))
+
+
 def test_raw_client_sync_request_rejects_positional_arguments(faker: Faker) -> None:
     raw_client = _raw_client()
     try:
@@ -240,6 +255,7 @@ def _raw_client_options(**overrides: object) -> dict[str, object]:
         "http_proxy_authorization": None,
         "https_proxy_url": None,
         "https_proxy_authorization": None,
+        "policy_hooks": None,
     }
     options.update(overrides)
     return options

--- a/tests/client_policy_hooks/requests.py
+++ b/tests/client_policy_hooks/requests.py
@@ -1,0 +1,20 @@
+from foghttp import AsyncClient, Client
+from foghttp.methods import GET
+
+
+def send_sync_request(client: Client, url: str, *, streaming: bool) -> None:
+    if not streaming:
+        client.get(url)
+        return
+
+    with client.stream(GET, url):
+        pass
+
+
+async def send_async_request(client: AsyncClient, url: str, *, streaming: bool) -> None:
+    if not streaming:
+        await client.get(url)
+        return
+
+    async with client.stream(GET, url):
+        pass

--- a/tests/client_policy_hooks/test_async_hooks.py
+++ b/tests/client_policy_hooks/test_async_hooks.py
@@ -1,0 +1,136 @@
+import asyncio
+
+import pytest
+
+import foghttp
+from foghttp.methods import GET
+from foghttp.policy import (
+    TransportPolicyHooks,
+    TransportPolicyRequest,
+    TransportPolicyResponse,
+)
+from foghttp.status_codes.redirect import FOUND
+from foghttp.status_codes.success import OK
+from tests.client_policy_hooks.requests import send_async_request
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=("buffered", "streaming"))
+async def test_async_policy_hooks_observe_each_transport_stage(
+    http_server: str,
+    *,
+    streaming: bool,
+) -> None:
+    events: list[tuple[str, TransportPolicyRequest | TransportPolicyResponse]] = []
+
+    def before_send(request: TransportPolicyRequest) -> None:
+        events.append(("before_send", request))
+
+    def on_response_headers(response: TransportPolicyResponse) -> None:
+        events.append(("on_response_headers", response))
+
+    def after_response_body(response: TransportPolicyResponse) -> None:
+        events.append(("after_response_body", response))
+
+    hooks = TransportPolicyHooks(
+        before_send=before_send,
+        on_response_headers=on_response_headers,
+        after_response_body=after_response_body,
+    )
+    initial_url = f"{http_server}/redirect/{FOUND}"
+
+    async with foghttp.AsyncClient(follow_redirects=True, policy_hooks=hooks) as client:
+        if streaming:
+            async with client.stream(GET, initial_url) as response:
+                assert response.status_code == OK
+                final_url = response.url
+        else:
+            response = await client.get(initial_url)
+            assert response.status_code == OK
+            final_url = response.url
+
+    assert [stage for stage, _view in events] == [
+        "before_send",
+        "on_response_headers",
+        "after_response_body",
+        "before_send",
+        "on_response_headers",
+    ]
+    first_request = events[0][1]
+    redirect_response = events[1][1]
+    redirected_request = events[3][1]
+    final_response = events[4][1]
+    assert isinstance(first_request, TransportPolicyRequest)
+    assert first_request == TransportPolicyRequest(GET, initial_url, "empty", 0)
+    assert isinstance(redirect_response, TransportPolicyResponse)
+    assert redirect_response.request == first_request
+    assert redirect_response.status_code == FOUND
+    assert events[2][1] == redirect_response
+    assert isinstance(redirected_request, TransportPolicyRequest)
+    assert redirected_request == TransportPolicyRequest(GET, final_url, "empty", 1)
+    assert isinstance(final_response, TransportPolicyResponse)
+    assert final_response.request == redirected_request
+    assert final_response.status_code == OK
+
+
+async def test_async_hook_exception_is_propagated(http_server: str) -> None:
+    def reject_request(request: TransportPolicyRequest) -> None:
+        message = f"blocked {request.method}"
+        raise RuntimeError(message)
+
+    hooks = TransportPolicyHooks(before_send=reject_request)
+
+    async with foghttp.AsyncClient(policy_hooks=hooks) as client:
+        with pytest.raises(RuntimeError, match="blocked GET"):
+            await client.get(http_server)
+        stats = client.stats()
+
+    assert stats.pool_acquire_attempts == 0
+
+
+async def test_async_policy_hook_is_shared_by_concurrent_requests(http_server: str) -> None:
+    observed_urls: list[str] = []
+
+    def observe(request: TransportPolicyRequest) -> None:
+        observed_urls.append(request.url)
+
+    hooks = TransportPolicyHooks(before_send=observe)
+    urls = [f"{http_server}/status/{OK}?request={index}" for index in range(20)]
+
+    async with foghttp.AsyncClient(policy_hooks=hooks) as client:
+        responses = await asyncio.gather(*(client.get(url) for url in urls))
+
+    assert all(response.status_code == OK for response in responses)
+    assert sorted(observed_urls) == sorted(urls)
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=("buffered", "streaming"))
+async def test_async_response_hook_failure_releases_transport_resources(
+    http_server: str,
+    *,
+    streaming: bool,
+) -> None:
+    reject_next_response = True
+
+    def reject_once(response: TransportPolicyResponse) -> None:
+        nonlocal reject_next_response
+        if reject_next_response:
+            reject_next_response = False
+            message = f"blocked status {response.status_code}"
+            raise RuntimeError(message)
+
+    hooks = TransportPolicyHooks(on_response_headers=reject_once)
+    limits = foghttp.Limits(max_active_requests=1, max_connections=1)
+
+    async with foghttp.AsyncClient(policy_hooks=hooks, limits=limits) as client:
+        with pytest.raises(RuntimeError, match="blocked status 200"):
+            await send_async_request(client, http_server, streaming=streaming)
+        stats_after_error = client.stats()
+        response = await client.get(http_server)
+
+    assert response.status_code == OK
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0
+    assert stats_after_error.response_body_aborted == 1
+    assert stats_after_error.connections_aborted == 1

--- a/tests/client_policy_hooks/test_contract.py
+++ b/tests/client_policy_hooks/test_contract.py
@@ -1,0 +1,116 @@
+from collections.abc import AsyncIterator
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+import foghttp
+from foghttp.policy import (
+    TransportPolicyBodyState,
+    TransportPolicyHooks,
+    TransportPolicyRequest,
+    TransportPolicyResponse,
+)
+
+
+def test_empty_policy_hooks_are_disabled() -> None:
+    assert TransportPolicyHooks().enabled is False
+
+
+def test_configured_policy_hook_is_enabled() -> None:
+    def observe(request: TransportPolicyRequest) -> None:
+        del request
+
+    hooks = TransportPolicyHooks(before_send=observe)
+
+    assert hooks.enabled is True
+
+
+def test_policy_hook_config_repr_omits_callbacks() -> None:
+    def observe(request: TransportPolicyRequest) -> None:
+        del request
+
+    assert "observe" not in repr(TransportPolicyHooks(before_send=observe))
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["before_send", "on_response_headers", "after_response_body"],
+)
+def test_policy_hooks_reject_non_callable_values(field: str) -> None:
+    with pytest.raises(TypeError, match=rf"{field} .* must be callable or None"):
+        TransportPolicyHooks(**{field: object()})
+
+
+def test_policy_hooks_reject_coroutine_functions() -> None:
+    async def async_hook(request: TransportPolicyRequest) -> None:
+        del request
+
+    with pytest.raises(TypeError, match=r"before_send .* must be synchronous"):
+        TransportPolicyHooks(before_send=async_hook)
+
+
+def test_policy_hooks_reject_async_callable_objects() -> None:
+    class AsyncPolicyHook:
+        async def __call__(self, request: TransportPolicyRequest) -> None:
+            del request
+
+    with pytest.raises(TypeError, match=r"before_send .* must be synchronous"):
+        TransportPolicyHooks(before_send=AsyncPolicyHook())
+
+
+def test_policy_hooks_reject_async_generator_functions() -> None:
+    async def async_hook(request: TransportPolicyRequest) -> AsyncIterator[None]:
+        del request
+        yield
+
+    with pytest.raises(TypeError, match=r"before_send .* must be synchronous"):
+        TransportPolicyHooks(before_send=async_hook)
+
+
+def test_policy_views_are_immutable_snapshots() -> None:
+    request = TransportPolicyRequest(
+        method="GET",
+        url="https://example.com/resource",
+        body="empty",
+        redirect_hop=0,
+    )
+    response = TransportPolicyResponse(
+        request=request,
+        status_code=200,
+        headers=(("content-type", "application/json"),),
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        request.method = "POST"
+    with pytest.raises(FrozenInstanceError):
+        response.status_code = 201
+
+    assert isinstance(response.headers, tuple)
+    assert isinstance(response.headers[0], tuple)
+
+
+def test_policy_view_repr_redacts_url_and_header_values() -> None:
+    request = TransportPolicyRequest(
+        method="GET",
+        url="https://example.com/resource?access_token=secret",
+        body="empty",
+        redirect_hop=0,
+    )
+    response = TransportPolicyResponse(
+        request=request,
+        status_code=200,
+        headers=(("set-cookie", "session=secret"),),
+    )
+
+    representation = repr(response)
+
+    assert "access_token=<redacted>" in representation
+    assert "session=secret" not in representation
+    assert "headers=<1 headers>" in representation
+
+
+def test_policy_contracts_are_exported_at_package_root() -> None:
+    assert foghttp.TransportPolicyBodyState is TransportPolicyBodyState
+    assert foghttp.TransportPolicyHooks is TransportPolicyHooks
+    assert foghttp.TransportPolicyRequest is TransportPolicyRequest
+    assert foghttp.TransportPolicyResponse is TransportPolicyResponse

--- a/tests/client_policy_hooks/test_sync_hooks.py
+++ b/tests/client_policy_hooks/test_sync_hooks.py
@@ -1,0 +1,237 @@
+from typing import cast
+
+import pytest
+
+import foghttp
+from foghttp.methods import GET
+from foghttp.policy import (
+    TransportPolicyHooks,
+    TransportPolicyRequest,
+    TransportPolicyResponse,
+)
+from foghttp.status_codes.redirect import FOUND, SEE_OTHER, TEMPORARY_REDIRECT
+from foghttp.status_codes.success import OK
+from tests.client_policy_hooks.requests import send_sync_request
+from tests.support.http_routes import REPEATED_HEADERS_PATH
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=("buffered", "streaming"))
+def test_sync_policy_hooks_observe_each_transport_stage(
+    sync_http_server: str,
+    *,
+    streaming: bool,
+) -> None:
+    events: list[tuple[str, TransportPolicyRequest | TransportPolicyResponse]] = []
+
+    def before_send(request: TransportPolicyRequest) -> None:
+        events.append(("before_send", request))
+
+    def on_response_headers(response: TransportPolicyResponse) -> None:
+        events.append(("on_response_headers", response))
+
+    def after_response_body(response: TransportPolicyResponse) -> None:
+        events.append(("after_response_body", response))
+
+    hooks = TransportPolicyHooks(
+        before_send=before_send,
+        on_response_headers=on_response_headers,
+        after_response_body=after_response_body,
+    )
+    initial_url = f"{sync_http_server}/redirect/{FOUND}"
+
+    with foghttp.Client(follow_redirects=True, policy_hooks=hooks) as client:
+        if streaming:
+            with client.stream(GET, initial_url) as response:
+                assert response.status_code == OK
+                final_url = response.url
+        else:
+            response = client.get(initial_url)
+            assert response.status_code == OK
+            final_url = response.url
+
+    assert [stage for stage, _view in events] == [
+        "before_send",
+        "on_response_headers",
+        "after_response_body",
+        "before_send",
+        "on_response_headers",
+    ]
+    first_request = events[0][1]
+    redirect_response = events[1][1]
+    redirected_request = events[3][1]
+    final_response = events[4][1]
+    assert isinstance(first_request, TransportPolicyRequest)
+    assert first_request == TransportPolicyRequest(GET, initial_url, "empty", 0)
+    assert isinstance(redirect_response, TransportPolicyResponse)
+    assert redirect_response.request is not first_request
+    assert redirect_response.request == first_request
+    assert redirect_response.status_code == FOUND
+    assert ("location", "/final") in redirect_response.headers
+    assert events[2][1] == redirect_response
+    assert isinstance(redirected_request, TransportPolicyRequest)
+    assert redirected_request == TransportPolicyRequest(GET, final_url, "empty", 1)
+    assert isinstance(final_response, TransportPolicyResponse)
+    assert final_response.request == redirected_request
+    assert final_response.status_code == OK
+
+
+def test_sync_hook_exception_is_propagated_before_transport_acquire(sync_http_server: str) -> None:
+    def reject_request(request: TransportPolicyRequest) -> None:
+        message = f"blocked {request.method}"
+        raise RuntimeError(message)
+
+    hooks = TransportPolicyHooks(before_send=reject_request)
+
+    with foghttp.Client(policy_hooks=hooks) as client:
+        with pytest.raises(RuntimeError, match="blocked GET"):
+            client.get(sync_http_server)
+        stats = client.stats()
+
+    assert stats.pool_acquire_attempts == 0
+
+
+def test_request_hook_observes_body_policy_after_redirect_mutation(sync_http_server: str) -> None:
+    requests: list[TransportPolicyRequest] = []
+    hooks = TransportPolicyHooks(before_send=requests.append)
+
+    with foghttp.Client(follow_redirects=True, policy_hooks=hooks) as client:
+        response = client.post(
+            f"{sync_http_server}/redirect/{SEE_OTHER}",
+            content=b"payload",
+        )
+
+    assert response.status_code == OK
+    assert [(request.method, request.body, request.redirect_hop) for request in requests] == [
+        ("POST", "replayable", 0),
+        ("GET", "empty", 1),
+    ]
+
+
+def test_response_hook_preserves_repeated_header_order(sync_http_server: str) -> None:
+    observed: list[TransportPolicyResponse] = []
+    hooks = TransportPolicyHooks(on_response_headers=observed.append)
+
+    with foghttp.Client(policy_hooks=hooks) as client:
+        client.get(sync_http_server + REPEATED_HEADERS_PATH)
+
+    set_cookies = [value for name, value in observed[0].headers if name == "set-cookie"]
+    assert set_cookies == ["first=1", "second=2"]
+
+
+def test_policy_snapshot_escape_hatches_do_not_mutate_transport(sync_http_server: str) -> None:
+    def mutate_request(request: TransportPolicyRequest) -> None:
+        object.__setattr__(request, "method", "DELETE")
+        object.__setattr__(request, "url", f"{sync_http_server}/status/500")
+
+    def mutate_response(response: TransportPolicyResponse) -> None:
+        object.__setattr__(response, "status_code", 500)
+        object.__setattr__(response, "headers", (("x-mutated", "true"),))
+
+    hooks = TransportPolicyHooks(
+        before_send=mutate_request,
+        on_response_headers=mutate_response,
+    )
+
+    with foghttp.Client(policy_hooks=hooks) as client:
+        response = client.get(sync_http_server)
+
+    assert response.status_code == OK
+    assert response.json()["request_line"].startswith("GET / HTTP/")
+    assert "x-mutated" not in response.headers
+
+
+def test_sync_hook_return_value_is_rejected(sync_http_server: str) -> None:
+    def invalid_hook(request: TransportPolicyRequest) -> None:
+        return cast("None", request)
+
+    hooks = TransportPolicyHooks(before_send=invalid_hook)
+
+    with (
+        foghttp.Client(policy_hooks=hooks) as client,
+        pytest.raises(TypeError, match="transport policy hooks must return None"),
+    ):
+        client.get(sync_http_server)
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=("buffered", "streaming"))
+def test_sync_response_hook_failure_releases_transport_resources(
+    sync_http_server: str,
+    *,
+    streaming: bool,
+) -> None:
+    reject_next_response = True
+
+    def reject_once(response: TransportPolicyResponse) -> None:
+        nonlocal reject_next_response
+        if reject_next_response:
+            reject_next_response = False
+            message = f"blocked status {response.status_code}"
+            raise RuntimeError(message)
+
+    hooks = TransportPolicyHooks(on_response_headers=reject_once)
+    limits = foghttp.Limits(max_active_requests=1, max_connections=1)
+
+    with foghttp.Client(policy_hooks=hooks, limits=limits) as client:
+        with pytest.raises(RuntimeError, match="blocked status 200"):
+            send_sync_request(client, sync_http_server, streaming=streaming)
+        stats_after_error = client.stats()
+        response = client.get(sync_http_server)
+
+    assert response.status_code == OK
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0
+    assert stats_after_error.response_body_aborted == 1
+    assert stats_after_error.connections_aborted == 1
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=("buffered", "streaming"))
+def test_after_body_hook_failure_releases_redirect_resources(
+    sync_http_server: str,
+    *,
+    streaming: bool,
+) -> None:
+    def reject_redirect(response: TransportPolicyResponse) -> None:
+        message = f"blocked redirect {response.status_code}"
+        raise RuntimeError(message)
+
+    hooks = TransportPolicyHooks(after_response_body=reject_redirect)
+    limits = foghttp.Limits(max_active_requests=1, max_connections=1)
+    redirect_url = f"{sync_http_server}/redirect/{FOUND}"
+
+    with foghttp.Client(
+        follow_redirects=True,
+        policy_hooks=hooks,
+        limits=limits,
+    ) as client:
+        with pytest.raises(RuntimeError, match=f"blocked redirect {FOUND}"):
+            send_sync_request(client, redirect_url, streaming=streaming)
+        stats_after_error = client.stats()
+        response = client.get(sync_http_server)
+
+    assert response.status_code == OK
+    assert stats_after_error.total_requests == 1
+    assert stats_after_error.failed_requests == 1
+    assert stats_after_error.active_requests == 0
+    assert stats_after_error.pending_requests == 0
+    assert stats_after_error.buffered_response_bytes == 0
+    assert stats_after_error.response_body_reuse_eligible + stats_after_error.response_body_closed == 1
+    assert stats_after_error.response_body_aborted == 0
+    assert stats_after_error.connections_aborted == 0
+
+
+def test_redirect_safety_validation_precedes_after_body_hook(sync_http_server: str) -> None:
+    observed: list[TransportPolicyResponse] = []
+    hooks = TransportPolicyHooks(after_response_body=observed.append)
+
+    with (
+        foghttp.Client(follow_redirects=True, policy_hooks=hooks) as client,
+        pytest.raises(foghttp.RequestError, match="non-replayable request body"),
+    ):
+        client.post(
+            f"{sync_http_server}/redirect/{TEMPORARY_REDIRECT}",
+            content=iter((b"payload",)),
+        )
+
+    assert observed == []

--- a/tests/client_proxy/client_options.py
+++ b/tests/client_proxy/client_options.py
@@ -26,6 +26,7 @@ def client_options(
         tls=tls,
         runtime=None,
         runtime_workers=None,
+        policy_hooks=None,
         telemetry=None,
         lifecycle_debug=None,
     )

--- a/tests/pyo3_boundary/test_raw_client_signatures.py
+++ b/tests/pyo3_boundary/test_raw_client_signatures.py
@@ -25,6 +25,7 @@ RAW_CLIENT_KEYWORD_ONLY_PARAMETERS = (
     "http_proxy_authorization",
     "https_proxy_url",
     "https_proxy_authorization",
+    "policy_hooks",
 )
 
 RAW_REQUEST_KEYWORD_ONLY_PARAMETERS = (

--- a/tests/test_raw_client.py
+++ b/tests/test_raw_client.py
@@ -21,6 +21,7 @@ from foghttp._client.runtime.constants import RUNTIME_WORKERS_ENV
 from foghttp._request_body import RequestBody
 from foghttp.limits import Limits
 from foghttp.methods import GET
+from foghttp.policy import TransportPolicyHooks, TransportPolicyRequest
 from foghttp.timeouts import Timeouts
 from foghttp.tls import TLSConfig
 
@@ -47,6 +48,7 @@ RAW_CLIENT_INIT_ARGUMENTS = (
     "http_proxy_authorization",
     "https_proxy_url",
     "https_proxy_authorization",
+    "policy_hooks",
 )
 
 RAW_REQUEST_ARGUMENTS = (
@@ -76,6 +78,7 @@ def _client_config(
     trust_env: bool = False,
     proxy: str | None = None,
     tls: TLSConfig | None = None,
+    policy_hooks: TransportPolicyHooks | None = None,
 ) -> ClientConfig:
     return ClientConfig.from_options(
         ClientOptions(
@@ -93,6 +96,7 @@ def _client_config(
             tls=tls,
             runtime=runtime,
             runtime_workers=runtime_workers,
+            policy_hooks=policy_hooks,
             telemetry=None,
             lifecycle_debug=None,
         ),
@@ -178,6 +182,7 @@ def test_create_raw_client_passes_transport_limits_to_rust_client(
         "http_proxy_authorization": None,
         "https_proxy_url": None,
         "https_proxy_authorization": None,
+        "policy_hooks": None,
     }
 
 
@@ -206,6 +211,31 @@ def test_create_raw_client_passes_proxy_endpoint_and_auth_to_rust_client(
     assert captured_options["http_proxy_authorization"] == expected_auth
     assert captured_options["https_proxy_url"] == "http://proxy.example:8080"
     assert captured_options["https_proxy_authorization"] == expected_auth
+
+
+def test_client_config_normalizes_empty_policy_hooks() -> None:
+    assert _client_config(policy_hooks=TransportPolicyHooks()).policy_hooks is None
+
+
+def test_create_raw_client_passes_enabled_policy_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_options: dict[str, object] = {}
+
+    class RawClientProbe:
+        def __init__(self, **kwargs: object) -> None:
+            captured_options.update(kwargs)
+
+    def before_send(request: TransportPolicyRequest) -> None:
+        del request
+
+    hooks = TransportPolicyHooks(before_send=before_send)
+    monkeypatch.setattr(_foghttp, "RawClient", RawClientProbe)
+
+    raw_client = create_raw_client(config=_client_config(policy_hooks=hooks))
+
+    assert isinstance(raw_client, RawClientProbe)
+    assert captured_options["policy_hooks"] is hooks
 
 
 def test_create_raw_client_passes_tls_trust_boundary_to_rust_client(

--- a/tests/test_raw_client_errors.py
+++ b/tests/test_raw_client_errors.py
@@ -92,6 +92,7 @@ def _default_client_config() -> ClientConfig:
             tls=None,
             runtime="dedicated",
             runtime_workers=1,
+            policy_hooks=None,
             telemetry=None,
             lifecycle_debug=None,
         ),

--- a/tests/types/test_policy_contracts.py
+++ b/tests/types/test_policy_contracts.py
@@ -1,0 +1,38 @@
+from collections.abc import Callable
+from typing import assert_type
+
+from foghttp.policy import (
+    TransportPolicyHooks,
+    TransportPolicyRequest,
+    TransportPolicyResponse,
+)
+
+
+def observe_request(request: TransportPolicyRequest) -> None:
+    assert request.method
+
+
+def observe_response(response: TransportPolicyResponse) -> None:
+    assert response.status_code > 0
+
+
+def test_policy_hook_callable_contracts() -> None:
+    hooks = TransportPolicyHooks(
+        before_send=observe_request,
+        on_response_headers=observe_response,
+        after_response_body=observe_response,
+    )
+
+    assert_type(
+        hooks.before_send,
+        Callable[[TransportPolicyRequest], None] | None,
+    )
+    assert_type(
+        hooks.on_response_headers,
+        Callable[[TransportPolicyResponse], None] | None,
+    )
+    assert_type(
+        hooks.after_response_body,
+        Callable[[TransportPolicyResponse], None] | None,
+    )
+    assert hooks.enabled is True


### PR DESCRIPTION
- expose typed immutable request and response snapshots
- bridge opt-in hooks through Rust-owned policy stages
- preserve redirect safety and lifecycle telemetry on failures
- document execution, security, and timeout constraints