### PR TITLE
chore(release): prepare 0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "brotli",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foghttp"
-version = "0.3.8"
+version = "0.3.9"
 description = "Observable Rust-powered HTTP client for Python services."
 edition = "2021"
 rust-version = "1.88"

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,9 @@ uv run examples/async_json_fanout.py
 uv run examples/async_resource_limits.py
 uv run examples/async_lifecycle_debug.py
 uv run examples/async_streaming.py
+uv run examples/authentication.py
 uv run examples/compressed_response.py
+uv run examples/cookies.py
 uv run examples/http_proxy.py
 uv run examples/multipart_uploads.py
 uv run examples/redirects.py
@@ -42,8 +44,12 @@ uv run examples/telemetry_hooks.py
   debug snapshots and strict no-leak assertion pattern.
 - [async_streaming.py](./async_streaming.py): async bytes, text, and line response
   streaming with explicit context-managed cleanup.
+- [authentication.py](./authentication.py): request-aware client auth with a
+  redaction-aware `Authorization` header.
 - [compressed_response.py](./compressed_response.py): manual
   `Accept-Encoding` negotiation with transparent buffered response decoding.
+- [cookies.py](./cookies.py): an opt-in client cookie session across a redirect
+  and a later request.
 - [http_proxy.py](./http_proxy.py): direct request by default, or HTTP proxy
   routing / HTTPS `CONNECT` tunnelling with
   `FOGHTTP_HTTP_PROXY=http://proxy:port`; set `FOGHTTP_PROXY_TARGET_URL` to
@@ -69,5 +75,7 @@ uv run examples/telemetry_hooks.py
 FogHTTP supports sync and async response streaming for bytes, text, and lines,
 plus plain HTTP proxy routing and HTTPS proxy `CONNECT` through `http://` proxy
 endpoints. Streaming request uploads and multipart `files=` uploads are
-available. Do not use these examples as templates for cookie sessions,
-SOCKS/PAC proxy clients, TLS-to-proxy endpoints, or streaming decompression yet.
+available. The cookie example is HTTP service-client state, not browser-grade
+public-suffix, SameSite, partitioned, or third-party cookie policy. Do not use
+these examples as templates for SOCKS/PAC proxy clients, TLS-to-proxy endpoints,
+or streaming decompression yet.

--- a/examples/authentication.py
+++ b/examples/authentication.py
@@ -1,0 +1,27 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "foghttp",
+# ]
+#
+# [tool.uv.sources]
+# foghttp = { path = "../", editable = true }
+# ///
+
+import foghttp
+
+
+def authenticate(request: foghttp.AuthRequest) -> dict[str, str]:
+    return {"Authorization": f"Bearer example-{request.method.lower()}"}
+
+
+def main() -> None:
+    with foghttp.Client(auth=authenticate) as client:
+        response = client.get("https://httpbin.org/bearer")
+        response.raise_for_status()
+
+    print("authenticated:", response.json()["authenticated"])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cookies.py
+++ b/examples/cookies.py
@@ -1,0 +1,24 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "foghttp",
+# ]
+#
+# [tool.uv.sources]
+# foghttp = { path = "../", editable = true }
+# ///
+
+import foghttp
+
+
+def main() -> None:
+    with foghttp.Client(base_url="https://httpbin.org", cookies=True) as client:
+        client.get("/cookies/set", params={"foghttp-session": "active"}).raise_for_status()
+        response = client.get("/cookies")
+        response.raise_for_status()
+
+    print("cookies:", response.json()["cookies"])
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "foghttp"
-version = "0.3.8"
+version = "0.3.9"
 description = "Observable Rust-powered HTTP client for Python services."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
Synchronize Python and Rust package metadata.
Add runnable authentication and cookie examples.
Refresh release documentation and limitations.

Closes: #197