### PR TITLE
feat(redirects): harden redirect header security matrix

### DIFF
--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -129,41 +129,37 @@ query at a different origin.
 ## Security Policy
 
 FogHTTP applies a conservative redirect security policy on every redirect hop.
+The policy runs after the target URL and body action have been resolved and
+before the next request is sent.
 
-For same-origin redirects, request headers are preserved unless the redirect
-changes the request method and drops the body.
+| Header category | Fields | Redirect behavior |
+|---|---|---|
+| Transport routing, framing, proxy, and connection | `Host`, `Content-Length`, `Transfer-Encoding`, `Connection`, `Keep-Alive`, `Proxy-Authorization`, `Proxy-Connection`, `TE`, `Trailer`, `Upgrade`, plus fields named by `Connection` | Always removed from the previous request. The transport derives fresh routing and framing fields for the new URL and body and applies proxy credentials for the selected route. |
+| Conditional validators | `If-Match`, `If-None-Match`, `If-Modified-Since`, `If-Unmodified-Since`, `If-Range` | Always removed because the validator describes the previous target resource. |
+| Origin-scoped credentials and metadata | `Authorization`, `Cookie`, `Origin`, `Referer` | Preserved for same-origin redirects and removed for cross-origin redirects. |
+| Content metadata | Every `Content-*` field, including `Content-Type`, `Content-Encoding`, `Content-Language`, `Content-Location`, `Content-Range`, `Content-Disposition`, and `Content-Digest`; also legacy `Digest`, current `Repr-Digest`, and `Last-Modified` | Preserved only while the request body is preserved. Removed when a method rewrite or cross-origin policy drops the body. |
+| Other caller headers | For example, `Accept` and application-specific fields | Preserved. |
 
-For cross-origin redirects, FogHTTP strips sensitive headers before sending the
-next request:
+Same-origin means that the scheme, normalized host, and effective port all
+match. A change to any of those components is cross-origin.
 
-- `Authorization`
-- `Proxy-Authorization`
-- `Cookie`
-- `Origin`
-- `Referer`
+The safe API already rejects manual transport-managed fields. Rebuilding them
+inside the Rust redirect policy also protects the lower-level boundary and
+prevents stale authority, framing, proxy credentials, or connection state from
+crossing a hop.
 
-This is intentionally strict. It prevents credentials, manually supplied
-cookies, origin metadata, and referrer metadata from being forwarded to a
-different origin by a redirect response. `Host` is transport-managed and cannot
-be set manually through the safe API.
+The conditional and content rules follow the redirect guidance in
+[RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html). FogHTTP recognizes both
+the obsolete `Digest` field and its current
+[RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html) replacements.
 
-When a redirect rewrites `POST` or `QUERY` to `GET`, FogHTTP drops the request
-body and strips body-specific headers:
-
-- `Content-Encoding`
-- `Content-Length`
-- `Content-Type`
-- `Transfer-Encoding`
-
-`Content-Length` and `Transfer-Encoding` are transport-managed and cannot be set
-manually through the safe API.
-
-For same-origin method-preserving POST and QUERY redirects, FogHTTP resends a
-replayable body. For cross-origin method-preserving POST and QUERY redirects,
-FogHTTP preserves the method but drops the body and body-specific headers
-before the next request. This prevents JSON payloads, tokens, form data, and
-other request bodies from being forwarded to a different origin by a redirect
-response.
+For same-origin method-preserving redirects, FogHTTP resends a replayable body.
+For cross-origin method-preserving redirects, FogHTTP preserves the method but
+drops any body and its content metadata before the next request. This rule also
+protects bodies supplied through the generic `request()` API for methods whose
+convenience helpers do not accept body arguments. It prevents JSON payloads,
+tokens, form data, and other request bodies from being forwarded to a different
+origin by a redirect response.
 
 FogHTTP also blocks `https -> http` redirects. Scheme downgrade redirects are
 too easy to misuse once credentials, cookies, body replay, or future auth helpers
@@ -173,6 +169,12 @@ following the downgrade.
 Direct streaming bodies use the explicit non-replayable path and are not resent
 automatically. Factory-backed streams are replayable because each attempt gets
 a fresh provider.
+
+Automatic redirects cannot infer whether an arbitrary application header such
+as `X-API-Key` contains an origin-scoped secret. Keep automatic redirects
+disabled and follow the response explicitly when custom credentials require a
+different forwarding policy. This is also the explicit escape hatch for callers
+that need behavior looser than the built-in matrix.
 
 ## Proxy Policy
 

--- a/src/core/policy/pipeline.rs
+++ b/src/core/policy/pipeline.rs
@@ -1,6 +1,6 @@
 use super::error::PolicyError;
 use super::proxy::{ProxyPolicy, TransportRoute};
-use super::redirect::{redirect_decision, RedirectAction, RedirectDecision};
+use super::redirect::{redirect_decision, RedirectAction, RedirectDecision, RedirectHeaderPolicy};
 use super::request::{PolicyRequest, RequestBodyMutation, ResponseHead};
 use crate::core::url::HttpUrl;
 
