### PR TITLE
feat(telemetry): add structured lifecycle debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - bounded global/per-origin request backpressure, FIFO pending-acquire limits,
   explicit HTTP/1.1 connection caps, and per-origin pressure diagnostics
 - typed telemetry event hooks with redacted request/response lifecycle events
+- opt-in structured lifecycle debug logging through standard Python `logging`
 - versioned telemetry snapshots that separate alert-oriented stats from
   diagnostic dump APIs
 - optional Prometheus/OpenMetrics adapters with bounded labels and no

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ FogHTTP is designed around a few engineering priorities:
   pressure, idle lifecycle snapshots, and stuck request diagnostics
 - opt-in typed telemetry event hooks with redacted request/response lifecycle
   events
+- opt-in structured lifecycle debug logging through standard Python `logging`
 - optional Prometheus/OpenMetrics adapters over typed events and alert-oriented
   transport stats
 - opt-in typed transport policy hooks for lightweight request admission and

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -131,6 +131,60 @@ If a request is already failing because of transport, timeout, cancellation, or
 stream cleanup, telemetry cleanup errors are suppressed so the original request
 failure is not masked.
 
+## Structured debug logging
+
+`StructuredLoggingTelemetrySink` projects selected lifecycle events onto the
+standard-library logger named `foghttp.lifecycle` at `DEBUG` level. FogHTTP does
+not install handlers, configure the root logger, or enable the sink implicitly.
+Applications opt in through the existing telemetry contract:
+
+```python
+import logging
+
+from foghttp import Client, StructuredLoggingTelemetrySink, TelemetryConfig
+
+
+logging.basicConfig(level=logging.DEBUG)
+logging.getLogger("foghttp.lifecycle").setLevel(logging.DEBUG)
+
+with Client(
+    telemetry=TelemetryConfig(sink=StructuredLoggingTelemetrySink()),
+) as client:
+    client.get("https://api.example.com/items?token=secret")
+```
+
+The sink emits connection opened/open-failed/reused/closed/aborted events,
+redirect and retry decisions, and terminal request events representing a
+timeout. Other request, response-header, and body-completion events are not
+logged by this adapter.
+
+Every emitted `LogRecord` has the following `extra` attributes. Fields that do
+not apply to an event are present with value `None`, so a formatter attached to
+the dedicated logger can use a stable field set.
+
+| field | meaning |
+| --- | --- |
+| `foghttp_event_type` | Typed lifecycle event name. |
+| `foghttp_schema_version` | Telemetry event schema version. |
+| `foghttp_event_sequence`, `foghttp_observed_at_ns` | Client-local ordering and monotonic observation time. |
+| `foghttp_request_id`, `foghttp_mode`, `foghttp_method` | Request correlation fields when applicable. |
+| `foghttp_origin` | Normalized scheme/host/port only; never userinfo, path, query, or fragment. |
+| `foghttp_status_code`, `foghttp_elapsed_ns`, `foghttp_redirect_hop` | Response or lifecycle phase context when applicable. |
+| `foghttp_retry_attempt`, `foghttp_retry_decision`, `foghttp_retry_reason`, `foghttp_retry_backoff_ns` | Retry decision context. |
+| `foghttp_outcome`, `foghttp_error_type`, `foghttp_timeout_phase` | Terminal outcome and typed error/timeout context. |
+
+The adapter deliberately does not copy `redacted_url`, headers, or body data
+into log records. It normalizes `origin` again at the logging boundary, so raw
+userinfo, path, query, and fragment data cannot cross through that field.
+
+The default client path remains unchanged: without
+`TelemetryConfig(sink=...)`, FogHTTP creates no telemetry events and makes no
+logging calls. The sink also checks `Logger.isEnabledFor(DEBUG)` before building
+structured fields. Once installed, however, telemetry callbacks and configured
+logging handlers run inline on the request thread or event loop; keep handlers
+fast or route records through application-owned non-blocking logging
+infrastructure.
+
 Pool acquire and connection lifecycle events are recorded in Rust when an
 opt-in sink is configured. Rust never invokes the Python sink directly. It
 writes compact records to a bounded, non-blocking client journal; Python drains

