### PR TITLE
chore(release): prepare 0.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "brotli",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foghttp"
-version = "0.3.7"
+version = "0.3.8"
 description = "Observable Rust-powered HTTP client for Python services."
 edition = "2021"
 homepage = "https://github.com/AmberFog/foghttp"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - typed telemetry event hooks with redacted request/response lifecycle events
 - versioned telemetry snapshots that separate alert-oriented stats from
   diagnostic dump APIs
+- opt-in Rust-owned retries with replayability gates and immutable attempt
+  traces, plus opt-in per-hop and post-DNS SSRF destination controls
 - opt-in async lifecycle debug snapshots for staging and tests
 - lazy process-wide shared Tokio runtime by default, opt-in dedicated runtime
   tuning, and fail-closed client ownership across `fork()`
@@ -170,7 +172,8 @@ available as bytes/text/line context-managed APIs. Streaming `content=` uploads
 and multipart `files=` uploads are available with explicit replayability and
 cleanup rules. HTTP proxy routing and HTTPS proxy `CONNECT` tunnelling are
 available through `proxy=` and `trust_env=True` when the proxy endpoint itself
-uses `http://`.
+uses `http://`. Proxy-routed requests fail closed when `SSRFPolicy` is enabled
+because the client cannot prove which target address a remote proxy resolves.
 Cookies, auth helpers, HTTP/2, automatic `Accept-Encoding` negotiation,
 streaming decompression, and per-request connect timeout reconfiguration are
 planned for later versions. Physical connection caps currently apply to the

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: "home"
 hero:
   name: "FogHTTP"
   text: "Rust-powered HTTP client for Python"
-  tagline: "Buffered JSON and form requests, streaming and multipart uploads, sync and async response streaming, transparent response decoding, base URL clients, default headers and params, opt-in safe retries, redirects, custom CA certificates, cancellation, and observable request limits with pool diagnostics."
+  tagline: "Buffered JSON and form requests, streaming and multipart uploads, sync and async response streaming, transparent response decoding, base URL clients, default headers and params, opt-in safe retries and SSRF destination controls, redirects, custom CA certificates, cancellation, and observable request limits with pool diagnostics."
 
 features:
   - title: "Rust transport"
@@ -104,6 +104,9 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - cancellable buffered async requests
 - bounded sync and async response streaming
 - prepared requests that can be inspected before sending
+- opt-in safe retries with request-scoped attempt diagnostics
+- direct service clients that need an opt-in SSRF guard for partially trusted
+  destination URLs
 - simple benchmarks against other buffered HTTP clients
 
 ## Key Features

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -56,7 +56,11 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - opt-in synchronous transport policy hooks with immutable request/response
   snapshots and Rust-owned redirect safety
 - opt-in retry policy for selected statuses and pre-header network failures,
-  gated by method safety and request-body replayability
+  gated by method safety and request-body replayability, with immutable
+  request-scoped attempt traces on responses and terminal `FogHTTPError`
+- opt-in SSRF destination policy with scheme/origin/domain allowlists,
+  per-redirect checks, post-resolution address validation, and typed redacted
+  `SSRFError` reasons
 - opt-in async lifecycle debug snapshots for active async request handles,
   pending transport pressure, strict test checks, and unclosed-client context
 - default per-response and aggregate buffered response memory limits
@@ -102,6 +106,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | telemetry hook granularity | `TelemetryConfig` currently dispatches Python-level request/response lifecycle events; lower-level Rust pool acquire and connection lifecycle event delivery is planned before Prometheus/OpenTelemetry exporters |
 | transport policy hook execution | `TransportPolicyHooks` callbacks are synchronous, inline, non-reentrant, and may run on Rust transport worker threads; `after_response_body` observes only redirect bodies consumed internally, not the final response body returned to the caller |
 | retry scope | Retry is client-level and opt-in. It covers configured response statuses and pre-header `NetworkError` only; response-body errors, FogHTTP timeouts, local upload-provider failures, auth refresh, hedging, and circuit breaking are not retried. |
+| SSRF protection scope | `SSRFPolicy` is client-level and opt-in. It validates initial and redirected destinations plus every resolved address, but it is not a replacement for network egress policy. Proxy routes fail closed because a remote proxy can resolve the target independently. |
 | diagnostic snapshot transactionality | `stats()`, `dump_transport_state()`, and `dump_pool_diagnostics()` include `schema_version` and a monotonic `snapshot_sequence`, but the `dump_*` APIs remain diagnostic snapshots rather than lock-protected SLA transactions; use `stats()` for alert-oriented low-cardinality metrics |
 
 ## Practical Guidance
