### PR TITLE
feat(cookies): add opt-in client cookie jar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,16 +73,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "time",
- "version_check",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,7 +126,6 @@ version = "0.3.8"
 dependencies = [
  "brotli",
  "bytes",
- "cookie",
  "fastrand",
  "flate2",
  "http-body-util",
@@ -147,6 +136,7 @@ dependencies = [
  "pyo3",
  "rfc_6265",
  "rustls",
+ "time",
  "tokio",
  "tower-service",
  "url",
@@ -852,12 +842,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +90,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "displaydoc"
@@ -120,6 +136,7 @@ version = "0.3.8"
 dependencies = [
  "brotli",
  "bytes",
+ "cookie",
  "fastrand",
  "flate2",
  "http-body-util",
@@ -128,6 +145,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "pyo3",
+ "rfc_6265",
  "rustls",
  "tokio",
  "tower-service",
@@ -436,6 +454,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +491,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -541,6 +571,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rfc_6265"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c385d4fba1a27dee6cdda85c619e8f714131a1c36da3ee4b67230414c8d7fd84"
+dependencies = [
+ "idna",
+ "time",
 ]
 
 [[package]]
@@ -689,6 +729,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "time"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +852,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "foghttp"
 version = "0.3.8"
 description = "Observable Rust-powered HTTP client for Python services."
 edition = "2021"
+rust-version = "1.88"
 homepage = "https://github.com/AmberFog/foghttp"
 license = "MIT"
 publish = false
@@ -23,6 +24,8 @@ fastrand = "2.3.0"
 flate2 = "1.1.9"
 http-body-util = "0.1.3"
 httpdate = "1.0.3"
+cookie = { version = "0.18.1", default-features = false }
+rfc_6265 = { version = "0.1.1", default-features = false, features = ["date", "idna", "path"] }
 url = "2.5.8"
 
 [dependencies.hyper]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ fastrand = "2.3.0"
 flate2 = "1.1.9"
 http-body-util = "0.1.3"
 httpdate = "1.0.3"
-cookie = { version = "0.18.1", default-features = false }
 rfc_6265 = { version = "0.1.1", default-features = false, features = ["date", "idna", "path"] }
+time = { version = "0.3.54", default-features = false, features = ["std"] }
 url = "2.5.8"
 
 [dependencies.hyper]

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ async with foghttp.AsyncClient() as client:
 - grouped HTTP status constants and reusable HTTP method constants
 - client-level Basic and synchronous callable authentication with retry refresh
   and cross-origin credential stripping
+- opt-in client-owned cookie jar with bounded domain/path/expiry matching,
+  redirect/retry coordination, and redacted diagnostics
 
 ## Documentation
 
@@ -150,6 +152,7 @@ async with foghttp.AsyncClient() as client:
 - [Quickstart](https://github.com/AmberFog/foghttp/blob/main/docs/quickstart.md)
 - [Request builder compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/request-builder.md)
 - [Authentication](https://github.com/AmberFog/foghttp/blob/main/docs/auth.md)
+- [Cookies](https://github.com/AmberFog/foghttp/blob/main/docs/cookies.md)
 - [Client lifecycle](https://github.com/AmberFog/foghttp/blob/main/docs/lifecycle.md)
 - [Packaging and Python compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/packaging.md)
 - [Timeout model](https://github.com/AmberFog/foghttp/blob/main/docs/timeouts.md)
@@ -177,8 +180,8 @@ cleanup rules. HTTP proxy routing and HTTPS proxy `CONNECT` tunnelling are
 available through `proxy=` and `trust_env=True` when the proxy endpoint itself
 uses `http://`. Proxy-routed requests fail closed when `SSRFPolicy` is enabled
 because the client cannot prove which target address a remote proxy resolves.
-Cookies, provider-specific OAuth flows, HTTP/2, automatic `Accept-Encoding`
-negotiation, streaming decompression, and per-request connect timeout
+Provider-specific OAuth flows, HTTP/2, automatic `Accept-Encoding` negotiation,
+streaming decompression, and per-request connect timeout
 reconfiguration are planned for later versions. Physical connection caps
 currently apply to the HTTP/1.1 connector path; HTTP/2 will require separate
 stream-level limits.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -121,5 +121,8 @@ contents of an exception raised by the callable remain the application's
 responsibility.
 
 The API is intentionally FogHTTP-native rather than compatible with
-`httpx.Auth`. Cookie jars, OAuth flows, provider SDKs, async auth callables, and
-a public middleware framework remain outside this interface.
+`httpx.Auth`. The opt-in [cookie jar](./cookies.md) is a separate Rust-owned
+transport policy. If an auth hook supplies `Cookie`, that explicit value wins
+for the hop and the jar does not merge into it. OAuth flows, provider SDKs,
+async auth callables, and a public middleware framework remain outside this
+interface.

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -1,0 +1,106 @@
+# Cookies
+
+FogHTTP cookies are client-level, opt-in session state. The default remains
+stateless: `cookies=False` stores nothing and never adds a `Cookie` header.
+
+```python
+import foghttp
+
+
+with foghttp.Client(cookies=True) as client:
+    login = client.post(
+        "https://api.example.com/login",
+        json={"username": "ada", "password": "secret"},  # pragma: allowlist secret
+    )
+    login.raise_for_status()
+
+    profile = client.get("https://api.example.com/profile")
+    profile.raise_for_status()
+```
+
+`AsyncClient(cookies=True)` has the same behavior. The jar belongs to one
+client, is kept only in memory, and disappears with that client. Clients never
+share cookie state implicitly.
+
+## Matching And Storage
+
+The Rust transport owns the jar because redirects, retries, and streaming
+response headers are already managed there. Enabling cookies does not add a
+Python callback to each request.
+
+For every `Set-Cookie` response field, FogHTTP independently applies the
+following rules:
+
+- host-only and `Domain` cookies use HTTP cookie domain matching
+- `Path` uses segment-boundary matching; a missing or relative value uses the
+  request URL's default path
+- `Max-Age` takes precedence over tolerant HTTP cookie-date `Expires` parsing;
+  persistent lifetimes are capped at 400 days and expired cookies are removed
+- `Secure` cookies are accepted and sent only for HTTPS or a trustworthy
+  loopback origin
+- an insecure origin cannot overwrite or delete a matching secure cookie
+- `__Secure-` and `__Host-` name-prefix requirements are enforced
+- malformed or rejected fields do not prevent valid sibling fields from being
+  stored
+
+Matching cookies are sent with longer paths first, then by creation order.
+Cookie values are opaque: percent-looking octets are preserved exactly rather
+than decoded or canonicalized. Cookie scope does not include the TCP port.
+
+Response headers update the jar before redirect or retry handling, before a
+buffered body is read, and before a streaming response is exposed. A cookie set
+on a retryable response can therefore be used by the next attempt. A body read
+failure does not roll back a valid `Set-Cookie` already received in the response
+headers.
+
+## Header Precedence And Redirects
+
+FogHTTP removes only its own previously attached `Cookie` header and selects
+again for every transport attempt and redirect hop. It never blindly forwards
+a managed cookie from the source URL to the redirect target.
+
+An explicit request, prepared-request, client-default, or auth-generated
+`Cookie` header wins for that hop. FogHTTP does not merge the jar into an
+explicit value. The existing redirect security policy preserves explicit
+cookies for same-origin redirects and removes them for cross-origin redirects;
+after removal, the jar may select cookies that independently match the target.
+
+Because HTTP cookies are scoped by host/domain and path rather than port, a
+cookie may be sent to another port on the same matching host. `Secure` still
+prevents sending a secure cookie over an untrusted plain-HTTP destination.
+
+## Capacity And Expiration
+
+The in-memory jar is bounded:
+
+- at most 4096 octets for the cookie name and value together
+- at most 16 KiB for one `Set-Cookie` field
+- at most 50 cookies per stored domain value
+- at most 3000 cookies per client
+
+Expired entries are removed first. When a domain limit is exceeded, non-secure
+cookies are evicted before secure cookies; equal-priority cookies and global
+overflow are ordered by least recent access. Servers must tolerate cookie
+eviction, as required for interoperable HTTP cookie use.
+
+## Redaction
+
+`Cookie` and `Set-Cookie` values are available through the normal header API,
+but their values are redacted from request, response, redirect-history, and
+header `repr()` output. Telemetry does not record request or response header
+values. The native jar has no public debug or inspection representation and
+does not log rejected cookie contents.
+
+## V1 Boundaries
+
+The v1 jar is an HTTP service-client feature, not a browser cookie engine:
+
+- no public-suffix list is applied; only accept `Domain` cookies from services
+  you trust not to set an overly broad suffix
+- `SameSite`, `Partitioned`, and browser third-party-cookie policy are not
+  enforced because FogHTTP has no browser top-level-site context
+- there is no persistent storage, public jar mutation/inspection API, or
+  automatic sharing between clients
+
+Use a browser automation stack when those browser security and privacy
+semantics are part of the application contract.

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -42,10 +42,16 @@ following rules:
 - `__Secure-` and `__Host-` name-prefix requirements are enforced
 - malformed or rejected fields do not prevent valid sibling fields from being
   stored
+- nameless fields such as `Set-Cookie: session-token` are returned without an
+  equals sign, following the HTTP cookie retrieval algorithm
 
 Matching cookies are sent with longer paths first, then by creation order.
-Cookie values are opaque: percent-looking octets are preserved exactly rather
-than decoded or canonicalized. Cookie scope does not include the TCP port.
+Cookie values are opaque: supported ASCII header octets, including
+percent-looking values, are preserved exactly rather than decoded or
+canonicalized. Name/value pairs containing non-ASCII `obs-text` are ignored
+rather than transcoded across the Python/Rust string boundary. Cookie scope
+does not include the TCP port. Non-ASCII `Domain` attributes are rejected;
+ASCII punycode domains remain supported.
 
 Response headers update the jar before redirect or retry handling, before a
 buffered body is read, and before a streaming response is exposed. A cookie set

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: "home"
 hero:
   name: "FogHTTP"
   text: "Rust-powered HTTP client for Python"
-  tagline: "Buffered JSON and form requests, streaming and multipart uploads, sync and async response streaming, transparent response decoding, base URL clients, default headers and params, opt-in safe retries and SSRF destination controls, redirects, custom CA certificates, cancellation, and observable request limits with pool diagnostics."
+  tagline: "Buffered JSON and form requests, streaming and multipart uploads, sync and async response streaming, transparent response decoding, base URL clients, default headers and params, opt-in cookies, safe retries and SSRF destination controls, redirects, custom CA certificates, cancellation, and observable request limits with pool diagnostics."
 
 features:
   - title: "Rust transport"
@@ -68,6 +68,8 @@ FogHTTP is designed around a few engineering priorities:
   post-resolution IP checks, and DNS rebinding mitigation
 - client-level Basic authentication and synchronous request-aware auth hooks
   with retry refresh and cross-origin credential stripping
+- opt-in client-owned cookie jar with bounded RFC-style domain, path, expiry,
+  redirect, and retry behavior
 - versioned telemetry snapshots that separate alert-oriented stats from
   diagnostic dump APIs
 - opt-in async lifecycle debug snapshots for tests, staging, and incident
@@ -81,6 +83,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - [Quickstart](./quickstart.md)
 - [Request builder compatibility](./request-builder.md)
 - [Authentication](./auth.md)
+- [Cookies](./cookies.md)
 - [Client lifecycle](./lifecycle.md)
 - [Packaging and Python compatibility](./packaging.md)
 - [Timeout model](./timeouts.md)
@@ -120,6 +123,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - `base_url` for reusable API clients and relative request paths
 - default client headers and query params for reusable API clients
 - client-level `auth=` for Basic credentials or synchronous header refresh
+- opt-in `cookies=True` session state; see [Cookies](./cookies.md)
 - query params with repeated keys, JSON, form-urlencoded data, buffered
   bytes/text bodies, file-like bodies, streaming bytes-like iterables, and
   multipart `files=` uploads
@@ -166,8 +170,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 
 ## Not Yet
 
-FogHTTP does not yet implement cookies, HTTP/2, automatic `Accept-Encoding`
-negotiation, streaming decompression, or provider-specific authentication flows.
+FogHTTP does not yet implement HTTP/2, automatic `Accept-Encoding` negotiation,
+streaming decompression, or provider-specific authentication flows.
 `trust_env` supports HTTP proxy routing, HTTPS
 `CONNECT` tunnelling through `http://` proxy endpoints, and `SSL_CERT_FILE`.
 Disabling TLS verification is intentionally not supported. See

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -534,7 +534,9 @@ if diagnostics["pending_requests"]:
 
 The lifecycle contract currently applies to buffered requests/responses,
 sync/async streamed response bodies, streaming request bodies passed through
-`content=`, and synchronous callable auth hooks. Cookies and provider-specific
+`content=`, synchronous callable auth hooks, and the opt-in cookie jar. Cookie
+state belongs to one client and disappears when that client is closed or
+dropped; it is never persisted or shared globally. Provider-specific
 authentication flows may extend the lifecycle model later.
 
 FogHTTP exposes socket lifecycle telemetry for the current HTTP/1 path, but

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -61,6 +61,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - opt-in SSRF destination policy with scheme/origin/domain allowlists,
   per-redirect checks, post-resolution address validation, and typed redacted
   `SSRFError` reasons
+- opt-in client-owned cookie jar with bounded domain/path/expiry matching and
+  per-hop redirect/retry selection
 - opt-in async lifecycle debug snapshots for active async request handles,
   pending transport pressure, strict test checks, and unclosed-client context
 - default per-response and aggregate buffered response memory limits
@@ -86,12 +88,12 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | Multipart header values | Field names, filenames, and part content types are currently limited to printable ASCII; non-ASCII filenames need a later compatibility design |
 | Streaming uploads | Available through `content=` for binary file-like objects, sync bytes-like iterables, zero-arg byte-stream factories, and async bytes-like iterables/factories on `AsyncClient`; direct stream/file bodies are non-replayable for method-preserving redirects, while factories can replay by returning a fresh stream |
 | Upload typing contracts | Public provider/factory and multipart aliases are available for streaming `content=` and multipart `files=` APIs |
-| Cookie jar | `cookies=True` is rejected |
+| Cookie jar | Available through client-level `cookies=True`; storage is memory-only and client-owned, with no public-suffix-list or browser SameSite/third-party policy in v1 |
 | Plain HTTP proxy routing | Available for `http://` targets through explicit `proxy=` or `trust_env=True` environment config |
 | HTTPS proxy `CONNECT` | Available for `https://` targets through explicit `proxy=` or `trust_env=True` when the proxy endpoint itself uses `http://`; TLS is validated against the target host |
 | TLS-to-proxy endpoints | `https://proxy.example:443` proxy endpoint URLs are rejected; TLS-to-proxy is not implemented yet |
 | Environment proxy redirects | Same-origin redirects can continue; cross-origin redirects under `trust_env=True` proxy policy fail closed until per-hop environment proxy recomputation is implemented |
-| Authentication | Basic credentials and synchronous callable header refresh are available through client-level `auth=`; cookie jars, async hooks, OAuth flows, and provider SDKs are not built in |
+| Authentication | Basic credentials and synchronous callable header refresh are available through client-level `auth=`; async hooks, OAuth flows, and provider SDKs are not built in |
 | Disabling TLS verification | Not available by design; use `TLSConfig` with explicit CA certificates |
 | OS trust store integration | Not available; FogHTTP uses bundled WebPKI roots unless `trust_webpki_roots=False` is set |
 | HTTP/2 | Not available |
@@ -119,7 +121,7 @@ Use FogHTTP today when:
   default
 - requests are JSON-heavy, use small form-urlencoded bodies, multipart file
   uploads, or explicit streaming upload bodies
-- redirects are compatible with FogHTTP auth scope and do not require a cookie jar
+- redirects are compatible with FogHTTP auth and cookie scope
 - sync and async clients with explicit lifecycle are enough
 - async request cancellation and sync/async stream cleanup behavior are useful
 - global/per-origin request-slot backpressure and opt-in global/per-host
@@ -135,7 +137,7 @@ Wait before using FogHTTP when:
 - you need SOCKS, PAC, WPAD, or platform proxy discovery
 - you require proxy routing and application-layer SSRF protection on the same
   client; enforce destination policy at the proxy or network egress boundary
-- you rely on cookies across requests
+- you require browser-grade public-suffix, SameSite, partitioned, or third-party cookie policy
 - you need per-request connect timeout reconfiguration
 - you need automatic compression negotiation instead of manual
   `Accept-Encoding`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -555,6 +555,10 @@ with foghttp.Client() as client:
     response = client.get("https://httpbin.org/headers", headers=headers)
 ```
 
+Reading `Set-Cookie` directly does not enable session state. Use
+`Client(cookies=True)` or `AsyncClient(cookies=True)` for the opt-in managed
+jar described in [Cookies](./cookies.md).
+
 FogHTTP treats authority, framing, and hop-by-hop request headers as
 transport-managed. The safe API rejects manual `Host`, `Content-Length`,
 `Transfer-Encoding`, `TE`, `Trailer`, `Connection`, `Upgrade`, `Keep-Alive`,

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -207,8 +207,15 @@ with foghttp.Client(follow_redirects=True, max_redirects=5) as client:
     response = client.get("https://example.com/redirect-loop")
 ```
 
-## Current Limitations
+## Cookie Scope
 
-FogHTTP does not yet implement cookie jar behavior. User-supplied `Cookie`
-headers are treated as sensitive and are not forwarded across origins during
-redirects.
+With `cookies=True`, FogHTTP removes its managed `Cookie` header before every
+redirect and selects again for the target URL. Host/domain, path, expiry, and
+`Secure` rules therefore decide what the next hop receives; a source cookie is
+never blindly copied to another host. Cookie scope does not include the TCP
+port, matching HTTP cookie semantics.
+
+A caller-supplied `Cookie` remains authoritative on same-origin redirects and
+is stripped by the normal cross-origin header policy. After that stripping, a
+cookie matching the redirect target may be selected from the managed jar. See
+[Cookies](./cookies.md) for the complete contract.

--- a/docs/request-builder.md
+++ b/docs/request-builder.md
@@ -25,7 +25,7 @@ the current FogHTTP API. The same flow is available as a runnable example in
 | `data` | Supported | Mappings and repeated pairs are encoded as `application/x-www-form-urlencoded`. Raw `bytes` or `str` are sent as buffered body content without adding a semantic content type. |
 | `files` | Supported | Builds `multipart/form-data` uploads. Accepts bytes-like file parts, binary file-like objects, sync byte streams, byte-stream factories, and async byte streams/factories on `AsyncClient`. Can be combined with mapping or repeated-pair `data=` form fields. |
 | `auth` | Supported | Client-level Basic credentials or a synchronous callable. See [Authentication](./auth.md). |
-| cookies/session jar | Planned | `cookies=True` is rejected today. |
+| cookies/session jar | Supported | Client-level and opt-in through `cookies=True`. See [Cookies](./cookies.md). |
 | proxy / `trust_env` | Supported | HTTP proxy routing and HTTPS `CONNECT` tunnelling through client-level `proxy=` or `trust_env=True` when the proxy endpoint uses `http://`. |
 | `timeout` | Partly supported | Per-request `pool`, `read`, `write`, and `total` timeouts are supported. Per-request `connect` does not reconfigure the connector. |
 | `follow_redirects` | Supported | Client-level setting. GET/HEAD/POST/QUERY redirects use conservative security rules. |
@@ -334,7 +334,7 @@ upload/download workflows with observable request limits.
 
 Current intentional gaps:
 
-- no cookie jar or provider-specific OAuth helper
+- no provider-specific OAuth helper
 - no asynchronous auth callable
 - no streaming decompression helpers yet
 - no disabling TLS verification

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -299,10 +299,10 @@ except foghttp.HTTPStatusError as exc:
 | Streaming decompression | Not implemented; buffered responses support transparent decoding |
 | Streaming uploads | Available through `content=`; streaming bodies are non-replayable for method-preserving redirects |
 | Multipart files | Available through `files=` |
-| Cookies/session jar | Not implemented |
+| Cookies/session jar | Available as an opt-in, memory-only client policy through `cookies=True` |
 | Proxy routing | HTTP proxy routing and HTTPS `CONNECT` tunnelling through `http://` proxy endpoints are available; SOCKS, PAC, TLS-to-proxy endpoints and platform proxy discovery are not implemented |
 | HTTP/2 | Not implemented |
-| Cookie jar and provider-specific OAuth integration | Not implemented; use the native callable auth hook for request headers |
+| Browser-grade cookies and provider-specific OAuth integration | Cookie domain/path/expiry sessions are available; public-suffix, SameSite/third-party browser policy and provider OAuth flows are not built in |
 | Unbounded buffered large downloads | `max_response_body_size` defaults to 10 MiB and `max_buffered_response_bytes` defaults to 100 MiB for buffered fail-fast protection; use `stream()` for incremental byte downloads |
 | Automatic compression negotiation | Not implemented; pass `Accept-Encoding` manually when you want compressed buffered responses |
 

--- a/foghttp/_client/config.py
+++ b/foghttp/_client/config.py
@@ -31,6 +31,7 @@ class ClientConfig:
     timeouts: timeouts.Timeouts
     follow_redirects: bool
     max_redirects: int
+    cookies: bool
     trust_env: bool
     tls: TLSConfig | None
     proxy_resolver: ProxyResolver
@@ -67,6 +68,7 @@ class ClientConfig:
             timeouts=_DEFAULT_TIMEOUTS if options.timeouts is None else options.timeouts,
             follow_redirects=options.follow_redirects,
             max_redirects=options.max_redirects,
+            cookies=options.cookies,
             trust_env=options.trust_env,
             tls=tls_from_trusted_environment(explicit_tls=options.tls, env_config=env_config),
             proxy_resolver=proxy_resolver,

--- a/foghttp/_client/options.py
+++ b/foghttp/_client/options.py
@@ -8,7 +8,6 @@ from ..headers import HeaderSource
 from ..lifecycle_debug import AsyncLifecycleDebugConfig
 from ..limits import Limits
 from ..messages import (
-    COOKIES_UNSUPPORTED,
     HTTP_VERSION_UNSUPPORTED,
     MAX_REDIRECTS_INVALID,
 )
@@ -50,7 +49,5 @@ def validate_client_options(options: ClientOptions) -> None:
         runtime=options.runtime,
         runtime_workers=options.runtime_workers,
     )
-    if options.cookies:
-        raise NotImplementedError(COOKIES_UNSUPPORTED)
     if options.http_versions and options.http_versions != ["HTTP/1.1"]:
         raise NotImplementedError(HTTP_VERSION_UNSUPPORTED)

--- a/foghttp/_client/raw/lifecycle.py
+++ b/foghttp/_client/raw/lifecycle.py
@@ -38,6 +38,7 @@ def create_raw_client(
             connect_timeout=config.timeouts.connect,
             follow_redirects=config.follow_redirects,
             max_redirects=config.max_redirects,
+            cookies_enabled=config.cookies,
             ca_certificates=ca_certificate_bytes(config.tls),
             trust_webpki_roots=trust_webpki_roots(config.tls),
             runtime=config.runtime,

--- a/foghttp/_foghttp.pyi
+++ b/foghttp/_foghttp.pyi
@@ -403,6 +403,7 @@ class RawClient:
         connect_timeout: float,
         follow_redirects: bool,
         max_redirects: int,
+        cookies_enabled: bool,
         ca_certificates: Sequence[bytes],
         trust_webpki_roots: bool,
         runtime: str,

--- a/foghttp/messages.py
+++ b/foghttp/messages.py
@@ -5,7 +5,6 @@ __all__ = (
     "BODY_PARAMETER_CONFLICT",
     "CLIENT_CLOSED",
     "CONNECTION_ACQUIRE_TIMEOUT",
-    "COOKIES_UNSUPPORTED",
     "HTTP_VERSION_UNSUPPORTED",
     "MAX_REDIRECTS_INVALID",
     "MULTIPART_CONTENT_TYPE_BOUNDARY_UNSUPPORTED",
@@ -46,7 +45,6 @@ BODY_PARAMETER_CONFLICT = (
 )
 CLIENT_CLOSED = "FogHTTP client is closed"
 CONNECTION_ACQUIRE_TIMEOUT = "connection acquire timeout expired"
-COOKIES_UNSUPPORTED = "cookies are planned after the MVP"
 HTTP_VERSION_UNSUPPORTED = "only HTTP/1.1 is supported in the MVP"
 MAX_REDIRECTS_INVALID = "max_redirects must be greater than or equal to 0"
 MULTIPART_DATA_UNSUPPORTED = "files can only be combined with mapping or repeated-pair form data"

--- a/src/core/policy/cookies.rs
+++ b/src/core/policy/cookies.rs
@@ -1,13 +1,13 @@
 use crate::core::headers::HeaderPairs;
 use crate::core::url::HttpUrl;
-use cookie::time::{OffsetDateTime, SignedDuration};
-use cookie::Cookie as RawCookie;
 use hyper::header::HeaderValue;
 use rfc_6265::date::parse_cookie_date;
 use rfc_6265::domain::{domain_matches, to_ascii};
+use rfc_6265::grammar::{has_host_prefix, has_secure_prefix};
 use rfc_6265::path::{default_path, path_matches};
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use time::{Duration, OffsetDateTime};
 
 const MAX_COOKIE_PAIR_OCTETS: usize = 4096;
 const MAX_COOKIE_ATTRIBUTE_VALUE_OCTETS: usize = 1024;
@@ -16,8 +16,6 @@ const MAX_COOKIES_PER_DOMAIN: usize = 50;
 const MAX_COOKIES: usize = 3000;
 const MAX_COOKIE_AGE_SECONDS: i64 = 400 * 24 * 60 * 60;
 const SET_COOKIE_HEADER_NAME: &str = "set-cookie";
-const SECURE_COOKIE_PREFIX: &str = "__Secure-";
-const HOST_COOKIE_PREFIX: &str = "__Host-";
 
 #[derive(Clone)]
 pub(crate) struct CookieJar {
@@ -57,7 +55,8 @@ impl CookieJar {
 
         for (name, value) in headers {
             if name.eq_ignore_ascii_case(SET_COOKIE_HEADER_NAME)
-                && value.len() <= MAX_SET_COOKIE_OCTETS
+                && response_header_octet_len(value)
+                    .is_some_and(|octets| octets <= MAX_SET_COOKIE_OCTETS)
             {
                 store.store(value, &host, url.path(), secure, now);
             }
@@ -70,7 +69,7 @@ impl CookieJar {
 }
 
 // RFC 10025 includes host_only and last_access in storage semantics. Keep one
-// storage owner while delegating opaque parsing and date/domain/path algorithms.
+// storage owner while reusing the crate's date, domain, path, and prefix primitives.
 #[derive(Default)]
 struct CookieStore {
     cookies: Vec<StoredCookie>,
@@ -154,9 +153,7 @@ impl CookieStore {
             if !header.is_empty() {
                 header.push_str("; ");
             }
-            header.push_str(&cookie.name);
-            header.push('=');
-            header.push_str(&cookie.value);
+            header.push_str(&cookie.wire_pair);
         }
         Some(header)
     }
@@ -215,7 +212,7 @@ impl CookieStore {
 
 struct StoredCookie {
     name: String,
-    value: String,
+    wire_pair: String,
     domain: String,
     path: String,
     host_only: bool,
@@ -236,17 +233,19 @@ impl StoredCookie {
         if contains_disallowed_control(value) {
             return None;
         }
-        let parsed = RawCookie::parse(value.to_owned()).ok()?;
-        let name = parsed.name();
-        let cookie_value = parsed.value();
-        if !is_safe_cookie_pair(name, cookie_value) {
-            return None;
-        }
+        let (name, cookie_value) = parse_cookie_pair(value)?;
+        let wire_pair = serialize_cookie_pair(name, cookie_value)?;
 
         let attributes = CookieAttributes::parse(value, now);
-        let (domain, host_only) = match attributes.domain {
+        let domain_attribute = attributes
+            .domain
+            .map(|domain| domain.strip_prefix('.').unwrap_or(domain));
+        let (domain, host_only) = match domain_attribute {
             Some(domain) if !domain.is_empty() => {
-                let domain = canonical_cookie_domain(domain.strip_prefix('.').unwrap_or(domain))?;
+                if !domain.is_ascii() {
+                    return None;
+                }
+                let domain = canonical_cookie_domain(domain)?;
                 if !domain_matches(origin_host, &domain) {
                     return None;
                 }
@@ -254,7 +253,7 @@ impl StoredCookie {
             }
             _ => (origin_host.to_owned(), true),
         };
-        let explicit_root_path = attributes.path == Some("/");
+        let path_attribute_present = attributes.path.is_some();
         let path = attributes
             .path
             .filter(|path| path.starts_with('/'))
@@ -264,18 +263,21 @@ impl StoredCookie {
         if secure && !origin_secure {
             return None;
         }
-        if has_ascii_case_insensitive_prefix(name, SECURE_COOKIE_PREFIX) && !secure {
+        if has_secure_prefix(name) && !secure {
             return None;
         }
-        if has_ascii_case_insensitive_prefix(name, HOST_COOKIE_PREFIX)
-            && (!secure || !host_only || !explicit_root_path)
+        if has_host_prefix(name)
+            && (!secure || !host_only || !path_attribute_present || path != "/")
         {
+            return None;
+        }
+        if name.is_empty() && (has_secure_prefix(cookie_value) || has_host_prefix(cookie_value)) {
             return None;
         }
 
         Some(Self {
             name: name.to_owned(),
-            value: cookie_value.to_owned(),
+            wire_pair,
             domain,
             path,
             host_only,
@@ -324,7 +326,9 @@ impl<'a> CookieAttributes<'a> {
                 raw_attribute.split_once('=').unwrap_or((raw_attribute, ""));
             let name = trim_cookie_whitespace(name);
             let attribute_value = trim_cookie_whitespace(attribute_value);
-            if attribute_value.len() > MAX_COOKIE_ATTRIBUTE_VALUE_OCTETS {
+            if response_header_octet_len(attribute_value)
+                .is_none_or(|octets| octets > MAX_COOKIE_ATTRIBUTE_VALUE_OCTETS)
+            {
                 continue;
             }
 
@@ -366,11 +370,11 @@ fn parse_max_age(value: &str, now: OffsetDateTime) -> Option<OffsetDateTime> {
             .saturating_add(i64::from(byte - b'0'))
             .min(MAX_COOKIE_AGE_SECONDS)
     });
-    Some(now.saturating_add(SignedDuration::seconds(seconds)))
+    Some(now.saturating_add(Duration::seconds(seconds)))
 }
 
 fn clamp_cookie_expiry(expires: OffsetDateTime, now: OffsetDateTime) -> OffsetDateTime {
-    expires.min(now.saturating_add(SignedDuration::seconds(MAX_COOKIE_AGE_SECONDS)))
+    expires.min(now.saturating_add(Duration::seconds(MAX_COOKIE_AGE_SECONDS)))
 }
 
 fn trim_cookie_whitespace(value: &str) -> &str {
@@ -383,18 +387,41 @@ fn contains_disallowed_control(value: &str) -> bool {
         .any(|byte| matches!(byte, 0x00..=0x08 | 0x0a..=0x1f | 0x7f))
 }
 
-fn is_safe_cookie_pair(name: &str, value: &str) -> bool {
-    name.len() + value.len() <= MAX_COOKIE_PAIR_OCTETS
-        && name.is_ascii()
-        && value.is_ascii()
-        && HeaderValue::from_str(&format!("{name}={value}")).is_ok()
+// Response headers map each wire byte to one Latin-1 scalar. Counting UTF-8
+// storage bytes would make obs-text consume two octets and change RFC limits.
+fn response_header_octet_len(value: &str) -> Option<usize> {
+    let mut octets = 0;
+    for character in value.chars() {
+        if character > '\u{ff}' {
+            return None;
+        }
+        octets += 1;
+    }
+    Some(octets)
 }
 
-fn has_ascii_case_insensitive_prefix(value: &str, prefix: &str) -> bool {
-    value
-        .as_bytes()
-        .get(..prefix.len())
-        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix.as_bytes()))
+fn parse_cookie_pair(value: &str) -> Option<(&str, &str)> {
+    let pair = value
+        .split_once(';')
+        .map_or(value, |(pair, _attributes)| pair);
+    let (name, cookie_value) = pair.split_once('=').unwrap_or(("", pair));
+    let name = trim_cookie_whitespace(name);
+    let cookie_value = trim_cookie_whitespace(cookie_value);
+    (!name.is_empty() || !cookie_value.is_empty()).then_some((name, cookie_value))
+}
+
+fn serialize_cookie_pair(name: &str, value: &str) -> Option<String> {
+    if name.len() + value.len() > MAX_COOKIE_PAIR_OCTETS || !name.is_ascii() || !value.is_ascii() {
+        return None;
+    }
+    let mut pair = String::with_capacity(name.len() + value.len() + usize::from(!name.is_empty()));
+    if !name.is_empty() {
+        pair.push_str(name);
+        pair.push('=');
+    }
+    pair.push_str(value);
+    HeaderValue::from_str(&pair).ok()?;
+    Some(pair)
 }
 
 fn canonical_cookie_domain(value: &str) -> Option<String> {
@@ -419,6 +446,8 @@ fn is_trustworthy_origin(url: &HttpUrl) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::headers::response_headers;
+    use hyper::header::{HeaderMap, SET_COOKIE};
 
     const NOW_SECONDS: i64 = 1_752_000_000;
 
@@ -432,6 +461,15 @@ mod tests {
 
     fn set_cookie(value: impl Into<String>) -> HeaderPairs {
         vec![(SET_COOKIE_HEADER_NAME.to_owned(), value.into())]
+    }
+
+    fn raw_set_cookie(value: &[u8]) -> HeaderPairs {
+        let mut headers = HeaderMap::new();
+        headers.append(
+            SET_COOKIE,
+            HeaderValue::from_bytes(value).expect("valid raw Set-Cookie value"),
+        );
+        response_headers(&headers)
     }
 
     #[test]
@@ -490,6 +528,117 @@ mod tests {
         assert_eq!(
             jar.request_header_at(&origin, now()),
             Some("opaque=%41%2F%25; quoted=\"a%2Fb\"".to_owned()),
+        );
+    }
+
+    #[test]
+    fn serializes_nameless_cookies_without_an_equals_sign() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+
+        jar.store_response_at(&origin, &set_cookie("nameless-token; Path=/"), now());
+        jar.store_response_at(&origin, &set_cookie("named=value; Path=/"), now());
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("nameless-token; named=value".to_owned()),
+        );
+
+        jar.store_response_at(&origin, &set_cookie("=replacement-token; Path=/"), now());
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("replacement-token; named=value".to_owned()),
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_prefixes_in_nameless_cookie_values() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+
+        jar.store_response_at(&origin, &set_cookie("safe-token; Path=/"), now());
+        jar.store_response_at(
+            &origin,
+            &set_cookie("__Secure-hidden; Secure; Path=/"),
+            now(),
+        );
+        jar.store_response_at(
+            &origin,
+            &set_cookie("=__Host-hidden; Secure; Path=/"),
+            now(),
+        );
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("safe-token".to_owned()),
+        );
+    }
+
+    #[test]
+    fn rejects_non_ascii_domain_attributes_but_accepts_ascii_punycode() {
+        let jar = CookieJar::new();
+        let origin = url("https://xn--mnchen-3ya.de/");
+
+        jar.store_response_at(
+            &origin,
+            &set_cookie("unicode=one; Domain=münchen.de; Path=/"),
+            now(),
+        );
+        assert_eq!(jar.request_header_at(&origin, now()), None);
+
+        jar.store_response_at(
+            &origin,
+            &set_cookie("punycode=two; Domain=xn--mnchen-3ya.de; Path=/"),
+            now(),
+        );
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("punycode=two".to_owned()),
+        );
+    }
+
+    #[test]
+    fn counts_attribute_limits_in_original_response_header_octets() {
+        let jar = CookieJar::new();
+        let secure_origin = url("https://example.test/");
+        let plain_origin = url("http://example.test/");
+
+        let mut exact_secure = b"exact=value; Secure=".to_vec();
+        exact_secure.extend(std::iter::repeat_n(0x80, MAX_COOKIE_ATTRIBUTE_VALUE_OCTETS));
+        jar.store_response_at(&secure_origin, &raw_set_cookie(&exact_secure), now());
+
+        let mut oversized_secure = b"oversized=value; Secure=".to_vec();
+        oversized_secure.extend(std::iter::repeat_n(
+            0x80,
+            MAX_COOKIE_ATTRIBUTE_VALUE_OCTETS + 1,
+        ));
+        jar.store_response_at(&secure_origin, &raw_set_cookie(&oversized_secure), now());
+
+        let mut non_ascii_domain = b"domain=value; Domain=".to_vec();
+        non_ascii_domain.extend(std::iter::repeat_n(0x80, 600));
+        jar.store_response_at(&secure_origin, &raw_set_cookie(&non_ascii_domain), now());
+
+        assert_eq!(
+            jar.request_header_at(&secure_origin, now()),
+            Some("exact=value; oversized=value".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&plain_origin, now()),
+            Some("oversized=value".to_owned()),
+        );
+    }
+
+    #[test]
+    fn empty_domain_after_leading_dot_uses_host_only_scope() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        jar.store_response_at(&origin, &set_cookie("dot=one; Domain=.; Path=/"), now());
+
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("dot=one".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&url("https://sub.example.test/"), now()),
+            None,
         );
     }
 
@@ -562,7 +711,7 @@ mod tests {
             Some("short=1".to_owned()),
         );
         assert_eq!(
-            jar.request_header_at(&origin, now() + SignedDuration::seconds(2)),
+            jar.request_header_at(&origin, now() + Duration::seconds(2)),
             None,
         );
 
@@ -585,7 +734,7 @@ mod tests {
             Some("dated=one".to_owned()),
         );
         assert_eq!(
-            jar.request_header_at(&origin, now() + SignedDuration::seconds(2)),
+            jar.request_header_at(&origin, now() + Duration::seconds(2)),
             None,
         );
 
@@ -605,25 +754,22 @@ mod tests {
         ];
         jar.store_response_at(&origin, &far_future, now());
         assert_eq!(
-            jar.request_header_at(&origin, now() + SignedDuration::seconds(9)),
+            jar.request_header_at(&origin, now() + Duration::seconds(9)),
             Some("max=one; expires=two; precedence=three".to_owned()),
         );
         assert_eq!(
-            jar.request_header_at(&origin, now() + SignedDuration::seconds(11)),
+            jar.request_header_at(&origin, now() + Duration::seconds(11)),
             Some("max=one; expires=two".to_owned()),
         );
         assert_eq!(
             jar.request_header_at(
                 &origin,
-                now() + SignedDuration::seconds(MAX_COOKIE_AGE_SECONDS - 1),
+                now() + Duration::seconds(MAX_COOKIE_AGE_SECONDS - 1),
             ),
             Some("max=one; expires=two".to_owned()),
         );
         assert_eq!(
-            jar.request_header_at(
-                &origin,
-                now() + SignedDuration::seconds(MAX_COOKIE_AGE_SECONDS),
-            ),
+            jar.request_header_at(&origin, now() + Duration::seconds(MAX_COOKIE_AGE_SECONDS)),
             None,
         );
     }
@@ -639,7 +785,7 @@ mod tests {
             now(),
         );
         assert_eq!(
-            jar.request_header_at(&origin, now() + SignedDuration::seconds(2)),
+            jar.request_header_at(&origin, now() + Duration::seconds(2)),
             None,
         );
 
@@ -664,7 +810,7 @@ mod tests {
         jar.store_response_at(
             &origin,
             &[
-                ("set-cookie".to_owned(), "missing-pair".to_owned()),
+                ("set-cookie".to_owned(), "=; Path=/".to_owned()),
                 ("set-cookie".to_owned(), oversized),
                 (
                     "set-cookie".to_owned(),
@@ -748,6 +894,46 @@ mod tests {
         assert_eq!(
             jar.request_header_at(&origin, now()),
             Some("__Host-valid=three".to_owned()),
+        );
+    }
+
+    #[test]
+    fn host_prefix_uses_present_normalized_path_attribute() {
+        let jar = CookieJar::new();
+        let root_default = url("https://example.test/set");
+        jar.store_response_at(
+            &root_default,
+            &[
+                (
+                    "set-cookie".to_owned(),
+                    "__Host-relative=one; Secure; Path=relative".to_owned(),
+                ),
+                (
+                    "set-cookie".to_owned(),
+                    "__Host-empty=two; Secure; Path=".to_owned(),
+                ),
+                (
+                    "set-cookie".to_owned(),
+                    "__Host-bare=three; Secure; Path".to_owned(),
+                ),
+            ],
+            now(),
+        );
+
+        let nested_default = url("https://example.test/private/set");
+        jar.store_response_at(
+            &nested_default,
+            &set_cookie("__Host-nested=four; Secure; Path=relative"),
+            now(),
+        );
+
+        assert_eq!(
+            jar.request_header_at(&root_default, now()),
+            Some("__Host-relative=one; __Host-empty=two; __Host-bare=three".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&url("https://example.test/private/resource"), now()),
+            Some("__Host-relative=one; __Host-empty=two; __Host-bare=three".to_owned()),
         );
     }
 

--- a/src/core/policy/cookies.rs
+++ b/src/core/policy/cookies.rs
@@ -1,0 +1,879 @@
+use crate::core::headers::HeaderPairs;
+use crate::core::url::HttpUrl;
+use cookie::time::{OffsetDateTime, SignedDuration};
+use cookie::Cookie as RawCookie;
+use hyper::header::HeaderValue;
+use rfc_6265::date::parse_cookie_date;
+use rfc_6265::domain::{domain_matches, to_ascii};
+use rfc_6265::path::{default_path, path_matches};
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+const MAX_COOKIE_PAIR_OCTETS: usize = 4096;
+const MAX_COOKIE_ATTRIBUTE_VALUE_OCTETS: usize = 1024;
+const MAX_SET_COOKIE_OCTETS: usize = 16 * 1024;
+const MAX_COOKIES_PER_DOMAIN: usize = 50;
+const MAX_COOKIES: usize = 3000;
+const MAX_COOKIE_AGE_SECONDS: i64 = 400 * 24 * 60 * 60;
+const SET_COOKIE_HEADER_NAME: &str = "set-cookie";
+const SECURE_COOKIE_PREFIX: &str = "__Secure-";
+const HOST_COOKIE_PREFIX: &str = "__Host-";
+
+#[derive(Clone)]
+pub(crate) struct CookieJar {
+    store: Arc<Mutex<CookieStore>>,
+}
+
+impl CookieJar {
+    pub(crate) fn new() -> Self {
+        Self {
+            store: Arc::new(Mutex::new(CookieStore::default())),
+        }
+    }
+
+    pub(crate) fn request_header(&self, url: &HttpUrl) -> Option<String> {
+        self.request_header_at(url, OffsetDateTime::now_utc())
+    }
+
+    pub(crate) fn store_response(&self, url: &HttpUrl, headers: &HeaderPairs) {
+        self.store_response_at(url, headers, OffsetDateTime::now_utc());
+    }
+
+    fn request_header_at(&self, url: &HttpUrl, now: OffsetDateTime) -> Option<String> {
+        let host = canonical_cookie_domain(&url.host())?;
+        let secure = is_trustworthy_origin(url);
+        let mut store = self.lock();
+        store.purge_expired(now);
+        store.request_header(&host, url.path(), secure)
+    }
+
+    fn store_response_at(&self, url: &HttpUrl, headers: &[(String, String)], now: OffsetDateTime) {
+        let Some(host) = canonical_cookie_domain(&url.host()) else {
+            return;
+        };
+        let secure = is_trustworthy_origin(url);
+        let mut store = self.lock();
+        store.purge_expired(now);
+
+        for (name, value) in headers {
+            if name.eq_ignore_ascii_case(SET_COOKIE_HEADER_NAME)
+                && value.len() <= MAX_SET_COOKIE_OCTETS
+            {
+                store.store(value, &host, url.path(), secure, now);
+            }
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, CookieStore> {
+        self.store.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+// RFC 10025 includes host_only and last_access in storage semantics. Keep one
+// storage owner while delegating opaque parsing and date/domain/path algorithms.
+#[derive(Default)]
+struct CookieStore {
+    cookies: Vec<StoredCookie>,
+    next_creation: u64,
+    next_access: u64,
+}
+
+impl CookieStore {
+    fn store(
+        &mut self,
+        value: &str,
+        origin_host: &str,
+        request_path: &str,
+        origin_secure: bool,
+        now: OffsetDateTime,
+    ) {
+        let Some(mut candidate) =
+            StoredCookie::parse(value, origin_host, request_path, origin_secure, now)
+        else {
+            return;
+        };
+
+        if !origin_secure && self.would_overlay_secure_cookie(&candidate) {
+            return;
+        }
+
+        let existing = self
+            .cookies
+            .iter()
+            .position(|cookie| cookie.has_same_identity(&candidate));
+        if candidate.is_expired(now) {
+            if let Some(index) = existing {
+                self.cookies.remove(index);
+            }
+            return;
+        }
+
+        candidate.last_access = self.next_access;
+        self.next_access = self.next_access.saturating_add(1);
+        if let Some(index) = existing {
+            candidate.creation = self.cookies[index].creation;
+            self.cookies[index] = candidate;
+            return;
+        }
+
+        candidate.creation = self.next_creation;
+        let domain = candidate.domain.clone();
+        self.next_creation = self.next_creation.saturating_add(1);
+        self.cookies.push(candidate);
+        self.enforce_capacity(&domain);
+    }
+
+    fn request_header(&mut self, host: &str, path: &str, secure: bool) -> Option<String> {
+        let mut matching = self
+            .cookies
+            .iter()
+            .enumerate()
+            .filter_map(|(index, cookie)| cookie.matches(host, path, secure).then_some(index))
+            .collect::<Vec<_>>();
+        matching.sort_by(|left, right| {
+            self.cookies[*right]
+                .path
+                .len()
+                .cmp(&self.cookies[*left].path.len())
+                .then_with(|| {
+                    self.cookies[*left]
+                        .creation
+                        .cmp(&self.cookies[*right].creation)
+                })
+        });
+
+        if matching.is_empty() {
+            return None;
+        }
+        let access = self.next_access;
+        self.next_access = self.next_access.saturating_add(1);
+        let mut header = String::new();
+        for index in matching {
+            let cookie = &mut self.cookies[index];
+            cookie.last_access = access;
+            if !header.is_empty() {
+                header.push_str("; ");
+            }
+            header.push_str(&cookie.name);
+            header.push('=');
+            header.push_str(&cookie.value);
+        }
+        Some(header)
+    }
+
+    fn purge_expired(&mut self, now: OffsetDateTime) {
+        self.cookies.retain(|cookie| !cookie.is_expired(now));
+    }
+
+    fn would_overlay_secure_cookie(&self, candidate: &StoredCookie) -> bool {
+        self.cookies.iter().any(|existing| {
+            existing.secure
+                && existing.name == candidate.name
+                && (domain_matches(&candidate.domain, &existing.domain)
+                    || domain_matches(&existing.domain, &candidate.domain))
+                && path_matches(&candidate.path, &existing.path)
+        })
+    }
+
+    fn enforce_capacity(&mut self, domain: &str) {
+        while self
+            .cookies
+            .iter()
+            .filter(|cookie| cookie.domain == domain)
+            .count()
+            > MAX_COOKIES_PER_DOMAIN
+        {
+            let has_non_secure = self
+                .cookies
+                .iter()
+                .any(|cookie| cookie.domain == domain && !cookie.secure);
+            let index = self
+                .cookies
+                .iter()
+                .enumerate()
+                .filter(|(_index, cookie)| {
+                    cookie.domain == domain && (!has_non_secure || !cookie.secure)
+                })
+                .min_by_key(|(_index, cookie)| (cookie.last_access, cookie.creation))
+                .map(|(index, _cookie)| index)
+                .expect("an over-capacity domain has a cookie");
+            self.cookies.remove(index);
+        }
+
+        while self.cookies.len() > MAX_COOKIES {
+            let index = self
+                .cookies
+                .iter()
+                .enumerate()
+                .min_by_key(|(_index, cookie)| (cookie.last_access, cookie.creation))
+                .map(|(index, _cookie)| index)
+                .expect("an over-capacity store has a cookie");
+            self.cookies.remove(index);
+        }
+    }
+}
+
+struct StoredCookie {
+    name: String,
+    value: String,
+    domain: String,
+    path: String,
+    host_only: bool,
+    secure: bool,
+    expires_at: Option<OffsetDateTime>,
+    creation: u64,
+    last_access: u64,
+}
+
+impl StoredCookie {
+    fn parse(
+        value: &str,
+        origin_host: &str,
+        request_path: &str,
+        origin_secure: bool,
+        now: OffsetDateTime,
+    ) -> Option<Self> {
+        if contains_disallowed_control(value) {
+            return None;
+        }
+        let parsed = RawCookie::parse(value.to_owned()).ok()?;
+        let name = parsed.name();
+        let cookie_value = parsed.value();
+        if !is_safe_cookie_pair(name, cookie_value) {
+            return None;
+        }
+
+        let attributes = CookieAttributes::parse(value, now);
+        let (domain, host_only) = match attributes.domain {
+            Some(domain) if !domain.is_empty() => {
+                let domain = canonical_cookie_domain(domain.strip_prefix('.').unwrap_or(domain))?;
+                if !domain_matches(origin_host, &domain) {
+                    return None;
+                }
+                (domain, false)
+            }
+            _ => (origin_host.to_owned(), true),
+        };
+        let explicit_root_path = attributes.path == Some("/");
+        let path = attributes
+            .path
+            .filter(|path| path.starts_with('/'))
+            .unwrap_or_else(|| default_path(request_path))
+            .to_owned();
+        let secure = attributes.secure;
+        if secure && !origin_secure {
+            return None;
+        }
+        if has_ascii_case_insensitive_prefix(name, SECURE_COOKIE_PREFIX) && !secure {
+            return None;
+        }
+        if has_ascii_case_insensitive_prefix(name, HOST_COOKIE_PREFIX)
+            && (!secure || !host_only || !explicit_root_path)
+        {
+            return None;
+        }
+
+        Some(Self {
+            name: name.to_owned(),
+            value: cookie_value.to_owned(),
+            domain,
+            path,
+            host_only,
+            secure,
+            expires_at: attributes.max_age.or(attributes.expires),
+            creation: 0,
+            last_access: 0,
+        })
+    }
+
+    fn has_same_identity(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.domain == other.domain
+            && self.host_only == other.host_only
+            && self.path == other.path
+    }
+
+    fn is_expired(&self, now: OffsetDateTime) -> bool {
+        self.expires_at.is_some_and(|expires_at| expires_at <= now)
+    }
+
+    fn matches(&self, host: &str, path: &str, secure: bool) -> bool {
+        (if self.host_only {
+            self.domain == host
+        } else {
+            domain_matches(host, &self.domain)
+        }) && path_matches(path, &self.path)
+            && (!self.secure || secure)
+    }
+}
+
+#[derive(Default)]
+struct CookieAttributes<'a> {
+    domain: Option<&'a str>,
+    path: Option<&'a str>,
+    secure: bool,
+    expires: Option<OffsetDateTime>,
+    max_age: Option<OffsetDateTime>,
+}
+
+impl<'a> CookieAttributes<'a> {
+    fn parse(value: &'a str, now: OffsetDateTime) -> Self {
+        let mut attributes = Self::default();
+        for raw_attribute in value.split(';').skip(1) {
+            let (name, attribute_value) =
+                raw_attribute.split_once('=').unwrap_or((raw_attribute, ""));
+            let name = trim_cookie_whitespace(name);
+            let attribute_value = trim_cookie_whitespace(attribute_value);
+            if attribute_value.len() > MAX_COOKIE_ATTRIBUTE_VALUE_OCTETS {
+                continue;
+            }
+
+            if name.eq_ignore_ascii_case("domain") {
+                attributes.domain = Some(attribute_value);
+            } else if name.eq_ignore_ascii_case("path") {
+                attributes.path = Some(attribute_value);
+            } else if name.eq_ignore_ascii_case("secure") {
+                attributes.secure = true;
+            } else if name.eq_ignore_ascii_case("expires") {
+                if let Some(expires) = parse_cookie_date(attribute_value) {
+                    attributes.expires = Some(clamp_cookie_expiry(expires, now));
+                }
+            } else if name.eq_ignore_ascii_case("max-age") {
+                if let Some(expires) = parse_max_age(attribute_value, now) {
+                    attributes.max_age = Some(expires);
+                }
+            }
+        }
+        attributes
+    }
+}
+
+fn parse_max_age(value: &str, now: OffsetDateTime) -> Option<OffsetDateTime> {
+    let (negative, digits) = match value.strip_prefix('-') {
+        Some(digits) => (true, digits),
+        None => (false, value),
+    };
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    if negative || digits.bytes().all(|byte| byte == b'0') {
+        return Some(now);
+    }
+
+    let seconds = digits.bytes().fold(0_i64, |seconds, byte| {
+        seconds
+            .saturating_mul(10)
+            .saturating_add(i64::from(byte - b'0'))
+            .min(MAX_COOKIE_AGE_SECONDS)
+    });
+    Some(now.saturating_add(SignedDuration::seconds(seconds)))
+}
+
+fn clamp_cookie_expiry(expires: OffsetDateTime, now: OffsetDateTime) -> OffsetDateTime {
+    expires.min(now.saturating_add(SignedDuration::seconds(MAX_COOKIE_AGE_SECONDS)))
+}
+
+fn trim_cookie_whitespace(value: &str) -> &str {
+    value.trim_matches([' ', '\t'])
+}
+
+fn contains_disallowed_control(value: &str) -> bool {
+    value
+        .bytes()
+        .any(|byte| matches!(byte, 0x00..=0x08 | 0x0a..=0x1f | 0x7f))
+}
+
+fn is_safe_cookie_pair(name: &str, value: &str) -> bool {
+    name.len() + value.len() <= MAX_COOKIE_PAIR_OCTETS
+        && name.is_ascii()
+        && value.is_ascii()
+        && HeaderValue::from_str(&format!("{name}={value}")).is_ok()
+}
+
+fn has_ascii_case_insensitive_prefix(value: &str, prefix: &str) -> bool {
+    value
+        .as_bytes()
+        .get(..prefix.len())
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix.as_bytes()))
+}
+
+fn canonical_cookie_domain(value: &str) -> Option<String> {
+    value
+        .parse::<IpAddr>()
+        .map(|address| address.to_string())
+        .ok()
+        .or_else(|| to_ascii(value))
+}
+
+fn is_trustworthy_origin(url: &HttpUrl) -> bool {
+    if url.scheme() == "https" {
+        return true;
+    }
+    let host = url.host();
+    if let Ok(address) = host.parse::<IpAddr>() {
+        return address.is_loopback();
+    }
+    host.eq_ignore_ascii_case("localhost") || host.to_ascii_lowercase().ends_with(".localhost")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW_SECONDS: i64 = 1_752_000_000;
+
+    fn now() -> OffsetDateTime {
+        OffsetDateTime::from_unix_timestamp(NOW_SECONDS).expect("test timestamp")
+    }
+
+    fn url(value: &str) -> HttpUrl {
+        HttpUrl::parse(value).expect("test URL")
+    }
+
+    fn set_cookie(value: impl Into<String>) -> HeaderPairs {
+        vec![(SET_COOKIE_HEADER_NAME.to_owned(), value.into())]
+    }
+
+    #[test]
+    fn selects_cookies_by_domain_and_path_in_protocol_order() {
+        let jar = CookieJar::new();
+        let origin = url("https://api.example.test/login");
+        jar.store_response_at(
+            &origin,
+            &[
+                ("set-cookie".to_owned(), "host=1; Path=/".to_owned()),
+                (
+                    "set-cookie".to_owned(),
+                    "scoped=2; Domain=example.test; Path=/private".to_owned(),
+                ),
+            ],
+            now(),
+        );
+
+        assert_eq!(
+            jar.request_header_at(&url("https://api.example.test/private/item"), now()),
+            Some("scoped=2; host=1".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&url("https://www.example.test/private/item"), now()),
+            Some("scoped=2".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&url("https://api.example.test/public"), now()),
+            Some("host=1".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&url("https://unrelated.test/private/item"), now()),
+            None,
+        );
+    }
+
+    #[test]
+    fn preserves_opaque_cookie_values_without_percent_decoding() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        jar.store_response_at(
+            &origin,
+            &[
+                (
+                    "set-cookie".to_owned(),
+                    "opaque=%41%2F%25; Path=/".to_owned(),
+                ),
+                (
+                    "set-cookie".to_owned(),
+                    "quoted=\"a%2Fb\"; Path=/".to_owned(),
+                ),
+            ],
+            now(),
+        );
+
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("opaque=%41%2F%25; quoted=\"a%2Fb\"".to_owned()),
+        );
+    }
+
+    #[test]
+    fn host_only_flag_is_part_of_identity_and_deletion() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        jar.store_response_at(&origin, &set_cookie("id=host; Path=/"), now());
+        jar.store_response_at(
+            &origin,
+            &set_cookie("id=domain; Domain=example.test; Path=/"),
+            now(),
+        );
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("id=host; id=domain".to_owned()),
+        );
+
+        jar.store_response_at(
+            &origin,
+            &set_cookie("id=; Domain=example.test; Path=/; Max-Age=0"),
+            now(),
+        );
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("id=host".to_owned()),
+        );
+
+        jar.store_response_at(
+            &origin,
+            &set_cookie("id=domain-two; Domain=example.test; Path=/"),
+            now(),
+        );
+        jar.store_response_at(&origin, &set_cookie("id=; Path=/; Max-Age=0"), now());
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("id=domain-two".to_owned()),
+        );
+    }
+
+    #[test]
+    fn host_only_cookies_match_ipv4_and_ipv6_literals_exactly() {
+        let jar = CookieJar::new();
+        let ipv4 = url("http://127.0.0.1/");
+        let ipv6 = url("http://[::1]/");
+        jar.store_response_at(&ipv4, &set_cookie("ipv4=one; Secure; Path=/"), now());
+        jar.store_response_at(&ipv6, &set_cookie("ipv6=two; Secure; Path=/"), now());
+
+        assert_eq!(
+            jar.request_header_at(&ipv4, now()),
+            Some("ipv4=one".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&ipv6, now()),
+            Some("ipv6=two".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&url("http://127.0.0.2/"), now()),
+            None,
+        );
+    }
+
+    #[test]
+    fn expires_and_deletes_cookies() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        jar.store_response_at(&origin, &set_cookie("short=1; Max-Age=1"), now());
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("short=1".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&origin, now() + SignedDuration::seconds(2)),
+            None,
+        );
+
+        jar.store_response_at(&origin, &set_cookie("session=1; Path=/"), now());
+        jar.store_response_at(&origin, &set_cookie("session=; Path=/; Max-Age=0"), now());
+        assert_eq!(jar.request_header_at(&origin, now()), None);
+    }
+
+    #[test]
+    fn parses_cookie_dates_caps_lifetimes_and_honors_max_age_precedence() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        jar.store_response_at(
+            &origin,
+            &set_cookie("dated=one; Expires=18:40:01 2025 Jul 08"),
+            now(),
+        );
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("dated=one".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&origin, now() + SignedDuration::seconds(2)),
+            None,
+        );
+
+        let far_future = vec![
+            (
+                "set-cookie".to_owned(),
+                "max=one; Max-Age=999999999999999999999999999".to_owned(),
+            ),
+            (
+                "set-cookie".to_owned(),
+                "expires=two; Expires=Fri, 31 Dec 9999 23:59:59 GMT".to_owned(),
+            ),
+            (
+                "set-cookie".to_owned(),
+                "precedence=three; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=10".to_owned(),
+            ),
+        ];
+        jar.store_response_at(&origin, &far_future, now());
+        assert_eq!(
+            jar.request_header_at(&origin, now() + SignedDuration::seconds(9)),
+            Some("max=one; expires=two; precedence=three".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(&origin, now() + SignedDuration::seconds(11)),
+            Some("max=one; expires=two".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(
+                &origin,
+                now() + SignedDuration::seconds(MAX_COOKIE_AGE_SECONDS - 1),
+            ),
+            Some("max=one; expires=two".to_owned()),
+        );
+        assert_eq!(
+            jar.request_header_at(
+                &origin,
+                now() + SignedDuration::seconds(MAX_COOKIE_AGE_SECONDS),
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn ignores_oversized_attributes_without_replacing_earlier_valid_values() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/root");
+        let oversized_max_age = "9".repeat(MAX_COOKIE_ATTRIBUTE_VALUE_OCTETS + 1);
+        jar.store_response_at(
+            &origin,
+            &set_cookie(format!("short=one; Max-Age=1; Max-Age={oversized_max_age}")),
+            now(),
+        );
+        assert_eq!(
+            jar.request_header_at(&origin, now() + SignedDuration::seconds(2)),
+            None,
+        );
+
+        let oversized_path = format!("/{}", "x".repeat(MAX_COOKIE_ATTRIBUTE_VALUE_OCTETS));
+        jar.store_response_at(
+            &origin,
+            &set_cookie(format!("scoped=two; Path=/private; Path={oversized_path}")),
+            now(),
+        );
+        assert_eq!(jar.request_header_at(&origin, now()), None);
+        assert_eq!(
+            jar.request_header_at(&url("https://example.test/private"), now()),
+            Some("scoped=two".to_owned()),
+        );
+    }
+
+    #[test]
+    fn ignores_malformed_oversized_and_insecure_secure_cookies_independently() {
+        let jar = CookieJar::new();
+        let origin = url("http://example.test/");
+        let oversized = format!("large={}", "x".repeat(MAX_COOKIE_PAIR_OCTETS));
+        jar.store_response_at(
+            &origin,
+            &[
+                ("set-cookie".to_owned(), "missing-pair".to_owned()),
+                ("set-cookie".to_owned(), oversized),
+                (
+                    "set-cookie".to_owned(),
+                    "injected=one\r\nCookie: two".to_owned(),
+                ),
+                ("set-cookie".to_owned(), "secure=secret; Secure".to_owned()),
+                ("set-cookie".to_owned(), "valid=1".to_owned()),
+            ],
+            now(),
+        );
+
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("valid=1".to_owned()),
+        );
+    }
+
+    #[test]
+    fn enforces_cookie_pair_size_at_the_exact_boundary() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        let accepted = format!(
+            "limit={}",
+            "x".repeat(MAX_COOKIE_PAIR_OCTETS - "limit".len())
+        );
+        let rejected = format!(
+            "oversized={}",
+            "x".repeat(MAX_COOKIE_PAIR_OCTETS + 1 - "oversized".len())
+        );
+        jar.store_response_at(&origin, &set_cookie(accepted), now());
+        jar.store_response_at(&origin, &set_cookie(rejected), now());
+
+        let header = jar
+            .request_header_at(&origin, now())
+            .expect("the boundary-sized cookie is stored");
+        assert!(header.starts_with("limit="));
+        assert!(!header.contains("oversized="));
+    }
+
+    #[test]
+    fn replacement_preserves_creation_order() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        jar.store_response_at(&origin, &set_cookie("first=one; Path=/"), now());
+        jar.store_response_at(&origin, &set_cookie("second=two; Path=/"), now());
+        jar.store_response_at(&origin, &set_cookie("first=updated; Path=/"), now());
+
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("first=updated; second=two".to_owned()),
+        );
+    }
+
+    #[test]
+    fn enforces_secure_cookie_prefixes() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        jar.store_response_at(
+            &origin,
+            &[
+                (
+                    "set-cookie".to_owned(),
+                    "__secure-missing=one; Path=/".to_owned(),
+                ),
+                (
+                    "set-cookie".to_owned(),
+                    "__Host-domain=two; Secure; Domain=example.test; Path=/".to_owned(),
+                ),
+                (
+                    "set-cookie".to_owned(),
+                    "__HOST-missing-path=two; Secure".to_owned(),
+                ),
+                (
+                    "set-cookie".to_owned(),
+                    "__Host-valid=three; Secure; Path=/".to_owned(),
+                ),
+            ],
+            now(),
+        );
+
+        assert_eq!(
+            jar.request_header_at(&origin, now()),
+            Some("__Host-valid=three".to_owned()),
+        );
+    }
+
+    #[test]
+    fn evicts_non_secure_cookies_before_secure_cookies_for_a_domain() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        jar.store_response_at(
+            &origin,
+            &set_cookie("session=secret; Secure; Path=/"),
+            now(),
+        );
+        for index in 0..MAX_COOKIES_PER_DOMAIN {
+            jar.store_response_at(&origin, &set_cookie(format!("cookie{index}=value")), now());
+        }
+        let header = jar
+            .request_header_at(&origin, now())
+            .expect("capacity leaves stored cookies");
+        let pairs = header.split("; ").collect::<Vec<_>>();
+        assert_eq!(pairs.len(), MAX_COOKIES_PER_DOMAIN);
+        assert!(pairs.contains(&"session=secret"));
+        assert!(!pairs.contains(&"cookie0=value"));
+        assert!(pairs.contains(&"cookie49=value"));
+
+        let oversized_attribute =
+            format!("small=value; Path=/{}", "x".repeat(MAX_SET_COOKIE_OCTETS));
+        jar.store_response_at(&origin, &set_cookie(oversized_attribute), now());
+        assert!(!jar
+            .request_header_at(&origin, now())
+            .expect("existing cookies remain")
+            .contains("small=value"));
+    }
+
+    #[test]
+    fn recent_access_protects_a_cookie_from_domain_eviction() {
+        let jar = CookieJar::new();
+        let origin = url("https://example.test/");
+        jar.store_response_at(&origin, &set_cookie("keep=one; Path=/keep"), now());
+        jar.store_response_at(&origin, &set_cookie("evict=two; Path=/other"), now());
+        for index in 0..(MAX_COOKIES_PER_DOMAIN - 2) {
+            jar.store_response_at(
+                &origin,
+                &set_cookie(format!("filler{index}=value; Path=/other")),
+                now(),
+            );
+        }
+
+        assert_eq!(
+            jar.request_header_at(&url("https://example.test/keep"), now()),
+            Some("keep=one".to_owned()),
+        );
+        jar.store_response_at(&origin, &set_cookie("new=three; Path=/other"), now());
+
+        let other = jar
+            .request_header_at(&url("https://example.test/other"), now())
+            .expect("matching cookies remain");
+        assert!(!other.contains("evict=two"));
+        assert!(other.contains("new=three"));
+        assert_eq!(
+            jar.request_header_at(&url("https://example.test/keep"), now()),
+            Some("keep=one".to_owned()),
+        );
+    }
+
+    #[test]
+    fn bounds_total_cookie_count() {
+        let jar = CookieJar::new();
+        for index in 0..MAX_COOKIES {
+            let origin = url(&format!("https://host{index}.example.test/"));
+            jar.store_response_at(&origin, &set_cookie(format!("cookie{index}=value")), now());
+        }
+        assert_eq!(
+            jar.request_header_at(&url("https://host0.example.test/"), now()),
+            Some("cookie0=value".to_owned()),
+        );
+        let newest = url(&format!("https://host{MAX_COOKIES}.example.test/"));
+        jar.store_response_at(
+            &newest,
+            &set_cookie(format!("cookie{MAX_COOKIES}=value")),
+            now(),
+        );
+
+        assert_eq!(
+            jar.request_header_at(&url("https://host1.example.test/"), now()),
+            None,
+        );
+        assert_eq!(
+            jar.request_header_at(&newest, now()),
+            Some(format!("cookie{MAX_COOKIES}=value")),
+        );
+    }
+
+    #[test]
+    fn insecure_origin_cannot_overlay_existing_secure_cookie() {
+        let jar = CookieJar::new();
+        let secure_origin = url("https://example.test/login");
+        let insecure_origin = url("http://example.test/login/en");
+        jar.store_response_at(
+            &secure_origin,
+            &set_cookie("session=secure; Secure; Path=/login"),
+            now(),
+        );
+
+        jar.store_response_at(
+            &insecure_origin,
+            &set_cookie("session=attacker; Path=/login/en"),
+            now(),
+        );
+        jar.store_response_at(
+            &insecure_origin,
+            &set_cookie("session=; Path=/login; Max-Age=0"),
+            now(),
+        );
+        assert_eq!(
+            jar.request_header_at(&url("https://example.test/login/en"), now()),
+            Some("session=secure".to_owned()),
+        );
+
+        jar.store_response_at(
+            &insecure_origin,
+            &set_cookie("session=allowed; Path=/"),
+            now(),
+        );
+        assert_eq!(
+            jar.request_header_at(&url("https://example.test/login/en"), now()),
+            Some("session=secure; session=allowed".to_owned()),
+        );
+    }
+}

--- a/src/core/policy/mod.rs
+++ b/src/core/policy/mod.rs
@@ -1,3 +1,4 @@
+mod cookies;
 mod error;
 mod pipeline;
 mod proxy;
@@ -6,6 +7,7 @@ mod request;
 mod retry;
 mod ssrf;
 
+pub(crate) use cookies::CookieJar;
 pub(crate) use error::PolicyError;
 pub(crate) use pipeline::{PolicyMutation, PolicyPipeline, ResponsePolicyAction};
 pub(crate) use proxy::TransportRoute;

--- a/src/py/client/mod.rs
+++ b/src/py/client/mod.rs
@@ -18,7 +18,7 @@ use crate::core::client::{
 };
 use crate::core::headers::HeaderPairs;
 use crate::core::metrics::Metrics;
-use crate::core::policy::{RetryPolicy, SsrfPolicy};
+use crate::core::policy::{CookieJar, RetryPolicy, SsrfPolicy};
 use crate::core::response::BufferedBodyBudget;
 use crate::errors::FogHttpError;
 use crate::py::client::acquire::AcquireGate;
@@ -61,6 +61,7 @@ pub struct RawClient {
     buffered_body_budget: BufferedBodyBudget,
     follow_redirects: bool,
     max_redirects: usize,
+    cookie_jar: Option<CookieJar>,
     proxy_authorization: Option<String>,
     auth: Option<Arc<PythonAuth>>,
     policy_hooks: Option<Arc<PythonPolicyHooks>>,
@@ -87,6 +88,7 @@ impl RawClient {
         connect_timeout,
         follow_redirects,
         max_redirects,
+        cookies_enabled,
         ca_certificates,
         trust_webpki_roots,
         runtime,
@@ -130,6 +132,7 @@ impl RawClient {
         connect_timeout: f64,
         follow_redirects: bool,
         max_redirects: usize,
+        cookies_enabled: bool,
         ca_certificates: Vec<Vec<u8>>,
         trust_webpki_roots: bool,
         runtime: &str,
@@ -260,6 +263,7 @@ impl RawClient {
         );
         let runtime = ClientRuntime::build(py, max_active_requests, runtime_mode, runtime_workers)?;
         let future_setters = PythonFutureSetters::new(py)?;
+        let cookie_jar = cookies_enabled.then(CookieJar::new);
 
         Ok(Self {
             clients: Some(TransportClients::new(
@@ -278,6 +282,7 @@ impl RawClient {
             buffered_body_budget,
             follow_redirects,
             max_redirects,
+            cookie_jar,
             proxy_authorization: http_proxy_authorization,
             auth,
             policy_hooks,
@@ -336,6 +341,7 @@ impl RawClient {
         let buffered_body_budget = self.buffered_body_budget.clone();
         let follow_redirects = self.follow_redirects;
         let max_redirects = self.max_redirects;
+        let cookie_jar = self.cookie_jar.clone();
         let proxy_authorization = self.proxy_authorization.clone();
         let extensions = self.retained_request_extensions(extensions);
         let auth = self.auth.clone();
@@ -372,6 +378,7 @@ impl RawClient {
                         max_redirects,
                         retry_policy,
                         ssrf_policy,
+                        cookie_jar,
                         auth,
                         policy_hooks,
                         extensions,
@@ -432,6 +439,7 @@ impl RawClient {
         let buffered_body_budget = self.buffered_body_budget.clone();
         let follow_redirects = self.follow_redirects;
         let max_redirects = self.max_redirects;
+        let cookie_jar = self.cookie_jar.clone();
         let proxy_authorization = self.proxy_authorization.clone();
         let extensions = self.retained_request_extensions(extensions);
         let auth = self.auth.clone();
@@ -469,6 +477,7 @@ impl RawClient {
                     max_redirects,
                     retry_policy,
                     ssrf_policy,
+                    cookie_jar,
                     auth,
                     policy_hooks,
                     extensions,
@@ -528,6 +537,7 @@ impl RawClient {
         let buffered_body_budget = self.buffered_body_budget.clone();
         let follow_redirects = self.follow_redirects;
         let max_redirects = self.max_redirects;
+        let cookie_jar = self.cookie_jar.clone();
         let proxy_authorization = self.proxy_authorization.clone();
         let extensions = self.retained_request_extensions(extensions);
         let auth = self.auth.clone();
@@ -570,6 +580,7 @@ impl RawClient {
                         max_redirects,
                         retry_policy,
                         ssrf_policy,
+                        cookie_jar,
                         auth,
                         policy_hooks,
                         extensions,
@@ -633,6 +644,7 @@ impl RawClient {
         let buffered_body_budget = self.buffered_body_budget.clone();
         let follow_redirects = self.follow_redirects;
         let max_redirects = self.max_redirects;
+        let cookie_jar = self.cookie_jar.clone();
         let proxy_authorization = self.proxy_authorization.clone();
         let extensions = self.retained_request_extensions(extensions);
         let auth = self.auth.clone();
@@ -671,6 +683,7 @@ impl RawClient {
                     max_redirects,
                     retry_policy,
                     ssrf_policy,
+                    cookie_jar,
                     auth,
                     policy_hooks,
                     extensions,
@@ -728,6 +741,7 @@ impl RawClient {
     }
 
     fn close_resources(&mut self) {
+        self.cookie_jar.take();
         let current_process = self.process_id == current_process_id();
         if current_process {
             self.active_async_requests.abort_all();

--- a/src/py/client/transport/request.rs
+++ b/src/py/client/transport/request.rs
@@ -8,9 +8,9 @@ use crate::core::client::{
 use crate::core::headers::HeaderPairs;
 use crate::core::numeric::duration_from_secs;
 use crate::core::policy::{
-    redirect_headers, PolicyMutation, PolicyPipeline, PolicyRequest, RedirectHeaderPolicy,
-    RequestBodyMutation, RequestBodyPolicy, ResponseHead, ResponsePolicyAction, RetryDecision,
-    RetryPolicy, RetryStopReason, SsrfPolicy, TransportRoute,
+    redirect_headers, CookieJar, PolicyMutation, PolicyPipeline, PolicyRequest,
+    RedirectHeaderPolicy, RequestBodyMutation, RequestBodyPolicy, ResponseHead,
+    ResponsePolicyAction, RetryDecision, RetryPolicy, RetryStopReason, SsrfPolicy, TransportRoute,
 };
 use crate::core::request::{build_request, RequestBodyParts, RequestParts};
 use crate::core::response::BufferedBodyBudget;
@@ -37,6 +37,9 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
+const COOKIE_HEADER_NAME: &str = "cookie";
+const COOKIE_HEADER_WIRE_NAME: &str = "Cookie";
+
 pub struct TransportRequest {
     pub method: String,
     pub url: String,
@@ -58,9 +61,50 @@ pub struct TransportRequest {
     pub max_redirects: usize,
     pub retry_policy: Option<RetryPolicy>,
     pub ssrf_policy: Option<Arc<SsrfPolicy>>,
+    pub cookie_jar: Option<CookieJar>,
     pub auth: Option<Arc<PythonAuth>>,
     pub policy_hooks: Option<Arc<PythonPolicyHooks>>,
     pub extensions: Option<Py<PyAny>>,
+}
+
+struct RequestCookieState {
+    jar: CookieJar,
+    managed_header: bool,
+}
+
+impl RequestCookieState {
+    fn new(jar: CookieJar) -> Self {
+        Self {
+            jar,
+            managed_header: false,
+        }
+    }
+
+    fn attach(&mut self, url: &HttpUrl, headers: &mut HeaderPairs) {
+        if headers
+            .iter()
+            .any(|(name, _value)| name.eq_ignore_ascii_case(COOKIE_HEADER_NAME))
+        {
+            return;
+        }
+        let Some(value) = self.jar.request_header(url) else {
+            return;
+        };
+        headers.push((COOKIE_HEADER_WIRE_NAME.to_owned(), value));
+        self.managed_header = true;
+    }
+
+    fn store_response(&self, url: &HttpUrl, headers: &HeaderPairs) {
+        self.jar.store_response(url, headers);
+    }
+
+    fn remove_managed_header(&mut self, headers: &mut HeaderPairs) {
+        if !self.managed_header {
+            return;
+        }
+        headers.retain(|(name, _value)| !name.eq_ignore_ascii_case(COOKIE_HEADER_NAME));
+        self.managed_header = false;
+    }
 }
 
 struct RequestAuthState {
@@ -169,6 +213,7 @@ pub(super) struct RequestState {
     pub(super) body: RequestBodyState,
     pub(super) body_policy: RequestBodyPolicy,
     policy: PolicyPipeline,
+    cookies: Option<RequestCookieState>,
     auth: Option<RequestAuthState>,
     policy_hooks: Option<Arc<PythonPolicyHooks>>,
     extensions: Option<Py<PyAny>>,
@@ -279,6 +324,9 @@ impl RequestState {
         &mut self,
         redirect_hop: usize,
     ) -> PyResult<TransportRoute> {
+        if let Some(cookies) = self.cookies.as_mut() {
+            cookies.remove_managed_header(&mut self.headers);
+        }
         let request = self.policy_request();
         let route = self
             .policy
@@ -298,6 +346,9 @@ impl RequestState {
                 tokio::task::yield_now().await;
             }
         }
+        if let Some(cookies) = self.cookies.as_mut() {
+            cookies.attach(&self.url, &mut self.headers);
+        }
         let request = self.policy_request();
         if let Some(hooks) = self.policy_hooks.as_ref() {
             hooks.before_send(request, redirect_hop, self.extensions.as_ref())?;
@@ -311,6 +362,9 @@ impl RequestState {
         headers: &HeaderPairs,
         redirect_hop: usize,
     ) -> PyResult<Option<PendingResponsePolicyAction>> {
+        if let Some(cookies) = self.cookies.as_ref() {
+            cookies.store_response(&self.url, headers);
+        }
         self.retry_trace.observe_response(status_code, redirect_hop);
         let request = self.policy_request();
         let response = ResponseHead::new(status_code, headers);
@@ -470,6 +524,9 @@ impl RequestState {
             url,
         } = mutation;
 
+        if let Some(cookies) = self.cookies.as_mut() {
+            cookies.remove_managed_header(&mut self.headers);
+        }
         self.method = method.to_owned();
         self.url = url;
         self.headers = if let Some(auth) = self.auth.as_mut() {
@@ -518,6 +575,7 @@ impl RequestState {
                 parts.auth_removed_headers,
             )
         });
+        let cookies = parts.cookie_jar.map(RequestCookieState::new);
         Ok(Self {
             method: parts.method.to_uppercase(),
             url,
@@ -525,6 +583,7 @@ impl RequestState {
             body,
             body_policy,
             policy,
+            cookies,
             auth,
             policy_hooks: parts.policy_hooks,
             extensions: parts.extensions,

--- a/src/py/client/transport/tests.rs
+++ b/src/py/client/transport/tests.rs
@@ -173,6 +173,7 @@ fn transport_request(body: Option<Vec<u8>>, body_replayable: bool) -> TransportR
         max_redirects: 20,
         retry_policy: None,
         ssrf_policy: None,
+        cookie_jar: None,
         auth: None,
         policy_hooks: None,
         extensions: None,

--- a/tests/client_cookies/assertions.py
+++ b/tests/client_cookies/assertions.py
@@ -1,0 +1,13 @@
+__all__ = ("cookie_pairs", "request_cookie_pairs")
+
+from collections.abc import Iterable
+
+import foghttp
+
+
+def cookie_pairs(values: Iterable[str]) -> set[str]:
+    return {pair.strip() for value in values for pair in value.split(";") if pair.strip()}
+
+
+def request_cookie_pairs(response: foghttp.Response | foghttp.StreamResponse) -> set[str]:
+    return cookie_pairs(response.request.headers.get_list("cookie"))

--- a/tests/client_cookies/test_async_cookies.py
+++ b/tests/client_cookies/test_async_cookies.py
@@ -1,0 +1,47 @@
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+import foghttp
+from foghttp.status_codes.success import OK
+from tests.redirect_helpers import header_values
+from tests.support.http_routes import (
+    COOKIE_REDIRECT_PATH,
+    REPEATED_HEADERS_PATH,
+    SECURITY_HEADERS_PATH,
+)
+
+from .assertions import cookie_pairs
+
+
+async def test_async_cookie_jar_stores_and_sends_repeated_headers(http_server: str) -> None:
+    async with foghttp.AsyncClient(cookies=True) as client:
+        await client.get(http_server + REPEATED_HEADERS_PATH)
+        response = await client.get(http_server + SECURITY_HEADERS_PATH)
+
+    assert cookie_pairs(header_values(response.json(), "cookie")) == {"first=1", "second=2"}
+
+
+async def test_async_cookie_jar_does_not_leak_across_host_redirect(
+    http_server: str,
+) -> None:
+    target = _localhost_url(http_server, SECURITY_HEADERS_PATH)
+    redirect = f"{http_server}{COOKIE_REDIRECT_PATH}?{urlencode({'location': target})}"
+
+    async with foghttp.AsyncClient(cookies=True, follow_redirects=True) as client:
+        response = await client.get(redirect)
+
+    assert response.status_code == OK
+    assert header_values(response.json(), "cookie") == []
+
+
+async def test_async_cookie_jar_updates_before_stream_is_exposed(http_server: str) -> None:
+    async with foghttp.AsyncClient(cookies=True) as client:
+        async with client.stream("GET", http_server + REPEATED_HEADERS_PATH) as response:
+            assert response.status_code == OK
+        echoed = await client.get(http_server + SECURITY_HEADERS_PATH)
+
+    assert cookie_pairs(header_values(echoed.json(), "cookie")) == {"first=1", "second=2"}
+
+
+def _localhost_url(base_url: str, path: str) -> str:
+    parts = urlsplit(base_url)
+    return urlunsplit((parts.scheme, f"localhost:{parts.port}", path, "", ""))

--- a/tests/client_cookies/test_async_cookies.py
+++ b/tests/client_cookies/test_async_cookies.py
@@ -1,10 +1,16 @@
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
+import pytest
+
 import foghttp
 from foghttp.status_codes.success import OK
+from tests.http_body_scenarios import INCOMPLETE_CHUNKED_BODY_PATH
 from tests.redirect_helpers import header_values
 from tests.support.http_routes import (
+    COOKIE_BODY_PATH,
+    COOKIE_OPAQUE_PATH,
     COOKIE_REDIRECT_PATH,
+    COOKIE_ROOT_SET_PATH,
     REPEATED_HEADERS_PATH,
     SECURITY_HEADERS_PATH,
 )
@@ -20,26 +26,69 @@ async def test_async_cookie_jar_stores_and_sends_repeated_headers(http_server: s
     assert cookie_pairs(header_values(response.json(), "cookie")) == {"first=1", "second=2"}
 
 
-async def test_async_cookie_jar_does_not_leak_across_host_redirect(
+async def test_async_cookie_jar_reselects_for_cross_host_redirect(
     http_server: str,
 ) -> None:
     target = _localhost_url(http_server, SECURITY_HEADERS_PATH)
     redirect = f"{http_server}{COOKIE_REDIRECT_PATH}?{urlencode({'location': target})}"
 
     async with foghttp.AsyncClient(cookies=True, follow_redirects=True) as client:
-        response = await client.get(redirect)
+        await client.get(_localhost_url(http_server, COOKIE_ROOT_SET_PATH))
+        response = await client.get(
+            redirect,
+            headers={"Cookie": "source=caller-secret"},
+        )
 
     assert response.status_code == OK
-    assert header_values(response.json(), "cookie") == []
+    assert cookie_pairs(header_values(response.json(), "cookie")) == {
+        "root=cookie-secret",
+    }
+
+
+async def test_async_cookie_jar_ignores_obs_text_pair_without_losing_valid_siblings(
+    http_server: str,
+) -> None:
+    async with foghttp.AsyncClient(cookies=True) as client:
+        await client.get(http_server + COOKIE_OPAQUE_PATH)
+        response = await client.get(http_server + SECURITY_HEADERS_PATH)
+
+    assert cookie_pairs(header_values(response.json(), "cookie")) == {
+        'quoted="a%2Fb"',
+        "ascii=sibling",
+        "empty=",
+        "encoded=%FF",
+        "equals=a=b",
+        "literal=100%",
+        "nameless-token",
+        "opaque=%41%2F%25",
+    }
 
 
 async def test_async_cookie_jar_updates_before_stream_is_exposed(http_server: str) -> None:
-    async with foghttp.AsyncClient(cookies=True) as client:
-        async with client.stream("GET", http_server + REPEATED_HEADERS_PATH) as response:
-            assert response.status_code == OK
+    async with (
+        foghttp.AsyncClient(cookies=True) as client,
+        client.stream("GET", http_server + COOKIE_BODY_PATH) as response,
+    ):
+        assert response.status_code == OK
         echoed = await client.get(http_server + SECURITY_HEADERS_PATH)
 
-    assert cookie_pairs(header_values(echoed.json(), "cookie")) == {"first=1", "second=2"}
+    assert cookie_pairs(header_values(echoed.json(), "cookie")) == {
+        "retry_session=cookie-secret",
+    }
+
+
+async def test_async_cookie_jar_commits_before_incomplete_body_timeout(
+    http_server: str,
+) -> None:
+    timeouts = foghttp.Timeouts(total=0.05)
+    async with foghttp.AsyncClient(cookies=True, timeouts=timeouts) as client:
+        with pytest.raises(foghttp.TimeoutError, match="request total timeout expired"):
+            await client.get(http_server + INCOMPLETE_CHUNKED_BODY_PATH)
+        verification = await client.get(http_server + SECURITY_HEADERS_PATH)
+
+    assert cookie_pairs(header_values(verification.json(), "cookie")) == {
+        "incomplete_session=cookie-secret",
+    }
 
 
 def _localhost_url(base_url: str, path: str) -> str:

--- a/tests/client_cookies/test_sync_cookies.py
+++ b/tests/client_cookies/test_sync_cookies.py
@@ -1,0 +1,152 @@
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+import foghttp
+from foghttp.auth import AuthRequest
+from foghttp.status_codes.server_error import SERVICE_UNAVAILABLE
+from foghttp.status_codes.success import OK
+from tests.client_telemetry.models import RecordingTelemetrySink
+from tests.redirect_helpers import header_values
+from tests.support.http_routes import (
+    COOKIE_EXPIRE_PATH,
+    COOKIE_OPAQUE_PATH,
+    COOKIE_PATH_SET_PATH,
+    COOKIE_REDIRECT_PATH,
+    COOKIE_RETRY_PATH,
+    COOKIE_ROOT_SET_PATH,
+    REPEATED_HEADERS_PATH,
+    SECURITY_HEADERS_PATH,
+    TEXT_PATH,
+)
+
+from .assertions import cookie_pairs, request_cookie_pairs
+
+
+EXPECTED_RETRY_ATTEMPT_COUNT = 2
+
+
+def test_sync_cookie_jar_is_disabled_by_default(sync_http_server: str) -> None:
+    with foghttp.Client() as client:
+        client.get(sync_http_server + REPEATED_HEADERS_PATH)
+        response = client.get(sync_http_server + SECURITY_HEADERS_PATH)
+
+    assert header_values(response.json(), "cookie") == []
+
+
+def test_sync_cookie_jar_stores_repeated_headers_and_redacts_values(
+    sync_http_server: str,
+) -> None:
+    sink = RecordingTelemetrySink()
+    with foghttp.Client(
+        cookies=True,
+        telemetry=foghttp.TelemetryConfig(sink=sink),
+    ) as client:
+        set_response = client.get(sync_http_server + REPEATED_HEADERS_PATH)
+        response = client.get(sync_http_server + SECURITY_HEADERS_PATH)
+
+    assert cookie_pairs(header_values(response.json(), "cookie")) == {"first=1", "second=2"}
+    representation = repr((set_response, response.request, sink.events))
+    assert "first=1" not in representation
+    assert "second=2" not in representation
+    assert "<redacted>" in representation
+
+
+def test_sync_cookie_jar_preserves_opaque_values_on_the_wire(
+    sync_http_server: str,
+) -> None:
+    with foghttp.Client(cookies=True) as client:
+        client.get(sync_http_server + COOKIE_OPAQUE_PATH)
+        response = client.get(sync_http_server + SECURITY_HEADERS_PATH)
+
+    assert header_values(response.json(), "cookie") == [
+        'opaque=%41%2F%25; quoted="a%2Fb"; literal=100%; encoded=%FF; empty=; equals=a=b',
+    ]
+
+
+def test_sync_cookie_jar_honors_path_expiry_and_explicit_cookie_precedence(
+    sync_http_server: str,
+) -> None:
+    with foghttp.Client(cookies=True) as client:
+        client.get(sync_http_server + COOKIE_ROOT_SET_PATH)
+        client.get(sync_http_server + COOKIE_PATH_SET_PATH)
+        matching = client.get(sync_http_server + SECURITY_HEADERS_PATH)
+        outside_path = client.get(sync_http_server + TEXT_PATH)
+        explicit = client.get(
+            sync_http_server + SECURITY_HEADERS_PATH,
+            headers={"Cookie": "caller=explicit-secret"},
+        )
+        client.get(sync_http_server + COOKIE_EXPIRE_PATH)
+        after_expiry = client.get(sync_http_server + SECURITY_HEADERS_PATH)
+
+    assert cookie_pairs(header_values(matching.json(), "cookie")) == {
+        "root=cookie-secret",
+        "scoped=cookie-secret",
+    }
+    assert request_cookie_pairs(outside_path) == {"root=cookie-secret"}
+    assert cookie_pairs(header_values(explicit.json(), "cookie")) == {"caller=explicit-secret"}
+    assert cookie_pairs(header_values(after_expiry.json(), "cookie")) == {
+        "scoped=cookie-secret",
+    }
+
+
+def test_sync_cookie_jar_reselects_for_same_and_cross_host_redirects(
+    sync_http_server: str,
+) -> None:
+    same_host_url = _cookie_redirect_url(sync_http_server, SECURITY_HEADERS_PATH)
+    cross_host_target = _localhost_url(sync_http_server, SECURITY_HEADERS_PATH)
+    cross_host_url = _cookie_redirect_url(sync_http_server, cross_host_target)
+
+    with foghttp.Client(cookies=True, follow_redirects=True) as client:
+        same_host = client.get(same_host_url)
+    with foghttp.Client(cookies=True, follow_redirects=True) as client:
+        cross_host = client.get(cross_host_url)
+
+    assert cookie_pairs(header_values(same_host.json(), "cookie")) == {
+        "redirect_session=cookie-secret",
+    }
+    assert header_values(cross_host.json(), "cookie") == []
+
+
+def test_sync_cookie_jar_updates_before_retry(sync_http_server: str) -> None:
+    retry = foghttp.RetryPolicy(retries=1, backoff=0, jitter=0)
+    with foghttp.Client(cookies=True, retry=retry) as client:
+        response = client.get(sync_http_server + COOKIE_RETRY_PATH)
+
+    assert response.status_code == OK
+    assert response.retry_trace is not None
+    assert len(response.retry_trace.attempts) == EXPECTED_RETRY_ATTEMPT_COUNT
+    assert response.retry_trace.attempts[0].status_code == SERVICE_UNAVAILABLE
+    assert request_cookie_pairs(response) == {"retry_session=cookie-secret"}
+
+
+def test_sync_auth_cookie_takes_precedence_over_managed_cookie(
+    sync_http_server: str,
+) -> None:
+    def authenticate(_request: AuthRequest) -> dict[str, str]:
+        return {"Cookie": "auth=explicit-secret"}
+
+    with foghttp.Client(cookies=True, auth=authenticate) as client:
+        client.get(sync_http_server + COOKIE_ROOT_SET_PATH)
+        response = client.get(sync_http_server + SECURITY_HEADERS_PATH)
+
+    assert cookie_pairs(header_values(response.json(), "cookie")) == {
+        "auth=explicit-secret",
+    }
+    assert "explicit-secret" not in repr(response.request)
+
+
+def test_sync_cookie_jar_updates_before_stream_is_exposed(sync_http_server: str) -> None:
+    with foghttp.Client(cookies=True) as client:
+        with client.stream("GET", sync_http_server + REPEATED_HEADERS_PATH) as response:
+            assert response.status_code == OK
+        echoed = client.get(sync_http_server + SECURITY_HEADERS_PATH)
+
+    assert cookie_pairs(header_values(echoed.json(), "cookie")) == {"first=1", "second=2"}
+
+
+def _cookie_redirect_url(base_url: str, location: str) -> str:
+    return f"{base_url}{COOKIE_REDIRECT_PATH}?{urlencode({'location': location})}"
+
+
+def _localhost_url(base_url: str, path: str) -> str:
+    parts = urlsplit(base_url)
+    return urlunsplit((parts.scheme, f"localhost:{parts.port}", path, "", ""))

--- a/tests/client_cookies/test_sync_cookies.py
+++ b/tests/client_cookies/test_sync_cookies.py
@@ -1,12 +1,16 @@
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
+import pytest
+
 import foghttp
 from foghttp.auth import AuthRequest
 from foghttp.status_codes.server_error import SERVICE_UNAVAILABLE
 from foghttp.status_codes.success import OK
 from tests.client_telemetry.models import RecordingTelemetrySink
+from tests.http_body_scenarios import INCOMPLETE_CHUNKED_BODY_PATH
 from tests.redirect_helpers import header_values
 from tests.support.http_routes import (
+    COOKIE_BODY_PATH,
     COOKIE_EXPIRE_PATH,
     COOKIE_OPAQUE_PATH,
     COOKIE_PATH_SET_PATH,
@@ -19,9 +23,6 @@ from tests.support.http_routes import (
 )
 
 from .assertions import cookie_pairs, request_cookie_pairs
-
-
-EXPECTED_RETRY_ATTEMPT_COUNT = 2
 
 
 def test_sync_cookie_jar_is_disabled_by_default(sync_http_server: str) -> None:
@@ -50,7 +51,7 @@ def test_sync_cookie_jar_stores_repeated_headers_and_redacts_values(
     assert "<redacted>" in representation
 
 
-def test_sync_cookie_jar_preserves_opaque_values_on_the_wire(
+def test_sync_cookie_jar_preserves_supported_opaque_values_on_the_wire(
     sync_http_server: str,
 ) -> None:
     with foghttp.Client(cookies=True) as client:
@@ -58,7 +59,8 @@ def test_sync_cookie_jar_preserves_opaque_values_on_the_wire(
         response = client.get(sync_http_server + SECURITY_HEADERS_PATH)
 
     assert header_values(response.json(), "cookie") == [
-        'opaque=%41%2F%25; quoted="a%2Fb"; literal=100%; encoded=%FF; empty=; equals=a=b',
+        'opaque=%41%2F%25; quoted="a%2Fb"; literal=100%; encoded=%FF; empty=; '
+        "equals=a=b; nameless-token; ascii=sibling",
     ]
 
 
@@ -98,12 +100,18 @@ def test_sync_cookie_jar_reselects_for_same_and_cross_host_redirects(
     with foghttp.Client(cookies=True, follow_redirects=True) as client:
         same_host = client.get(same_host_url)
     with foghttp.Client(cookies=True, follow_redirects=True) as client:
-        cross_host = client.get(cross_host_url)
+        client.get(_localhost_url(sync_http_server, COOKIE_ROOT_SET_PATH))
+        cross_host = client.get(
+            cross_host_url,
+            headers={"Cookie": "source=caller-secret"},
+        )
 
     assert cookie_pairs(header_values(same_host.json(), "cookie")) == {
         "redirect_session=cookie-secret",
     }
-    assert header_values(cross_host.json(), "cookie") == []
+    assert cookie_pairs(header_values(cross_host.json(), "cookie")) == {
+        "root=cookie-secret",
+    }
 
 
 def test_sync_cookie_jar_updates_before_retry(sync_http_server: str) -> None:
@@ -113,8 +121,10 @@ def test_sync_cookie_jar_updates_before_retry(sync_http_server: str) -> None:
 
     assert response.status_code == OK
     assert response.retry_trace is not None
-    assert len(response.retry_trace.attempts) == EXPECTED_RETRY_ATTEMPT_COUNT
-    assert response.retry_trace.attempts[0].status_code == SERVICE_UNAVAILABLE
+    assert [attempt.status_code for attempt in response.retry_trace.attempts] == [
+        SERVICE_UNAVAILABLE,
+        OK,
+    ]
     assert request_cookie_pairs(response) == {"retry_session=cookie-secret"}
 
 
@@ -135,12 +145,31 @@ def test_sync_auth_cookie_takes_precedence_over_managed_cookie(
 
 
 def test_sync_cookie_jar_updates_before_stream_is_exposed(sync_http_server: str) -> None:
-    with foghttp.Client(cookies=True) as client:
-        with client.stream("GET", sync_http_server + REPEATED_HEADERS_PATH) as response:
-            assert response.status_code == OK
+    with (
+        foghttp.Client(cookies=True) as client,
+        client.stream("GET", sync_http_server + COOKIE_BODY_PATH) as response,
+    ):
+        assert response.status_code == OK
         echoed = client.get(sync_http_server + SECURITY_HEADERS_PATH)
 
-    assert cookie_pairs(header_values(echoed.json(), "cookie")) == {"first=1", "second=2"}
+    assert cookie_pairs(header_values(echoed.json(), "cookie")) == {
+        "retry_session=cookie-secret",
+    }
+
+
+def test_sync_cookie_jar_commits_before_incomplete_body_timeout(
+    sync_http_server: str,
+) -> None:
+    timeouts = foghttp.Timeouts(total=0.05)
+    with foghttp.Client(cookies=True, timeouts=timeouts) as client:
+        with pytest.raises(foghttp.TimeoutError) as exc_info:
+            client.get(sync_http_server + INCOMPLETE_CHUNKED_BODY_PATH)
+        verification = client.get(sync_http_server + SECURITY_HEADERS_PATH)
+
+    assert "request total timeout expired" in str(exc_info.value)
+    assert cookie_pairs(header_values(verification.json(), "cookie")) == {
+        "incomplete_session=cookie-secret",
+    }
 
 
 def _cookie_redirect_url(base_url: str, location: str) -> str:

--- a/tests/client_options/raw_options.py
+++ b/tests/client_options/raw_options.py
@@ -16,6 +16,7 @@ def raw_client_options(**overrides: object) -> dict[str, object]:
         "connect_timeout": 2.0,
         "follow_redirects": False,
         "max_redirects": 20,
+        "cookies_enabled": False,
         "ca_certificates": (),
         "trust_webpki_roots": True,
         "runtime": "dedicated",

--- a/tests/http_body_scenarios.py
+++ b/tests/http_body_scenarios.py
@@ -18,6 +18,7 @@ from foghttp.status_codes.success import OK
 
 
 BODY_RESPONSE_DELAY = 0.25
+INCOMPLETE_BODY_SET_COOKIE = "incomplete_session=cookie-secret; Path=/"
 DELAYED_EOF_UNKNOWN_SIZE_BYTES_PATH = "/delayed-eof-unknown-size-bytes"
 INCOMPLETE_CHUNKED_BODY_PATH = "/incomplete-chunked-body"
 SLOW_BODY_PATH = "/slow-body"
@@ -64,6 +65,7 @@ async def write_async_body_safety_response(
                 [
                     ("content-type", "application/octet-stream"),
                     ("transfer-encoding", "chunked"),
+                    ("set-cookie", INCOMPLETE_BODY_SET_COOKIE),
                     ("connection", "close"),
                 ],
                 b"1\r\nx\r\n",
@@ -165,6 +167,7 @@ def _write_sync_incomplete_chunked_body(
     handler.send_response(OK)
     handler.send_header("content-type", "application/octet-stream")
     handler.send_header("transfer-encoding", "chunked")
+    handler.send_header("set-cookie", INCOMPLETE_BODY_SET_COOKIE)
     handler.send_header("connection", "close")
     handler.end_headers()
     with suppress(OSError):

--- a/tests/pyo3_boundary/test_raw_client_signatures.py
+++ b/tests/pyo3_boundary/test_raw_client_signatures.py
@@ -17,6 +17,7 @@ RAW_CLIENT_KEYWORD_ONLY_PARAMETERS = (
     "connect_timeout",
     "follow_redirects",
     "max_redirects",
+    "cookies_enabled",
     "ca_certificates",
     "trust_webpki_roots",
     "runtime",

--- a/tests/support/http_routes.py
+++ b/tests/support/http_routes.py
@@ -1,4 +1,5 @@
 __all__ = (
+    "COOKIE_BODY_PATH",
     "COOKIE_EXPIRE_PATH",
     "COOKIE_OPAQUE_PATH",
     "COOKIE_PATH_SET_PATH",
@@ -33,13 +34,14 @@ REDIRECT_TO_STATUS_PATH_PARTS = 3
 STATUS_PATH_PARTS = 2
 UNKNOWN_SIZE_BYTES_ROUTE = "unknown-size-bytes"
 
-ECHO_HEADERS_PATH = "/headers/echo"
+COOKIE_BODY_PATH = "/cookies/body"
 COOKIE_EXPIRE_PATH = "/cookies/expire"
 COOKIE_OPAQUE_PATH = "/cookies/opaque"
 COOKIE_PATH_SET_PATH = "/cookies/path"
 COOKIE_REDIRECT_PATH = "/cookies/redirect"
 COOKIE_RETRY_PATH = "/cookies/retry"
 COOKIE_ROOT_SET_PATH = "/cookies/root"
+ECHO_HEADERS_PATH = "/headers/echo"
 OBS_TEXT_HEADERS_PATH = "/headers/obs-text"
 REDIRECT_TO_LOCATION_PATH = "/redirect-to-location"
 REPEATED_HEADERS_PATH = "/headers/repeated"
@@ -51,9 +53,15 @@ def cookie_response(
     path: str,
     query: str,
     request_cookies: list[str],
-) -> tuple[int, list[tuple[str, str]]] | None:
+) -> tuple[int, list[tuple[str, str]], bytes] | None:
     if path == COOKIE_PATH_SET_PATH:
-        response = OK, [("set-cookie", "scoped=cookie-secret; Path=/headers")]
+        response = OK, [("set-cookie", "scoped=cookie-secret; Path=/headers")], b""
+    elif path == COOKIE_BODY_PATH:
+        response = (
+            OK,
+            [("set-cookie", "retry_session=cookie-secret; Path=/")],
+            b"x" * 4096,
+        )
     elif path == COOKIE_OPAQUE_PATH:
         response = (
             OK,
@@ -62,14 +70,18 @@ def cookie_response(
                 ("set-cookie", 'quoted="a%2Fb"; Path=/'),
                 ("set-cookie", "literal=100%; Path=/"),
                 ("set-cookie", "encoded=%FF; Path=/"),
+                ("set-cookie", "latin=\xe9; Path=/"),
                 ("set-cookie", "empty=; Path=/"),
                 ("set-cookie", "equals=a=b; Path=/"),
+                ("set-cookie", "nameless-token; Path=/"),
+                ("set-cookie", "ascii=sibling; Path=/"),
             ],
+            b"",
         )
     elif path == COOKIE_ROOT_SET_PATH:
-        response = OK, [("set-cookie", "root=cookie-secret; Path=/")]
+        response = OK, [("set-cookie", "root=cookie-secret; Path=/")], b""
     elif path == COOKIE_EXPIRE_PATH:
-        response = OK, [("set-cookie", "root=; Path=/; Max-Age=0")]
+        response = OK, [("set-cookie", "root=; Path=/; Max-Age=0")], b""
     elif path == COOKIE_REDIRECT_PATH:
         locations = parse_qs(query, keep_blank_values=True).get("location", [])
         if locations:
@@ -79,18 +91,20 @@ def cookie_response(
                     ("location", locations[0]),
                     ("set-cookie", "redirect_session=cookie-secret; Path=/"),
                 ],
+                b"",
             )
         else:
             response = None
     elif path == COOKIE_RETRY_PATH:
         if any("retry_session=cookie-secret" in value for value in request_cookies):
-            response = OK, []
+            response = OK, [], b""
         else:
             response = (
                 SERVICE_UNAVAILABLE,
                 [
                     ("set-cookie", "retry_session=cookie-secret; Path=/"),
                 ],
+                b"",
             )
     else:
         response = None

--- a/tests/support/http_routes.py
+++ b/tests/support/http_routes.py
@@ -1,4 +1,10 @@
 __all__ = (
+    "COOKIE_EXPIRE_PATH",
+    "COOKIE_OPAQUE_PATH",
+    "COOKIE_PATH_SET_PATH",
+    "COOKIE_REDIRECT_PATH",
+    "COOKIE_RETRY_PATH",
+    "COOKIE_ROOT_SET_PATH",
     "ECHO_HEADERS_PATH",
     "OBS_TEXT_HEADERS_PATH",
     "REDIRECT_TO_LOCATION_PATH",
@@ -6,6 +12,7 @@ __all__ = (
     "SECURITY_HEADERS_PATH",
     "TEXT_PATH",
     "bytes_response_size",
+    "cookie_response",
     "redirect_status",
     "redirect_to_location",
     "redirect_to_status",
@@ -15,6 +22,10 @@ __all__ = (
 
 from urllib.parse import parse_qs
 
+from foghttp.status_codes.redirect import FOUND
+from foghttp.status_codes.server_error import SERVICE_UNAVAILABLE
+from foghttp.status_codes.success import OK
+
 
 BYTES_PATH_PARTS = 2
 REDIRECT_PATH_PARTS = 2
@@ -23,11 +34,67 @@ STATUS_PATH_PARTS = 2
 UNKNOWN_SIZE_BYTES_ROUTE = "unknown-size-bytes"
 
 ECHO_HEADERS_PATH = "/headers/echo"
+COOKIE_EXPIRE_PATH = "/cookies/expire"
+COOKIE_OPAQUE_PATH = "/cookies/opaque"
+COOKIE_PATH_SET_PATH = "/cookies/path"
+COOKIE_REDIRECT_PATH = "/cookies/redirect"
+COOKIE_RETRY_PATH = "/cookies/retry"
+COOKIE_ROOT_SET_PATH = "/cookies/root"
 OBS_TEXT_HEADERS_PATH = "/headers/obs-text"
 REDIRECT_TO_LOCATION_PATH = "/redirect-to-location"
 REPEATED_HEADERS_PATH = "/headers/repeated"
 SECURITY_HEADERS_PATH = "/headers/security"
 TEXT_PATH = "/text"
+
+
+def cookie_response(
+    path: str,
+    query: str,
+    request_cookies: list[str],
+) -> tuple[int, list[tuple[str, str]]] | None:
+    if path == COOKIE_PATH_SET_PATH:
+        response = OK, [("set-cookie", "scoped=cookie-secret; Path=/headers")]
+    elif path == COOKIE_OPAQUE_PATH:
+        response = (
+            OK,
+            [
+                ("set-cookie", "opaque=%41%2F%25; Path=/"),
+                ("set-cookie", 'quoted="a%2Fb"; Path=/'),
+                ("set-cookie", "literal=100%; Path=/"),
+                ("set-cookie", "encoded=%FF; Path=/"),
+                ("set-cookie", "empty=; Path=/"),
+                ("set-cookie", "equals=a=b; Path=/"),
+            ],
+        )
+    elif path == COOKIE_ROOT_SET_PATH:
+        response = OK, [("set-cookie", "root=cookie-secret; Path=/")]
+    elif path == COOKIE_EXPIRE_PATH:
+        response = OK, [("set-cookie", "root=; Path=/; Max-Age=0")]
+    elif path == COOKIE_REDIRECT_PATH:
+        locations = parse_qs(query, keep_blank_values=True).get("location", [])
+        if locations:
+            response = (
+                FOUND,
+                [
+                    ("location", locations[0]),
+                    ("set-cookie", "redirect_session=cookie-secret; Path=/"),
+                ],
+            )
+        else:
+            response = None
+    elif path == COOKIE_RETRY_PATH:
+        if any("retry_session=cookie-secret" in value for value in request_cookies):
+            response = OK, []
+        else:
+            response = (
+                SERVICE_UNAVAILABLE,
+                [
+                    ("set-cookie", "retry_session=cookie-secret; Path=/"),
+                ],
+            )
+    else:
+        response = None
+    return response
 
 
 def redirect_status(path: str) -> int | None:

--- a/tests/support/raw_responses.py
+++ b/tests/support/raw_responses.py
@@ -23,6 +23,7 @@ from tests.support.http_routes import (
     SECURITY_HEADERS_PATH,
     TEXT_PATH,
     bytes_response_size,
+    cookie_response,
     redirect_status,
     redirect_to_location,
     redirect_to_status,
@@ -100,7 +101,8 @@ def raw_http_server_response(headers: str, body: bytes) -> bytes:
     target_parts = urlsplit(target)
     path = target_parts.path
     response = (
-        _raw_redirect_to_location_response(path, target_parts.query)
+        _raw_cookie_response(path, target_parts.query, headers)
+        or _raw_redirect_to_location_response(path, target_parts.query)
         or _raw_redirect_to_status_response(path)
         or _raw_redirect_response(path)
         or _raw_status_response(path)
@@ -114,6 +116,14 @@ def raw_http_server_response(headers: str, body: bytes) -> bytes:
         or _raw_security_headers_response(path, headers, body)
     )
     return response or _raw_json_response(method=method, request_line=request_line, body=body)
+
+
+def _raw_cookie_response(path: str, query: str, headers: str) -> bytes | None:
+    response = cookie_response(path, query, header_values(headers, "cookie"))
+    if response is None:
+        return None
+    status_code, response_headers = response
+    return _raw_empty_response(status_code, _reason_phrase(status_code), response_headers)
 
 
 def json_payload(*, request_line: str, body: bytes) -> bytes:

--- a/tests/support/raw_responses.py
+++ b/tests/support/raw_responses.py
@@ -92,7 +92,8 @@ def raw_response(
     content: bytes = b"",
 ) -> bytes:
     header_lines = "".join(f"{name}: {value}\r\n" for name, value in headers)
-    return f"HTTP/1.1 {status_code} {reason}\r\n{header_lines}\r\n".encode() + content
+    head = f"HTTP/1.1 {status_code} {reason}\r\n{header_lines}\r\n".encode("latin-1")
+    return head + content
 
 
 def raw_http_server_response(headers: str, body: bytes) -> bytes:
@@ -122,8 +123,17 @@ def _raw_cookie_response(path: str, query: str, headers: str) -> bytes | None:
     response = cookie_response(path, query, header_values(headers, "cookie"))
     if response is None:
         return None
-    status_code, response_headers = response
-    return _raw_empty_response(status_code, _reason_phrase(status_code), response_headers)
+    status_code, response_headers, content = response
+    return raw_response(
+        status_code,
+        _reason_phrase(status_code),
+        [
+            *response_headers,
+            ("content-length", str(len(content))),
+            ("connection", "close"),
+        ],
+        content,
+    )
 
 
 def json_payload(*, request_line: str, body: bytes) -> bytes:

--- a/tests/support/sync_http_server.py
+++ b/tests/support/sync_http_server.py
@@ -101,13 +101,14 @@ class SyncHTTPHandler(BaseHTTPRequestHandler):
         )
         if response is None:
             return False
-        status_code, headers = response
+        status_code, headers, content = response
         self.send_response(status_code)
         for name, value in headers:
             self.send_header(name, value)
-        self.send_header("content-length", "0")
+        self.send_header("content-length", str(len(content)))
         self.send_header("connection", "close")
         self.end_headers()
+        self.wfile.write(content)
         return True
 
     def _write_redirect_to_location(self) -> bool:

--- a/tests/support/sync_http_server.py
+++ b/tests/support/sync_http_server.py
@@ -19,6 +19,7 @@ from tests.support.http_routes import (
     SECURITY_HEADERS_PATH,
     TEXT_PATH,
     bytes_response_size,
+    cookie_response,
     redirect_status,
     redirect_to_location,
     redirect_to_status,
@@ -71,6 +72,7 @@ class SyncHTTPHandler(BaseHTTPRequestHandler):
         handled = any(
             handler()
             for handler in (
+                self._write_cookie_response,
                 self._write_redirect_to_location,
                 lambda: self._write_redirect_to_status(path),
                 lambda: self._write_redirect(path),
@@ -89,6 +91,24 @@ class SyncHTTPHandler(BaseHTTPRequestHandler):
             return
 
         self._write_json(body)
+
+    def _write_cookie_response(self) -> bool:
+        target = urlsplit(self.path)
+        response = cookie_response(
+            target.path,
+            target.query,
+            self.headers.get_all("cookie", []),
+        )
+        if response is None:
+            return False
+        status_code, headers = response
+        self.send_response(status_code)
+        for name, value in headers:
+            self.send_header(name, value)
+        self.send_header("content-length", "0")
+        self.send_header("connection", "close")
+        self.end_headers()
+        return True
 
     def _write_redirect_to_location(self) -> bool:
         target = urlsplit(self.path)

--- a/tests/test_client_options.py
+++ b/tests/test_client_options.py
@@ -29,9 +29,9 @@ def test_limits_reject_negative_max_buffered_response_bytes() -> None:
         foghttp.Limits(max_buffered_response_bytes=-1)
 
 
-def test_client_rejects_cookies_until_supported() -> None:
-    with pytest.raises(NotImplementedError, match="cookies are planned after the MVP"):
-        foghttp.Client(cookies=True)
+def test_client_accepts_opt_in_cookies() -> None:
+    client = foghttp.Client(cookies=True)
+    client.close()
 
 
 def test_client_rejects_unsupported_http_versions() -> None:

--- a/tests/test_raw_client.py
+++ b/tests/test_raw_client.py
@@ -41,6 +41,7 @@ RAW_CLIENT_INIT_ARGUMENTS = (
     "connect_timeout",
     "follow_redirects",
     "max_redirects",
+    "cookies_enabled",
     "ca_certificates",
     "trust_webpki_roots",
     "runtime",
@@ -94,6 +95,7 @@ def _client_config(
     proxy: str | None = None,
     tls: TLSConfig | None = None,
     policy_hooks: TransportPolicyHooks | None = None,
+    cookies: bool = False,
 ) -> ClientConfig:
     return ClientConfig.from_options(
         ClientOptions(
@@ -105,7 +107,7 @@ def _client_config(
             http_versions=None,
             follow_redirects=follow_redirects,
             max_redirects=max_redirects,
-            cookies=False,
+            cookies=cookies,
             trust_env=trust_env,
             proxy=proxy,
             tls=tls,
@@ -173,6 +175,7 @@ def test_create_raw_client_passes_transport_limits_to_rust_client(
             timeouts=timeouts,
             follow_redirects=follow_redirects,
             max_redirects=max_redirects,
+            cookies=True,
             runtime_workers=runtime_workers,
         ),
     )
@@ -193,6 +196,7 @@ def test_create_raw_client_passes_transport_limits_to_rust_client(
         "connect_timeout": timeouts.connect,
         "follow_redirects": follow_redirects,
         "max_redirects": max_redirects,
+        "cookies_enabled": True,
         "ca_certificates": (),
         "trust_webpki_roots": True,
         "runtime": "dedicated",


### PR DESCRIPTION
Preserve RFC-compliant domain, path, expiry, and secure semantics.

Coordinate cookies with redirects, retries, auth, and streaming.

Add sync/async coverage and public documentation.

Closes #14