@@ -23,8 +23,8 @@ pub(crate) struct ResponsePolicyAction {
 pub(crate) enum PolicyMutation {
     Redirect {
         body: RequestBodyMutation,
+        header_policy: RedirectHeaderPolicy,
         method: &'static str,
-        remove_sensitive_headers: bool,
         url: HttpUrl,
     },
 }
@@ -102,8 +102,8 @@ impl PolicyPipeline {
 fn redirect_mutation(action: RedirectAction) -> PolicyMutation {
     PolicyMutation::Redirect {
         body: action.body,
+        header_policy: action.header_policy,
         method: action.method,
-        remove_sensitive_headers: action.remove_sensitive_headers,
         url: action.url,
     }
 }

--- a/src/core/policy/redirect/action.rs
+++ b/src/core/policy/redirect/action.rs
@@ -1,3 +1,4 @@
+use super::headers::RedirectHeaderPolicy;
 use super::method::redirect_method;
 use super::policy::redirect_security_policy;
 use super::status::redirect_status_code;
@@ -13,8 +14,8 @@ pub(in crate::core::policy) enum RedirectDecision {
 
 pub(in crate::core::policy) struct RedirectAction {
     pub(in crate::core::policy) body: RequestBodyMutation,
+    pub(in crate::core::policy) header_policy: RedirectHeaderPolicy,
     pub(in crate::core::policy) method: &'static str,
-    pub(in crate::core::policy) remove_sensitive_headers: bool,
     pub(in crate::core::policy) url: HttpUrl,
 }
 
@@ -26,7 +27,7 @@ pub(in crate::core::policy) fn redirect_decision(
     let location = header_value(response.headers(), "location")?;
     let (next_method, body) = redirect_method(request.method(), status_code)?;
     let next_url = request.url().join(location).ok()?;
-    let policy = redirect_security_policy(request.url(), &next_url, next_method, body);
+    let policy = redirect_security_policy(request.url(), &next_url, body);
 
     if let Some(error) = policy.block_error {
         return Some(RedirectDecision::Block(error));
@@ -34,8 +35,8 @@ pub(in crate::core::policy) fn redirect_decision(
 
     Some(RedirectDecision::Follow(RedirectAction {
         body: policy.body,
+        header_policy: policy.header_policy,
         method: next_method,
-        remove_sensitive_headers: policy.remove_sensitive_headers,
         url: next_url,
     }))
 }

--- a/src/core/policy/redirect/headers.rs
+++ b/src/core/policy/redirect/headers.rs
@@ -1,44 +1,89 @@
 use crate::core::headers::HeaderPairs;
 use crate::core::policy::request::RequestBodyMutation;
 
-const BODY_HEADERS: &[&str] = &[
-    "content-encoding",
+const ALWAYS_REBUILT_HEADERS: &[&str] = &[
+    "connection",
     "content-length",
-    "content-type",
+    "host",
+    "keep-alive",
+    "proxy-authorization",
+    "proxy-connection",
+    "te",
+    "trailer",
     "transfer-encoding",
+    "upgrade",
 ];
 
-const CROSS_ORIGIN_HEADERS: &[&str] = &[
-    "authorization",
-    "cookie",
-    "host",
-    "origin",
-    "proxy-authorization",
-    "referer",
+const CONDITIONAL_HEADERS: &[&str] = &[
+    "if-match",
+    "if-modified-since",
+    "if-none-match",
+    "if-range",
+    "if-unmodified-since",
 ];
+
+const CONTENT_HEADER_PREFIX: &str = "content-";
+const REPRESENTATION_HEADERS: &[&str] = &["digest", "last-modified", "repr-digest"];
+
+const CROSS_ORIGIN_HEADERS: &[&str] = &["authorization", "cookie", "origin", "referer"];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RedirectHeaderPolicy {
+    SameOrigin,
+    CrossOrigin,
+}
 
 pub(crate) fn redirect_headers(
     headers: HeaderPairs,
     body: RequestBodyMutation,
-    remove_sensitive_headers: bool,
+    policy: RedirectHeaderPolicy,
 ) -> HeaderPairs {
+    let connection_options = connection_options(&headers);
     headers
         .into_iter()
-        .filter(|(name, _value)| keep_redirect_header(name, body, remove_sensitive_headers))
+        .filter(|(name, _value)| keep_redirect_header(name, body, policy, &connection_options))
         .collect()
 }
 
 fn keep_redirect_header(
     name: &str,
     body: RequestBodyMutation,
-    remove_sensitive_headers: bool,
+    policy: RedirectHeaderPolicy,
+    connection_options: &[String],
 ) -> bool {
-    let name = name.to_ascii_lowercase();
-    if body == RequestBodyMutation::Drop && BODY_HEADERS.contains(&name.as_str()) {
+    if header_in(name, ALWAYS_REBUILT_HEADERS)
+        || header_in(name, CONDITIONAL_HEADERS)
+        || connection_options
+            .iter()
+            .any(|option| name.eq_ignore_ascii_case(option))
+    {
         return false;
     }
-    if remove_sensitive_headers && CROSS_ORIGIN_HEADERS.contains(&name.as_str()) {
+    if body == RequestBodyMutation::Drop && is_content_metadata_header(name) {
         return false;
     }
-    true
+    policy != RedirectHeaderPolicy::CrossOrigin || !header_in(name, CROSS_ORIGIN_HEADERS)
+}
+
+fn header_in(name: &str, headers: &[&str]) -> bool {
+    headers
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate))
+}
+
+fn is_content_metadata_header(name: &str) -> bool {
+    name.get(..CONTENT_HEADER_PREFIX.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(CONTENT_HEADER_PREFIX))
+        || header_in(name, REPRESENTATION_HEADERS)
+}
+
+fn connection_options(headers: &HeaderPairs) -> Vec<String> {
+    headers
+        .iter()
+        .filter(|(name, _value)| name.eq_ignore_ascii_case("connection"))
+        .flat_map(|(_name, value)| value.split(','))
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
+        .collect()
 }

--- a/src/core/policy/redirect/mod.rs
+++ b/src/core/policy/redirect/mod.rs
@@ -6,7 +6,7 @@ mod status;
 mod utils;
 
 pub(in crate::core::policy) use action::{redirect_decision, RedirectAction, RedirectDecision};
-pub(crate) use headers::redirect_headers;
+pub(crate) use headers::{redirect_headers, RedirectHeaderPolicy};
 
 #[cfg(test)]
 mod tests;

--- a/src/core/policy/redirect/policy.rs
+++ b/src/core/policy/redirect/policy.rs
@@ -1,4 +1,4 @@
-use crate::core::method::{GET, HEAD};
+use super::headers::RedirectHeaderPolicy;
 use crate::core::policy::error::PolicyError;
 use crate::core::policy::request::RequestBodyMutation;
 use crate::core::url::HttpUrl;
@@ -9,24 +9,26 @@ const HTTP_SCHEME: &str = "http";
 pub(super) struct RedirectSecurityPolicy {
     pub(super) block_error: Option<PolicyError>,
     pub(super) body: RequestBodyMutation,
-    pub(super) remove_sensitive_headers: bool,
+    pub(super) header_policy: RedirectHeaderPolicy,
 }
 
 pub(super) fn redirect_security_policy(
     current_url: &HttpUrl,
     next_url: &HttpUrl,
-    method: &str,
     body: RequestBodyMutation,
 ) -> RedirectSecurityPolicy {
-    let remove_sensitive_headers = !current_url.is_same_origin(next_url);
+    let header_policy = if current_url.is_same_origin(next_url) {
+        RedirectHeaderPolicy::SameOrigin
+    } else {
+        RedirectHeaderPolicy::CrossOrigin
+    };
     let block_error = if is_https_to_http_redirect(current_url, next_url) {
         Some(PolicyError::HttpsToHttpRedirectBlocked)
     } else {
         None
     };
     let body = if body == RequestBodyMutation::Preserve
-        && remove_sensitive_headers
-        && can_replay_request_body(method)
+        && header_policy == RedirectHeaderPolicy::CrossOrigin
     {
         RequestBodyMutation::Drop
     } else {
@@ -36,14 +38,10 @@ pub(super) fn redirect_security_policy(
     RedirectSecurityPolicy {
         block_error,
         body,
-        remove_sensitive_headers,
+        header_policy,
     }
 }
 
 fn is_https_to_http_redirect(current_url: &HttpUrl, next_url: &HttpUrl) -> bool {
     current_url.scheme() == HTTPS_SCHEME && next_url.scheme() == HTTP_SCHEME
-}
-
-fn can_replay_request_body(method: &str) -> bool {
-    method != GET && method != HEAD
 }

--- a/src/core/policy/redirect/tests.rs
+++ b/src/core/policy/redirect/tests.rs
@@ -37,7 +37,7 @@ fn follow_action(decision: Option<RedirectDecision>) -> RedirectAction {
 }
 
 #[test]
-fn same_origin_redirect_keeps_sensitive_headers() {
+fn every_redirect_rebuilds_transport_and_connection_headers() {
     let action = follow_action(decision(
         GET,
         "https://example.com/users",
@@ -45,21 +45,74 @@ fn same_origin_redirect_keeps_sensitive_headers() {
         "/accounts",
     ));
 
-    let headers = redirect_headers(
+    let headers = headers_after_redirect(
+        &action,
+        vec![
+            ("Connection".to_owned(), "keep-alive, x-hop".to_owned()),
+            ("Content-Length".to_owned(), "12".to_owned()),
+            ("Host".to_owned(), "example.com".to_owned()),
+            ("Keep-Alive".to_owned(), "timeout=5".to_owned()),
+            ("Proxy-Authorization".to_owned(), "Basic token".to_owned()),
+            ("Proxy-Connection".to_owned(), "keep-alive".to_owned()),
+            ("TE".to_owned(), "trailers".to_owned()),
+            ("Trailer".to_owned(), "x-checksum".to_owned()),
+            ("Transfer-Encoding".to_owned(), "chunked".to_owned()),
+            ("Upgrade".to_owned(), "websocket".to_owned()),
+            ("X-Hop".to_owned(), "connection-specific".to_owned()),
+            ("Accept".to_owned(), "application/json".to_owned()),
+        ],
+    );
+
+    assert_eq!(header_names(&headers), vec!["Accept"]);
+}
+
+#[test]
+fn every_redirect_strips_conditional_headers() {
+    let action = follow_action(decision(
+        GET,
+        "https://example.com/users",
+        StatusCode::FOUND,
+        "/accounts",
+    ));
+
+    let headers = headers_after_redirect(
+        &action,
+        vec![
+            ("If-Match".to_owned(), "\"etag\"".to_owned()),
+            ("If-Modified-Since".to_owned(), "yesterday".to_owned()),
+            ("If-None-Match".to_owned(), "\"etag\"".to_owned()),
+            ("If-Range".to_owned(), "\"etag\"".to_owned()),
+            ("If-Unmodified-Since".to_owned(), "yesterday".to_owned()),
+            ("Accept".to_owned(), "application/json".to_owned()),
+        ],
+    );
+
+    assert_eq!(header_names(&headers), vec!["Accept"]);
+}
+
+#[test]
+fn same_origin_redirect_keeps_origin_scoped_headers() {
+    let action = follow_action(decision(
+        GET,
+        "https://example.com/users",
+        StatusCode::FOUND,
+        "/accounts",
+    ));
+
+    let headers = headers_after_redirect(
+        &action,
         vec![
             ("Authorization".to_owned(), "Bearer token".to_owned()),
             ("Cookie".to_owned(), "session=1".to_owned()),
-            ("Host".to_owned(), "example.com".to_owned()),
             ("Origin".to_owned(), "https://example.com".to_owned()),
             ("Referer".to_owned(), "https://example.com/users".to_owned()),
+            ("Accept".to_owned(), "application/json".to_owned()),
         ],
-        action.body,
-        action.remove_sensitive_headers,
     );
 
     assert_eq!(
         header_names(&headers),
-        vec!["Authorization", "Cookie", "Host", "Origin", "Referer"]
+        vec!["Authorization", "Cookie", "Origin", "Referer", "Accept"]
     );
 }
 
@@ -72,20 +125,18 @@ fn cross_origin_redirect_strips_sensitive_headers() {
         "https://api.example.org/final",
     ));
 
-    let headers = redirect_headers(
+    let headers = headers_after_redirect(
+        &action,
         vec![
             ("Authorization".to_owned(), "Bearer token".to_owned()),
-            ("Proxy-Authorization".to_owned(), "Basic token".to_owned()),
             ("Cookie".to_owned(), "session=1".to_owned()),
-            ("Host".to_owned(), "example.com".to_owned()),
             ("Origin".to_owned(), "https://example.com".to_owned()),
             ("Referer".to_owned(), "https://example.com/users".to_owned()),
             ("Accept".to_owned(), "application/json".to_owned()),
         ],
-        action.body,
-        action.remove_sensitive_headers,
     );
 
+    assert_eq!(action.body, RequestBodyMutation::Drop);
     assert_eq!(header_names(&headers), vec!["Accept"]);
 }
 
@@ -98,16 +149,27 @@ fn method_rewrite_strips_body_headers() {
         "/final",
     ));
 
-    let headers = redirect_headers(
+    let headers = headers_after_redirect(
+        &action,
         vec![
+            ("Content-Checksum".to_owned(), "custom-checksum".to_owned()),
+            ("Content-Digest".to_owned(), "sha-256=:YWJj:".to_owned()),
+            (
+                "Content-Disposition".to_owned(),
+                "attachment; filename=payload.txt".to_owned(),
+            ),
+            ("Content-Encoding".to_owned(), "gzip".to_owned()),
+            ("Content-Language".to_owned(), "en".to_owned()),
+            ("Content-Location".to_owned(), "/source".to_owned()),
+            ("Content-Range".to_owned(), "bytes 0-2/3".to_owned()),
             ("Content-Type".to_owned(), "application/json".to_owned()),
             ("Content-Length".to_owned(), "12".to_owned()),
-            ("Content-Encoding".to_owned(), "gzip".to_owned()),
+            ("Digest".to_owned(), "sha-256=YWJj".to_owned()),
+            ("Last-Modified".to_owned(), "yesterday".to_owned()),
+            ("Repr-Digest".to_owned(), "sha-256=:YWJj:".to_owned()),
             ("Transfer-Encoding".to_owned(), "chunked".to_owned()),
             ("Authorization".to_owned(), "Bearer token".to_owned()),
         ],
-        action.body,
-        action.remove_sensitive_headers,
     );
 
     assert_eq!(action.method, GET);
@@ -124,20 +186,45 @@ fn method_preserving_redirect_keeps_body_headers() {
         "/final",
     ));
 
-    let headers = redirect_headers(
+    let headers = headers_after_redirect(
+        &action,
         vec![
+            ("Content-Checksum".to_owned(), "custom-checksum".to_owned()),
+            ("Content-Digest".to_owned(), "sha-256=:YWJj:".to_owned()),
+            (
+                "Content-Disposition".to_owned(),
+                "attachment; filename=payload.txt".to_owned(),
+            ),
+            ("Content-Encoding".to_owned(), "identity".to_owned()),
+            ("Content-Language".to_owned(), "en".to_owned()),
+            ("Content-Location".to_owned(), "/source".to_owned()),
+            ("Content-Range".to_owned(), "bytes 0-2/3".to_owned()),
             ("Content-Type".to_owned(), "application/json".to_owned()),
             ("Content-Length".to_owned(), "12".to_owned()),
+            ("Digest".to_owned(), "sha-256=YWJj".to_owned()),
+            ("Last-Modified".to_owned(), "yesterday".to_owned()),
+            ("Repr-Digest".to_owned(), "sha-256=:YWJj:".to_owned()),
+            ("Transfer-Encoding".to_owned(), "chunked".to_owned()),
         ],
-        action.body,
-        action.remove_sensitive_headers,
     );
 
     assert_eq!(action.method, POST);
     assert_eq!(action.body, RequestBodyMutation::Preserve);
     assert_eq!(
         header_names(&headers),
-        vec!["Content-Type", "Content-Length"]
+        vec![
+            "Content-Checksum",
+            "Content-Digest",
+            "Content-Disposition",
+            "Content-Encoding",
+            "Content-Language",
+            "Content-Location",
+            "Content-Range",
+            "Content-Type",
+            "Digest",
+            "Last-Modified",
+            "Repr-Digest",
+        ]
     );
 }
 
@@ -180,7 +267,8 @@ fn cross_origin_method_preserving_redirect_strips_body_headers() {
         "https://api.example.org/final",
     ));
 
-    let headers = redirect_headers(
+    let headers = headers_after_redirect(
+        &action,
         vec![
             ("Content-Type".to_owned(), "application/json".to_owned()),
             ("Content-Length".to_owned(), "12".to_owned()),
@@ -188,13 +276,15 @@ fn cross_origin_method_preserving_redirect_strips_body_headers() {
             ("Authorization".to_owned(), "Bearer token".to_owned()),
             ("Accept".to_owned(), "application/json".to_owned()),
         ],
-        action.body,
-        action.remove_sensitive_headers,
     );
 
     assert_eq!(action.method, POST);
     assert_eq!(action.body, RequestBodyMutation::Drop);
     assert_eq!(header_names(&headers), vec!["Accept"]);
+}
+
+fn headers_after_redirect(action: &RedirectAction, headers: HeaderPairs) -> HeaderPairs {
+    redirect_headers(headers, action.body, action.header_policy)
 }
 
 #[test]

--- a/src/py/client/transport/request.rs
+++ b/src/py/client/transport/request.rs
@@ -196,18 +196,14 @@ impl RequestState {
     fn apply_policy_mutation(&mut self, mutation: PolicyMutation) {
         let PolicyMutation::Redirect {
             body,
+            header_policy,
             method,
-            remove_sensitive_headers,
             url,
         } = mutation;
 
         self.method = method.to_owned();
         self.url = url;
-        self.headers = redirect_headers(
-            std::mem::take(&mut self.headers),
-            body,
-            remove_sensitive_headers,
-        );
+        self.headers = redirect_headers(std::mem::take(&mut self.headers), body, header_policy);
 
         if body == RequestBodyMutation::Drop {
             self.body = RequestBodyState::Empty;

--- a/tests/redirect_helpers.py
+++ b/tests/redirect_helpers.py
@@ -1,4 +1,6 @@
 __all__ = (
+    "REDIRECT_CONDITIONAL_HEADERS",
+    "REDIRECT_CONTENT_HEADERS",
     "REDIRECT_SECURITY_HEADERS",
     "SECURITY_HEADERS_PATH",
     "header_values",
@@ -10,6 +12,26 @@ from urllib.parse import urlencode
 
 
 SECURITY_HEADERS_PATH = "/headers/security"
+REDIRECT_CONDITIONAL_HEADERS = {
+    "if-match": '"request-etag"',
+    "if-modified-since": "Mon, 01 Jan 2024 00:00:00 GMT",
+    "if-none-match": '"cached-etag"',
+    "if-range": '"range-etag"',
+    "if-unmodified-since": "Mon, 01 Jan 2024 00:00:00 GMT",
+}
+REDIRECT_CONTENT_HEADERS = {
+    "content-checksum": "custom-checksum",
+    "content-digest": "sha-256=:YWJj:",
+    "content-disposition": "attachment; filename=payload.txt",
+    "content-encoding": "identity",
+    "content-language": "en",
+    "content-location": "/source",
+    "content-range": "bytes 0-2/3",
+    "content-type": "text/plain",
+    "digest": "sha-256=Z2hp",
+    "last-modified": "Mon, 01 Jan 2024 00:00:00 GMT",
+    "repr-digest": "sha-256=:ZGVm:",
+}
 REDIRECT_SECURITY_HEADERS = {
     "accept": "application/json",
     "authorization": "Bearer secret",

--- a/tests/support/raw_responses.py
+++ b/tests/support/raw_responses.py
@@ -1,4 +1,5 @@
 __all__ = (
+    "SECURITY_HEADER_NAMES",
     "header_values",
     "headers_payload",
     "json_payload",
@@ -27,6 +28,35 @@ from tests.support.http_routes import (
     redirect_to_status,
     status_code,
     unknown_size_bytes_response_size,
+)
+
+
+SECURITY_HEADER_NAMES = (
+    "accept",
+    "authorization",
+    "content-checksum",
+    "content-digest",
+    "content-disposition",
+    "content-encoding",
+    "content-language",
+    "content-length",
+    "content-location",
+    "content-range",
+    "content-type",
+    "cookie",
+    "digest",
+    "host",
+    "if-match",
+    "if-modified-since",
+    "if-none-match",
+    "if-range",
+    "if-unmodified-since",
+    "last-modified",
+    "origin",
+    "proxy-authorization",
+    "referer",
+    "repr-digest",
+    "transfer-encoding",
 )
 
 
@@ -274,22 +304,7 @@ def _raw_json_response(*, method: str, request_line: str, body: bytes) -> bytes:
 
 
 def _security_headers_from_raw(headers: str) -> dict[str, list[str]]:
-    return {
-        name: header_values(headers, name)
-        for name in (
-            "accept",
-            "authorization",
-            "content-encoding",
-            "content-length",
-            "content-type",
-            "cookie",
-            "host",
-            "origin",
-            "proxy-authorization",
-            "referer",
-            "transfer-encoding",
-        )
-    }
+    return {name: header_values(headers, name) for name in SECURITY_HEADER_NAMES}
 
 
 def _reason_phrase(status: int) -> str:

--- a/tests/support/sync_http_server.py
+++ b/tests/support/sync_http_server.py
@@ -25,7 +25,12 @@ from tests.support.http_routes import (
     status_code,
     unknown_size_bytes_response_size,
 )
-from tests.support.raw_responses import headers_payload, json_payload, security_headers_payload
+from tests.support.raw_responses import (
+    SECURITY_HEADER_NAMES,
+    headers_payload,
+    json_payload,
+    security_headers_payload,
+)
 
 
 class SyncHTTPHandler(BaseHTTPRequestHandler):
@@ -217,22 +222,7 @@ class SyncHTTPHandler(BaseHTTPRequestHandler):
         if path != SECURITY_HEADERS_PATH:
             return False
 
-        headers = {
-            name: self.headers.get_all(name, [])
-            for name in (
-                "accept",
-                "authorization",
-                "content-encoding",
-                "content-length",
-                "content-type",
-                "cookie",
-                "host",
-                "origin",
-                "proxy-authorization",
-                "referer",
-                "transfer-encoding",
-            )
-        }
+        headers = {name: self.headers.get_all(name, []) for name in SECURITY_HEADER_NAMES}
         payload = security_headers_payload(
             headers=headers,
             request_line=self.requestline,

--- a/tests/test_async_redirects.py
+++ b/tests/test_async_redirects.py
@@ -15,6 +15,8 @@ from foghttp.status_codes.redirect import (
 )
 from foghttp.status_codes.success import OK
 from tests.redirect_helpers import (
+    REDIRECT_CONDITIONAL_HEADERS,
+    REDIRECT_CONTENT_HEADERS,
     REDIRECT_SECURITY_HEADERS,
     SECURITY_HEADERS_PATH,
     header_values,
@@ -140,12 +142,17 @@ async def test_post_method_preserving_redirect_rejects_non_replayable_body(
     assert stats.active_requests == 0
 
 
-async def test_same_origin_redirect_preserves_sensitive_headers(http_server: str) -> None:
+async def test_same_origin_redirect_preserves_scoped_and_strips_conditional_headers(
+    http_server: str,
+) -> None:
     location = f"{http_server}{SECURITY_HEADERS_PATH}"
     url = redirect_to_location_url(http_server, status_code=FOUND, location=location)
 
     async with foghttp.AsyncClient(follow_redirects=True) as client:
-        response = await client.get(url, headers=REDIRECT_SECURITY_HEADERS)
+        response = await client.get(
+            url,
+            headers={**REDIRECT_SECURITY_HEADERS, **REDIRECT_CONDITIONAL_HEADERS},
+        )
 
     payload = response.json()
     assert header_values(payload, "authorization") == ["Bearer secret"]
@@ -154,6 +161,8 @@ async def test_same_origin_redirect_preserves_sensitive_headers(http_server: str
     assert header_values(payload, "host") == [urlsplit(http_server).netloc]
     assert header_values(payload, "origin") == ["https://example.com"]
     assert header_values(payload, "referer") == ["https://example.com/source"]
+    for name in REDIRECT_CONDITIONAL_HEADERS:
+        assert header_values(payload, name) == []
 
 
 async def test_cross_origin_redirect_strips_sensitive_headers(
@@ -164,7 +173,10 @@ async def test_cross_origin_redirect_strips_sensitive_headers(
     url = redirect_to_location_url(http_server, status_code=FOUND, location=location)
 
     async with foghttp.AsyncClient(follow_redirects=True) as client:
-        response = await client.get(url, headers=REDIRECT_SECURITY_HEADERS)
+        response = await client.get(
+            url,
+            headers={**REDIRECT_SECURITY_HEADERS, **REDIRECT_CONDITIONAL_HEADERS},
+        )
 
     payload = response.json()
     assert header_values(payload, "accept") == ["application/json"]
@@ -174,6 +186,33 @@ async def test_cross_origin_redirect_strips_sensitive_headers(
     assert header_values(payload, "host") == [urlsplit(secondary_http_server).netloc]
     assert header_values(payload, "origin") == []
     assert header_values(payload, "referer") == []
+    for name in REDIRECT_CONDITIONAL_HEADERS:
+        assert header_values(payload, name) == []
+
+
+async def test_cross_origin_get_redirect_drops_explicit_body(
+    http_server: str,
+    secondary_http_server: str,
+    faker: Faker,
+) -> None:
+    location = f"{secondary_http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(http_server, status_code=FOUND, location=location)
+    request_body = faker.sentence()
+
+    async with foghttp.AsyncClient(follow_redirects=True) as client:
+        request = client.build_request(
+            GET,
+            url,
+            headers=REDIRECT_CONTENT_HEADERS,
+            content=request_body,
+        )
+        assert request.content == request_body.encode()
+        response = await client.send(request)
+
+    payload = response.json()
+    assert payload["body"] == ""
+    for name in REDIRECT_CONTENT_HEADERS:
+        assert header_values(payload, name) == []
 
 
 async def test_post_redirect_rewrite_strips_body_headers(http_server: str, faker: Faker) -> None:
@@ -186,8 +225,7 @@ async def test_post_redirect_rewrite_strips_body_headers(http_server: str, faker
             url,
             headers={
                 "authorization": "Bearer secret",
-                "content-encoding": "identity",
-                "content-type": "text/plain",
+                **REDIRECT_CONTENT_HEADERS,
             },
             content=post_body,
         )
@@ -196,8 +234,10 @@ async def test_post_redirect_rewrite_strips_body_headers(http_server: str, faker
     assert payload["request_line"] == f"GET {SECURITY_HEADERS_PATH} HTTP/1.1"
     assert payload["body"] == ""
     assert header_values(payload, "authorization") == ["Bearer secret"]
-    assert header_values(payload, "content-encoding") == []
-    assert header_values(payload, "content-type") == []
+    assert header_values(payload, "content-length") == []
+    assert header_values(payload, "transfer-encoding") == []
+    for name in REDIRECT_CONTENT_HEADERS:
+        assert header_values(payload, name) == []
 
 
 async def test_post_redirect_preserving_method_keeps_body_headers(http_server: str, faker: Faker) -> None:
@@ -208,14 +248,17 @@ async def test_post_redirect_preserving_method_keeps_body_headers(http_server: s
     async with foghttp.AsyncClient(follow_redirects=True) as client:
         response = await client.post(
             url,
-            headers={"content-type": "text/plain"},
+            headers=REDIRECT_CONTENT_HEADERS,
             content=post_body,
         )
 
     payload = response.json()
     assert payload["request_line"] == f"POST {SECURITY_HEADERS_PATH} HTTP/1.1"
     assert payload["body"] == post_body
-    assert header_values(payload, "content-type") == ["text/plain"]
+    assert header_values(payload, "content-length") == [str(len(post_body.encode()))]
+    assert header_values(payload, "transfer-encoding") == []
+    for name, value in REDIRECT_CONTENT_HEADERS.items():
+        assert header_values(payload, name) == [value]
 
 
 @pytest.mark.parametrize("status_code", POST_REDIRECTS_PRESERVE_METHOD_STATUS_CODES)
@@ -238,8 +281,7 @@ async def test_cross_origin_post_redirect_drops_body_replay(
             url,
             headers={
                 **REDIRECT_SECURITY_HEADERS,
-                "content-encoding": "identity",
-                "content-type": "text/plain",
+                **REDIRECT_CONTENT_HEADERS,
             },
             content=post_body,
         )
@@ -249,8 +291,8 @@ async def test_cross_origin_post_redirect_drops_body_replay(
     assert payload["body"] == ""
     assert header_values(payload, "accept") == ["application/json"]
     assert header_values(payload, "authorization") == []
-    assert header_values(payload, "content-encoding") == []
-    assert header_values(payload, "content-type") == []
+    for name in REDIRECT_CONTENT_HEADERS:
+        assert header_values(payload, name) == []
     assert header_values(payload, "cookie") == []
     assert header_values(payload, "host") == [urlsplit(secondary_http_server).netloc]
     assert header_values(payload, "origin") == []

--- a/tests/test_sync_redirects.py
+++ b/tests/test_sync_redirects.py
@@ -15,6 +15,8 @@ from foghttp.status_codes.redirect import (
 )
 from foghttp.status_codes.success import OK
 from tests.redirect_helpers import (
+    REDIRECT_CONDITIONAL_HEADERS,
+    REDIRECT_CONTENT_HEADERS,
     REDIRECT_SECURITY_HEADERS,
     SECURITY_HEADERS_PATH,
     header_values,
@@ -153,12 +155,17 @@ def test_post_method_preserving_redirect_rejects_non_replayable_body(
     assert stats.active_requests == 0
 
 
-def test_same_origin_redirect_preserves_sensitive_headers(sync_http_server: str) -> None:
+def test_same_origin_redirect_preserves_scoped_and_strips_conditional_headers(
+    sync_http_server: str,
+) -> None:
     location = f"{sync_http_server}{SECURITY_HEADERS_PATH}"
     url = redirect_to_location_url(sync_http_server, status_code=FOUND, location=location)
 
     with foghttp.Client(follow_redirects=True) as client:
-        response = client.get(url, headers=REDIRECT_SECURITY_HEADERS)
+        response = client.get(
+            url,
+            headers={**REDIRECT_SECURITY_HEADERS, **REDIRECT_CONDITIONAL_HEADERS},
+        )
 
     payload = response.json()
     assert header_values(payload, "authorization") == ["Bearer secret"]
@@ -167,6 +174,8 @@ def test_same_origin_redirect_preserves_sensitive_headers(sync_http_server: str)
     assert header_values(payload, "host") == [urlsplit(sync_http_server).netloc]
     assert header_values(payload, "origin") == ["https://example.com"]
     assert header_values(payload, "referer") == ["https://example.com/source"]
+    for name in REDIRECT_CONDITIONAL_HEADERS:
+        assert header_values(payload, name) == []
 
 
 def test_cross_origin_redirect_strips_sensitive_headers(
@@ -177,7 +186,10 @@ def test_cross_origin_redirect_strips_sensitive_headers(
     url = redirect_to_location_url(sync_http_server, status_code=FOUND, location=location)
 
     with foghttp.Client(follow_redirects=True) as client:
-        response = client.get(url, headers=REDIRECT_SECURITY_HEADERS)
+        response = client.get(
+            url,
+            headers={**REDIRECT_SECURITY_HEADERS, **REDIRECT_CONDITIONAL_HEADERS},
+        )
 
     payload = response.json()
     assert header_values(payload, "accept") == ["application/json"]
@@ -187,6 +199,33 @@ def test_cross_origin_redirect_strips_sensitive_headers(
     assert header_values(payload, "host") == [urlsplit(secondary_sync_http_server).netloc]
     assert header_values(payload, "origin") == []
     assert header_values(payload, "referer") == []
+    for name in REDIRECT_CONDITIONAL_HEADERS:
+        assert header_values(payload, name) == []
+
+
+def test_cross_origin_get_redirect_drops_explicit_body(
+    sync_http_server: str,
+    secondary_sync_http_server: str,
+    faker: Faker,
+) -> None:
+    location = f"{secondary_sync_http_server}{SECURITY_HEADERS_PATH}"
+    url = redirect_to_location_url(sync_http_server, status_code=FOUND, location=location)
+    request_body = faker.sentence()
+
+    with foghttp.Client(follow_redirects=True) as client:
+        request = client.build_request(
+            GET,
+            url,
+            headers=REDIRECT_CONTENT_HEADERS,
+            content=request_body,
+        )
+        assert request.content == request_body.encode()
+        response = client.send(request)
+
+    payload = response.json()
+    assert payload["body"] == ""
+    for name in REDIRECT_CONTENT_HEADERS:
+        assert header_values(payload, name) == []
 
 
 def test_post_redirect_rewrite_strips_body_headers(sync_http_server: str, faker: Faker) -> None:
@@ -199,8 +238,7 @@ def test_post_redirect_rewrite_strips_body_headers(sync_http_server: str, faker:
             url,
             headers={
                 "authorization": "Bearer secret",
-                "content-encoding": "identity",
-                "content-type": "text/plain",
+                **REDIRECT_CONTENT_HEADERS,
             },
             content=post_body,
         )
@@ -209,8 +247,10 @@ def test_post_redirect_rewrite_strips_body_headers(sync_http_server: str, faker:
     assert payload["request_line"] == f"GET {SECURITY_HEADERS_PATH} HTTP/1.1"
     assert payload["body"] == ""
     assert header_values(payload, "authorization") == ["Bearer secret"]
-    assert header_values(payload, "content-encoding") == []
-    assert header_values(payload, "content-type") == []
+    assert header_values(payload, "content-length") == []
+    assert header_values(payload, "transfer-encoding") == []
+    for name in REDIRECT_CONTENT_HEADERS:
+        assert header_values(payload, name) == []
 
 
 def test_post_redirect_preserving_method_keeps_body_headers(sync_http_server: str, faker: Faker) -> None:
@@ -221,14 +261,17 @@ def test_post_redirect_preserving_method_keeps_body_headers(sync_http_server: st
     with foghttp.Client(follow_redirects=True) as client:
         response = client.post(
             url,
-            headers={"content-type": "text/plain"},
+            headers=REDIRECT_CONTENT_HEADERS,
             content=post_body,
         )
 
     payload = response.json()
     assert payload["request_line"] == f"POST {SECURITY_HEADERS_PATH} HTTP/1.1"
     assert payload["body"] == post_body
-    assert header_values(payload, "content-type") == ["text/plain"]
+    assert header_values(payload, "content-length") == [str(len(post_body.encode()))]
+    assert header_values(payload, "transfer-encoding") == []
+    for name, value in REDIRECT_CONTENT_HEADERS.items():
+        assert header_values(payload, name) == [value]
 
 
 @pytest.mark.parametrize("status_code", POST_REDIRECTS_PRESERVE_METHOD_STATUS_CODES)
@@ -251,8 +294,7 @@ def test_cross_origin_post_redirect_drops_body_replay(
             url,
             headers={
                 **REDIRECT_SECURITY_HEADERS,
-                "content-encoding": "identity",
-                "content-type": "text/plain",
+                **REDIRECT_CONTENT_HEADERS,
             },
             content=post_body,
         )
@@ -262,8 +304,8 @@ def test_cross_origin_post_redirect_drops_body_replay(
     assert payload["body"] == ""
     assert header_values(payload, "accept") == ["application/json"]
     assert header_values(payload, "authorization") == []
-    assert header_values(payload, "content-encoding") == []
-    assert header_values(payload, "content-type") == []
+    for name in REDIRECT_CONTENT_HEADERS:
+        assert header_values(payload, name) == []
     assert header_values(payload, "cookie") == []
     assert header_values(payload, "host") == [urlsplit(secondary_sync_http_server).netloc]
     assert header_values(payload, "origin") == []


### PR DESCRIPTION
- rebuild transport and connection headers on every redirect
- strip conditional and stale content metadata safely
- enforce typed same-origin and cross-origin header policies
- prevent cross-origin body replay for generic requests
- add comprehensive sync, async, and Rust regression coverage
- document redirect header forwarding rules

Refs #113