--- a/foghttp/__init__.py
+++ b/foghttp/__init__.py
@@ -43,6 +43,7 @@ __all__ = (
     "SSRFPolicy",
     "SSRFViolationReason",
     "StreamResponse",
+    "StructuredLoggingTelemetrySink",
     "TLSConfig",
     "TelemetryConfig",
     "TelemetryEvent",
@@ -129,6 +130,7 @@ from .telemetry import (
     TelemetryRequestOutcome,
 )
 from .telemetry.events import TelemetryRetryDecision, TelemetryRetryReason
+from .telemetry.logging import StructuredLoggingTelemetrySink
 from .timeout_diagnostics import TimeoutDiagnostic, TimeoutPhase
 from .timeouts import Timeouts
 from .tls import TLSConfig

--- a/foghttp/telemetry/__init__.py
+++ b/foghttp/telemetry/__init__.py
@@ -1,6 +1,7 @@
 """Typed telemetry event contract."""
 
 __all__ = (
+    "StructuredLoggingTelemetrySink",
     "TelemetryConfig",
     "TelemetryEvent",
     "TelemetryEventSink",
@@ -23,4 +24,5 @@ from .events import (
     TelemetryRetryDecision,
     TelemetryRetryReason,
 )
+from .logging import StructuredLoggingTelemetrySink
 from .sinks import TelemetryEventSink

--- a/foghttp/telemetry/logging.py
+++ b/foghttp/telemetry/logging.py
@@ -1,0 +1,88 @@
+__all__ = ("StructuredLoggingTelemetrySink",)
+
+import logging
+
+from ..errors.timeout import ConnectTimeout, PoolTimeout, ReadTimeout, TimeoutError, WriteTimeout
+from ..url import URL
+from .events import TelemetryEvent, TelemetryEventType
+
+
+_LOGGER_NAME = "foghttp.lifecycle"
+_LOGGED_EVENT_TYPES: frozenset[TelemetryEventType] = frozenset(
+    (
+        TelemetryEventType.CONNECTION_OPENED,
+        TelemetryEventType.CONNECTION_OPEN_FAILED,
+        TelemetryEventType.CONNECTION_REUSED,
+        TelemetryEventType.CONNECTION_CLOSED,
+        TelemetryEventType.CONNECTION_ABORTED,
+        TelemetryEventType.REDIRECT_DECISION,
+        TelemetryEventType.RETRY_DECISION,
+    ),
+)
+_TIMEOUT_ERROR_TYPES = frozenset(
+    error_type.__name__
+    for error_type in (
+        ConnectTimeout,
+        PoolTimeout,
+        ReadTimeout,
+        TimeoutError,
+        WriteTimeout,
+    )
+)
+
+
+class StructuredLoggingTelemetrySink:
+    """Write selected lifecycle telemetry to ``foghttp.lifecycle`` at DEBUG."""
+
+    def __init__(self) -> None:
+        self._logger = logging.getLogger(_LOGGER_NAME)
+
+    def emit(self, event: TelemetryEvent) -> None:
+        if not self._logger.isEnabledFor(logging.DEBUG) or not _is_logged_event(event):
+            return
+
+        self._logger.debug(
+            "FogHTTP lifecycle event: %s",
+            event.event_type.value,
+            extra=_log_fields(event),
+        )
+
+
+def _is_logged_event(event: TelemetryEvent) -> bool:
+    if event.event_type in _LOGGED_EVENT_TYPES:
+        return True
+    return event.event_type is TelemetryEventType.REQUEST_FINISHED and (
+        event.timeout_phase is not None or event.error_type in _TIMEOUT_ERROR_TYPES
+    )
+
+
+def _log_fields(event: TelemetryEvent) -> dict[str, object]:
+    return {
+        "foghttp_event_type": event.event_type.value,
+        "foghttp_schema_version": event.schema_version,
+        "foghttp_event_sequence": event.event_sequence,
+        "foghttp_observed_at_ns": event.observed_at_ns,
+        "foghttp_request_id": event.request_id,
+        "foghttp_mode": None if event.mode is None else event.mode.value,
+        "foghttp_method": event.method,
+        "foghttp_origin": _normalized_origin(event.origin),
+        "foghttp_status_code": event.status_code,
+        "foghttp_elapsed_ns": event.elapsed_ns,
+        "foghttp_redirect_hop": event.redirect_hop,
+        "foghttp_retry_attempt": event.retry_attempt,
+        "foghttp_retry_decision": None if event.retry_decision is None else event.retry_decision.value,
+        "foghttp_retry_reason": None if event.retry_reason is None else event.retry_reason.value,
+        "foghttp_retry_backoff_ns": event.retry_backoff_ns,
+        "foghttp_outcome": None if event.outcome is None else event.outcome.value,
+        "foghttp_error_type": event.error_type,
+        "foghttp_timeout_phase": event.timeout_phase,
+    }
+
+
+def _normalized_origin(origin: str | None) -> str | None:
+    if origin is None:
+        return None
+    try:
+        return URL(origin).origin
+    except ValueError:
+        return None

--- a/tests/client_telemetry/test_structured_logging.py
+++ b/tests/client_telemetry/test_structured_logging.py
@@ -1,0 +1,255 @@
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+import foghttp
+from foghttp.status_codes.success import OK
+from tests.client_keepalive.constants import KEEPALIVE_PATH
+from tests.client_keepalive.server import start_keepalive_server
+
+
+_LOGGER_NAME = "foghttp.lifecycle"
+_RAW_USERINFO = "logging-user:logging-password"
+_RAW_PATH = "private-logging-path"
+_RAW_QUERY_VALUE = "logging-token"
+
+
+def _event(
+    event_type: foghttp.TelemetryEventType,
+    *,
+    error_type: str | None = None,
+    timeout_phase: foghttp.TimeoutPhase | None = None,
+) -> foghttp.TelemetryEvent:
+    return foghttp.TelemetryEvent(
+        event_type=event_type,
+        event_sequence=1,
+        observed_at_ns=1,
+        error_type=error_type,
+        timeout_phase=timeout_phase,
+    )
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        pytest.param(_event(foghttp.TelemetryEventType.CONNECTION_OPENED), id="connection-opened"),
+        pytest.param(_event(foghttp.TelemetryEventType.CONNECTION_OPEN_FAILED), id="connection-open-failed"),
+        pytest.param(_event(foghttp.TelemetryEventType.CONNECTION_REUSED), id="connection-reused"),
+        pytest.param(_event(foghttp.TelemetryEventType.CONNECTION_CLOSED), id="connection-closed"),
+        pytest.param(_event(foghttp.TelemetryEventType.CONNECTION_ABORTED), id="connection-aborted"),
+        pytest.param(_event(foghttp.TelemetryEventType.REDIRECT_DECISION), id="redirect"),
+        pytest.param(_event(foghttp.TelemetryEventType.RETRY_DECISION), id="retry"),
+        pytest.param(
+            _event(
+                foghttp.TelemetryEventType.REQUEST_FINISHED,
+                error_type="ReadTimeout",
+                timeout_phase="response_body",
+            ),
+            id="timeout-with-phase",
+        ),
+        pytest.param(
+            _event(
+                foghttp.TelemetryEventType.REQUEST_FINISHED,
+                error_type="TimeoutError",
+            ),
+            id="timeout-without-phase",
+        ),
+    ],
+)
+def test_logging_sink_emits_selected_lifecycle_events(
+    event: foghttp.TelemetryEvent,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = foghttp.StructuredLoggingTelemetrySink()
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        sink.emit(event)
+
+    record = _single_foghttp_record(caplog)
+    assert record.levelno == logging.DEBUG
+    assert record.getMessage() == f"FogHTTP lifecycle event: {event.event_type.value}"
+    assert record.__dict__["foghttp_event_type"] == event.event_type.value
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        foghttp.TelemetryEventType.REQUEST_STARTED,
+        foghttp.TelemetryEventType.POOL_ACQUIRE_FINISHED,
+        foghttp.TelemetryEventType.RESPONSE_HEADERS_RECEIVED,
+        foghttp.TelemetryEventType.RESPONSE_BODY_FINISHED,
+        foghttp.TelemetryEventType.REQUEST_FINISHED,
+    ],
+)
+def test_logging_sink_ignores_non_lifecycle_events(
+    event_type: foghttp.TelemetryEventType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = foghttp.StructuredLoggingTelemetrySink()
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        sink.emit(_event(event_type))
+
+    assert _foghttp_records(caplog) == ()
+
+
+def test_logging_sink_exposes_stable_safe_structured_fields(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = foghttp.StructuredLoggingTelemetrySink()
+    event = foghttp.TelemetryEvent(
+        event_type=foghttp.TelemetryEventType.RETRY_DECISION,
+        event_sequence=7,
+        observed_at_ns=11,
+        request_id=13,
+        mode=foghttp.TelemetryRequestMode.BUFFERED,
+        method="GET",
+        origin=f"https://{_RAW_USERINFO}@example.com/{_RAW_PATH}?token={_RAW_QUERY_VALUE}",
+        redacted_url=f"https://example.com/{_RAW_PATH}?token={_RAW_QUERY_VALUE}",
+        status_code=503,
+        elapsed_ns=17,
+        redirect_hop=2,
+        retry_attempt=3,
+        retry_decision=foghttp.TelemetryRetryDecision.RETRY,
+        retry_reason=foghttp.TelemetryRetryReason.STATUS,
+        retry_backoff_ns=19,
+        outcome=foghttp.TelemetryRequestOutcome.ERROR,
+        error_type="ReadTimeout",
+        timeout_phase="response_body",
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        sink.emit(event)
+
+    record = _single_foghttp_record(caplog)
+    fields = {key: value for key, value in record.__dict__.items() if key.startswith("foghttp_")}
+    assert fields == {
+        "foghttp_event_type": "retry_decision",
+        "foghttp_schema_version": event.schema_version,
+        "foghttp_event_sequence": 7,
+        "foghttp_observed_at_ns": 11,
+        "foghttp_request_id": 13,
+        "foghttp_mode": "buffered",
+        "foghttp_method": "GET",
+        "foghttp_origin": "https://example.com",
+        "foghttp_status_code": 503,
+        "foghttp_elapsed_ns": 17,
+        "foghttp_redirect_hop": 2,
+        "foghttp_retry_attempt": 3,
+        "foghttp_retry_decision": "retry",
+        "foghttp_retry_reason": "status",
+        "foghttp_retry_backoff_ns": 19,
+        "foghttp_outcome": "error",
+        "foghttp_error_type": "ReadTimeout",
+        "foghttp_timeout_phase": "response_body",
+    }
+    serialized_record = f"{record.getMessage()} {fields!r}"
+    assert "foghttp_redacted_url" not in fields
+    assert _RAW_USERINFO not in serialized_record
+    assert _RAW_PATH not in serialized_record
+    assert _RAW_QUERY_VALUE not in serialized_record
+
+
+def test_logging_sink_drops_malformed_origin(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = foghttp.StructuredLoggingTelemetrySink()
+    malformed_origin = f"not-an-origin?token={_RAW_QUERY_VALUE}"
+    event = foghttp.TelemetryEvent(
+        event_type=foghttp.TelemetryEventType.CONNECTION_OPEN_FAILED,
+        event_sequence=1,
+        observed_at_ns=1,
+        origin=malformed_origin,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        sink.emit(event)
+
+    record = _single_foghttp_record(caplog)
+    assert record.__dict__["foghttp_origin"] is None
+    assert malformed_origin not in record.getMessage()
+
+
+def test_logging_sink_does_not_build_records_below_debug_level(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = foghttp.StructuredLoggingTelemetrySink()
+    log_fields = Mock()
+    monkeypatch.setattr("foghttp.telemetry.logging._log_fields", log_fields)
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        sink.emit(_event(foghttp.TelemetryEventType.CONNECTION_OPENED))
+
+    log_fields.assert_not_called()
+    assert _foghttp_records(caplog) == ()
+
+
+def test_sync_client_logging_is_disabled_by_default(
+    sync_http_server: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME), foghttp.Client() as client:
+        response = client.get(sync_http_server)
+
+    assert response.status_code == OK
+    assert _foghttp_records(caplog) == ()
+
+
+def test_sync_logging_emits_connection_lifecycle_without_url_secrets(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = foghttp.StructuredLoggingTelemetrySink()
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME), start_keepalive_server() as server:
+        url = f"{server.url}{KEEPALIVE_PATH}?token={_RAW_QUERY_VALUE}"
+        with foghttp.Client(telemetry=foghttp.TelemetryConfig(sink=sink)) as client:
+            first = client.get(url)
+            second = client.get(url)
+
+    assert first.status_code == OK
+    assert second.status_code == OK
+    records = _foghttp_records(caplog)
+    event_types = {record.__dict__["foghttp_event_type"] for record in records}
+    assert {
+        "connection_opened",
+        "connection_reused",
+        "connection_closed",
+    } <= event_types
+    assert all(record.__dict__["foghttp_origin"] == server.url for record in records)
+    assert all(_RAW_QUERY_VALUE not in record.getMessage() for record in records)
+
+
+async def test_async_logging_emits_terminal_timeout(
+    http_server: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = foghttp.StructuredLoggingTelemetrySink()
+    limits = foghttp.Limits(max_active_requests=0, max_pending_requests=1)
+    timeouts = foghttp.Timeouts(pool=0.001)
+
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        async with foghttp.AsyncClient(
+            limits=limits,
+            timeouts=timeouts,
+            telemetry=foghttp.TelemetryConfig(sink=sink),
+        ) as client:
+            with pytest.raises(foghttp.PoolTimeout):
+                await client.get(http_server)
+
+    timeout_record = next(
+        record for record in _foghttp_records(caplog) if record.__dict__["foghttp_event_type"] == "request_finished"
+    )
+    assert timeout_record.__dict__["foghttp_error_type"] == "PoolTimeout"
+    assert timeout_record.__dict__["foghttp_timeout_phase"] == "pool_acquire"
+
+
+def _foghttp_records(caplog: pytest.LogCaptureFixture) -> tuple[logging.LogRecord, ...]:
+    return tuple(record for record in caplog.records if record.name == _LOGGER_NAME)
+
+
+def _single_foghttp_record(caplog: pytest.LogCaptureFixture) -> logging.LogRecord:
+    records = _foghttp_records(caplog)
+    assert len(records) == 1
+    return records[0]

--- a/tests/types/test_structured_logging_contracts.py
+++ b/tests/types/test_structured_logging_contracts.py
@@ -1,0 +1,11 @@
+from typing import assert_type
+
+import foghttp
+
+
+def check_structured_logging_sink_contract() -> None:
+    sink = foghttp.StructuredLoggingTelemetrySink()
+    telemetry_sink: foghttp.TelemetryEventSink = sink
+
+    assert_type(sink, foghttp.StructuredLoggingTelemetrySink)
+    assert_type(telemetry_sink, foghttp.TelemetryEventSink)


### PR DESCRIPTION
Add an opt-in standard-library logging sink for redacted lifecycle events. Document the stable logger contract and cover sync, async, disabled, and redaction paths.

Closes #93