@@ -119,6 +124,8 @@ Use FogHTTP today when:
 - async request cancellation and sync/async stream cleanup behavior are useful
 - global/per-origin request-slot backpressure and opt-in global/per-host
   physical connection caps are enough for your resource control needs
+- you accept partially trusted destination URLs and can use direct connections
+  with an explicit client-level `SSRFPolicy`
 - you can reuse clients instead of creating many short-lived transport and pool
   instances once requests start flowing
 
@@ -126,6 +133,8 @@ Wait before using FogHTTP when:
 
 - you need transparent streaming decompression
 - you need SOCKS, PAC, WPAD, or platform proxy discovery
+- you require proxy routing and application-layer SSRF protection on the same
+  client; enforce destination policy at the proxy or network egress boundary
 - you rely on cookies across requests
 - you need per-request connect timeout reconfiguration
 - you need automatic compression negotiation instead of manual
@@ -142,6 +151,8 @@ to `ReadTimeout` for buffered responses and streamed body chunks. Buffered and
 streamed request body write progress timeout maps to `WriteTimeout`. The broader
 buffered transport deadline maps to the base `TimeoutError` with phase-aware
 diagnostics; for streaming responses it covers acquire, redirects, and response
-headers before the stream is returned. Dedicated connect timeout exception mapping is
-reserved for later timeout work. See
+headers before the stream is returned. An enabled SSRF policy raises
+`SSRFError` with a stable `SSRFViolationReason` before a blocked destination is
+sent. Dedicated connect timeout exception mapping is reserved for later timeout
+work. See
 [Timeout model](./timeouts.md) for the current behavior.

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,8 @@ uv run examples/multipart_uploads.py
 uv run examples/redirects.py
 uv run examples/prepared_requests.py
 uv run examples/request_builder_compatibility.py
+uv run examples/retry_policy.py
+uv run examples/ssrf_policy.py
 uv run examples/telemetry_hooks.py
 ```
 
@@ -55,6 +57,10 @@ uv run examples/telemetry_hooks.py
 - [request_builder_compatibility.py](./request_builder_compatibility.py):
   client defaults, repeated query params, form data, prepared requests, and body
   conflict validation.
+- [retry_policy.py](./retry_policy.py): opt-in status retries and immutable
+  request-scoped attempt trace inspection.
+- [ssrf_policy.py](./ssrf_policy.py): a trusted domain allowlist and stable
+  typed rejection reason for a blocked destination.
 - [telemetry_hooks.py](./telemetry_hooks.py): opt-in typed telemetry events with
   redacted URLs and explicit hook error policy.
 

--- a/examples/retry_policy.py
+++ b/examples/retry_policy.py
@@ -1,0 +1,41 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "foghttp",
+# ]
+#
+# [tool.uv.sources]
+# foghttp = { path = "../", editable = true }
+# ///
+
+import foghttp
+
+
+def main() -> None:
+    retry = foghttp.RetryPolicy(
+        retries=2,
+        backoff=0.0,
+        jitter=0.0,
+    )
+    with foghttp.Client(retry=retry) as client:
+        response = client.get("https://httpbin.org/status/503")
+
+    trace = response.retry_trace
+    if trace is None:
+        msg = "retry-enabled requests must expose a trace"
+        raise RuntimeError(msg)
+
+    print("final status:", response.status_code)
+    for attempt in trace.attempts:
+        print(
+            "attempt:",
+            attempt.attempt,
+            "decision:",
+            attempt.decision,
+            "reason:",
+            attempt.reason,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ssrf_policy.py
+++ b/examples/ssrf_policy.py
@@ -1,0 +1,30 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "foghttp",
+# ]
+#
+# [tool.uv.sources]
+# foghttp = { path = "../", editable = true }
+# ///
+
+import foghttp
+
+
+def main() -> None:
+    policy = foghttp.SSRFPolicy(
+        allowed_schemes=("https",),
+        allowed_domains=("httpbin.org",),
+    )
+    with foghttp.Client(ssrf=policy) as client:
+        response = client.get("https://httpbin.org/get")
+        print("allowed:", response.url, "status:", response.status_code)
+
+        try:
+            client.get("https://example.com/")
+        except foghttp.SSRFError as error:
+            print("blocked:", error.reason.value)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "foghttp"
-version = "0.3.7"
+version = "0.3.8"
 description = "Observable Rust-powered HTTP client for Python services."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
Synchronize Python and Rust package metadata, refresh retry and SSRF release documentation, and add runnable policy examples.

Refs #196