### PR TITLE
chore(release): prepare 0.3.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "brotli",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foghttp"
-version = "0.3.6"
+version = "0.3.7"
 description = "Observable Rust-powered HTTP client for Python services."
 edition = "2021"
 homepage = "https://github.com/AmberFog/foghttp"

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Runtime requirements:
 - `orjson>=3.11,<4`
 
 Published CPython wheels use the stable `cp311-abi3` ABI: each supported
-OS/architecture pair has one wheel for Python 3.11 and newer. The release
-pipeline currently installs and exercises those wheels on GIL-enabled CPython
-3.11 through 3.14. See [Packaging and Python compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/packaging.md)
+OS/architecture pair has one wheel for the currently validated GIL-enabled
+CPython 3.11 through 3.14 range. Newer Python versions are not part of the
+compatibility claim until they pass the same release checks. See [Packaging and Python compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/packaging.md)
 for the complete wheel matrix and validation policy.
 
 ## Quick Start
@@ -112,7 +112,8 @@ async with foghttp.AsyncClient() as client:
 - redacted repr/error surfaces for sensitive headers, URL credentials,
   token-like URL params, and buffered body bytes
 - normalized `URL` model with origin comparison and relative joins
-- GET/HEAD/POST/QUERY redirects with final URL, history, and conservative replay policy
+- GET/HEAD/POST/QUERY redirects with final URL, history, typed same-origin and
+  cross-origin header policy, and no cross-origin body replay
 - HTTP proxy routing and HTTPS proxy `CONNECT` tunnelling through explicit
   `proxy=` or `trust_env=True` when the proxy endpoint uses `http://`
 - HTTPS with default WebPKI roots, explicit custom CA certificates, and

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,7 +121,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - redacted repr/error surfaces for sensitive headers, URL credentials,
   token-like URL params, and buffered body bytes
 - normalized `URL` model with origin comparison and relative joins
-- GET/HEAD/POST/QUERY redirects with final URL, history, and conservative replay policy
+- GET/HEAD/POST/QUERY redirects with final URL, history, typed same-origin and
+  cross-origin header policy, and no cross-origin body replay
 - HTTPS with default WebPKI roots, explicit custom CA certificates, and
   custom-only CA trust
 - documented lazy transport creation, graceful sync close, async request

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -2,9 +2,11 @@
 
 FogHTTP ships a Rust extension built with PyO3. Published CPython wheels target
 the stable `cp311-abi3` ABI, matching the package minimum of Python 3.11. One
-wheel per supported operating-system and architecture pair can therefore be
-installed by GIL-enabled CPython 3.11 and newer instead of building a separate
-wheel for every CPython minor version.
+wheel per supported operating-system and architecture pair covers the
+currently validated GIL-enabled CPython 3.11-3.14 range instead of requiring a
+separate wheel for every supported CPython minor version. The ABI may remain
+compatible with newer Python versions, but FogHTTP does not claim that support
+until the full suite and exact wheel pass the release validation matrix.
 
 ## Release Matrix
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "foghttp"
-version = "0.3.6"
+version = "0.3.7"
 description = "Observable Rust-powered HTTP client for Python services."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
- bump Python and Rust package metadata
- refresh redirect and packaging documentation
- regenerate project lockfiles

Closes #195