### PR TITLE
feat(typing): expose request and response protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ async with foghttp.AsyncClient() as client:
 - [Client lifecycle](https://github.com/AmberFog/foghttp/blob/main/docs/lifecycle.md)
 - [Packaging and Python compatibility](https://github.com/AmberFog/foghttp/blob/main/docs/packaging.md)
 - [Timeout model](https://github.com/AmberFog/foghttp/blob/main/docs/timeouts.md)
+- [Public typing contracts](https://github.com/AmberFog/foghttp/blob/main/docs/typing.md)
 - [Upload typing contracts](https://github.com/AmberFog/foghttp/blob/main/docs/upload-types.md)
 - [Transport policy hooks](https://github.com/AmberFog/foghttp/blob/main/docs/policy-hooks.md)
 - [Retry policy](https://github.com/AmberFog/foghttp/blob/main/docs/retries.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - [Client lifecycle](./lifecycle.md)
 - [Packaging and Python compatibility](./packaging.md)
 - [Timeout model](./timeouts.md)
+- [Public typing contracts](./typing.md)
 - [Upload typing contracts](./upload-types.md)
 - [Transport policy hooks](./policy-hooks.md)
 - [Retry policy](./retries.md)
@@ -138,6 +139,8 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 - immutable request `extensions` for policy/application metadata outside the HTTP message
 - public upload typing contracts for streaming request bodies and multipart
   `files=` providers
+- public structural request, response, auth, telemetry, and policy typing
+  contracts for downstream integrations
 - case-insensitive `Headers` with repeated value support
 - safe policy for transport-managed request headers
 - redacted repr/error surfaces for sensitive headers, URL credentials,

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1,0 +1,75 @@
+# Public Typing Contracts
+
+FogHTTP provides structural typing contracts for application integrations that
+consume requests and responses without depending on FogHTTP's concrete runtime
+classes. Import these protocols from `foghttp.types`:
+
+```python
+from foghttp.types import ResponseProtocol
+
+
+def response_summary(response: ResponseProtocol) -> str:
+    return f"{response.request.method} {response.status_code}"
+```
+
+Concrete `Request`, `RequestInfo`, `Response`, `StreamResponse`, and
+`AsyncStreamResponse` objects satisfy the applicable protocols without
+inheriting from them.
+
+## Request And Response Protocols
+
+| Protocol | Stable surface |
+|---|---|
+| `RequestProtocol` | Method, URL, headers, and immutable request extensions shared by prepared requests and completed request metadata. |
+| `ResponseProtocol` | Metadata, status flags, redirect history, retry trace, encoding, and `raise_for_status()` shared by buffered and streaming responses. |
+| `BufferedResponseProtocol` | `ResponseProtocol` plus buffered `content`, `text`, and `json()`. |
+| `StreamResponseProtocol` | `ResponseProtocol` plus synchronous bytes, text, and line iterators and `close()`. |
+| `AsyncStreamResponseProtocol` | `ResponseProtocol` plus asynchronous bytes, text, and line iterators, `close()`, and `aclose()`. |
+
+`RequestProtocol` intentionally excludes request-body state. Buffered bytes,
+direct streams, files, and replayable factories have different ownership and
+replayability rules; use the provider contracts in
+[Upload typing contracts](./upload-types.md) for request bodies.
+
+The streaming protocols describe an already-entered response. The context
+manager returned by `Client.stream()` or `AsyncClient.stream()` remains the
+owner of response-body cleanup. See [Response streaming](./streaming.md).
+
+## Hook And Policy Contracts
+
+FogHTTP's stable callback surfaces are available at the package root:
+
+| Contract | Meaning |
+|---|---|
+| `AuthHook` and `AuthRequest` | Synchronous request-aware authentication. |
+| `TelemetryEventSink` and `TelemetryEvent` | Structural event-sink protocol and immutable telemetry event. |
+| `TransportPolicyRequestHook` | Synchronous request policy callback. |
+| `TransportPolicyResponseHook` | Synchronous response-head policy callback. |
+| `TransportPolicyHooks` | Configuration that assigns the policy callbacks to lifecycle stages. |
+
+Request, response, auth, and policy contracts may expose full URLs or headers.
+They are trusted application inputs, not telemetry-safe payloads. Do not copy
+them directly into logs, metrics, or traces. Use `TelemetryEvent` when an
+integration needs redacted observability data.
+
+## Stability Boundary
+
+These protocols are static typing contracts. They are not decorated with
+`runtime_checkable`, so do not use them with `isinstance()` or `issubclass()`.
+Static structural typing checks method signatures as well as attribute names;
+runtime protocol checks would only test attribute presence.
+
+The public protocols do not expose raw clients, connectors, sockets, permits,
+request-body replayability flags, cancellation handles, PyO3 bridge objects, or
+the private transport adapter protocols. Those remain implementation details
+and are not extension points.
+
+This API is additive. Existing annotations that use concrete FogHTTP classes
+remain valid; migrate to a protocol only when an integration accepts compatible
+wrappers, fakes, or multiple FogHTTP response modes.
+
+FogHTTP checks its public typing examples with strict mypy:
+
+```bash
+uv run --extra dev mypy --no-incremental
+```

--- a/docs/upload-types.md
+++ b/docs/upload-types.md
@@ -4,6 +4,9 @@ FogHTTP exposes public typing contracts for streaming request body providers and
 multipart `files=` uploads. These names let application code and wrappers type
 body providers without importing internal classes.
 
+Request and response metadata contracts are documented separately in
+[Public typing contracts](./typing.md).
+
 The runtime request API accepts streaming bodies through `content=` and
 multipart uploads through `files=`.
 

--- a/foghttp/__init__.py
+++ b/foghttp/__init__.py
@@ -62,7 +62,9 @@ __all__ = (
     "TransportPolicyBodyState",
     "TransportPolicyHooks",
     "TransportPolicyRequest",
+    "TransportPolicyRequestHook",
     "TransportPolicyResponse",
+    "TransportPolicyResponseHook",
     "TransportState",
     "TransportStats",
     "UnclosedClientError",
@@ -108,7 +110,9 @@ from .policy import (
     TransportPolicyBodyState,
     TransportPolicyHooks,
     TransportPolicyRequest,
+    TransportPolicyRequestHook,
     TransportPolicyResponse,
+    TransportPolicyResponseHook,
 )
 from .pool_diagnostics import OriginPoolDiagnostics, PoolBlockingReason, PoolDiagnostics
 from .request import Request

--- a/foghttp/policy.py
+++ b/foghttp/policy.py
@@ -5,7 +5,9 @@ __all__ = (
     "TransportPolicyBodyState",
     "TransportPolicyHooks",
     "TransportPolicyRequest",
+    "TransportPolicyRequestHook",
     "TransportPolicyResponse",
+    "TransportPolicyResponseHook",
 )
 
 from collections.abc import Callable
@@ -70,6 +72,10 @@ class TransportPolicyResponse:
         return f"{class_name}(request={request!r}, status_code={status_code!r}, headers=<{header_count} headers>)"
 
 
+TransportPolicyRequestHook: TypeAlias = Callable[[TransportPolicyRequest], None]
+TransportPolicyResponseHook: TypeAlias = Callable[[TransportPolicyResponse], None]
+
+
 @dataclass(frozen=True, slots=True)
 class TransportPolicyHooks:
     """Opt-in synchronous transport policy observers.
@@ -78,9 +84,9 @@ class TransportPolicyHooks:
     ``None`` and cannot mutate requests, responses, or transport resources.
     """
 
-    before_send: Callable[[TransportPolicyRequest], None] | None = field(default=None, repr=False)
-    on_response_headers: Callable[[TransportPolicyResponse], None] | None = field(default=None, repr=False)
-    after_response_body: Callable[[TransportPolicyResponse], None] | None = field(default=None, repr=False)
+    before_send: TransportPolicyRequestHook | None = field(default=None, repr=False)
+    on_response_headers: TransportPolicyResponseHook | None = field(default=None, repr=False)
+    after_response_body: TransportPolicyResponseHook | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         _validate_hook("before_send", self.before_send)

--- a/foghttp/types/__init__.py
+++ b/foghttp/types/__init__.py
@@ -5,8 +5,10 @@ __all__ = (
     "AsyncMultipartFileTuple",
     "AsyncMultipartFileValue",
     "AsyncMultipartFiles",
+    "AsyncStreamResponseProtocol",
     "BinaryFile",
     "BodyChunk",
+    "BufferedResponseProtocol",
     "HttpVersion",
     "HttpVersions",
     "QueryParamItem",
@@ -17,6 +19,9 @@ __all__ = (
     "RequestDataItem",
     "RequestDataItems",
     "RequestDataValue",
+    "RequestProtocol",
+    "ResponseProtocol",
+    "StreamResponseProtocol",
     "SyncByteStream",
     "SyncByteStreamFactory",
     "SyncMultipartFileContent",
@@ -29,6 +34,13 @@ from typing import TypeAlias
 
 from . import multipart as multipart_types
 from .http import HttpVersion, HttpVersions
+from .protocols import (
+    AsyncStreamResponseProtocol,
+    BufferedResponseProtocol,
+    RequestProtocol,
+    ResponseProtocol,
+    StreamResponseProtocol,
+)
 from .request import (
     QueryParamItem,
     QueryParamItems,

--- a/foghttp/types/protocols.py
+++ b/foghttp/types/protocols.py
@@ -1,0 +1,144 @@
+__all__ = (
+    "AsyncStreamResponseProtocol",
+    "BufferedResponseProtocol",
+    "RequestProtocol",
+    "ResponseProtocol",
+    "StreamResponseProtocol",
+)
+
+from collections.abc import AsyncIterator, Iterator
+from typing import TYPE_CHECKING, Any, Protocol
+
+
+if TYPE_CHECKING:
+    from foghttp.headers import Headers
+    from foghttp.request_extensions import RequestExtensions
+    from foghttp.retry_trace import RetryTrace
+
+
+class RequestProtocol(Protocol):
+    """Stable request metadata shared by prepared and completed requests."""
+
+    @property
+    def method(self) -> str: ...
+
+    @property
+    def url(self) -> str: ...
+
+    @property
+    def headers(self) -> "Headers": ...
+
+    @property
+    def extensions(self) -> "RequestExtensions": ...
+
+
+class _ResponseMetadataProtocol(Protocol):
+    @property
+    def status_code(self) -> int: ...
+
+    @property
+    def headers(self) -> "Headers": ...
+
+    @property
+    def url(self) -> str: ...
+
+    @property
+    def request(self) -> RequestProtocol: ...
+
+    @property
+    def http_version(self) -> str: ...
+
+    @property
+    def elapsed(self) -> float: ...
+
+    @property
+    def history(self) -> tuple["BufferedResponseProtocol", ...]: ...
+
+
+class _ResponseStatusProtocol(Protocol):
+    @property
+    def is_success(self) -> bool: ...
+
+    @property
+    def is_redirect(self) -> bool: ...
+
+    @property
+    def is_client_error(self) -> bool: ...
+
+    @property
+    def is_server_error(self) -> bool: ...
+
+    @property
+    def is_error(self) -> bool: ...
+
+    def raise_for_status(self) -> None: ...
+
+
+class ResponseProtocol(_ResponseMetadataProtocol, _ResponseStatusProtocol, Protocol):
+    """Stable metadata and status behavior shared by all response modes."""
+
+    @property
+    def retry_trace(self) -> "RetryTrace | None": ...
+
+    @property
+    def encoding(self) -> str: ...
+
+
+class BufferedResponseProtocol(ResponseProtocol, Protocol):
+    """Stable buffered-response body behavior."""
+
+    @property
+    def content(self) -> bytes: ...
+
+    @property
+    def text(self) -> str: ...
+
+    def json(self) -> Any: ...
+
+
+class StreamResponseProtocol(ResponseProtocol, Protocol):
+    """Stable synchronous streaming-response behavior."""
+
+    def close(self) -> None: ...
+
+    def iter_bytes(self) -> Iterator[bytes]: ...
+
+    def iter_text(
+        self,
+        *,
+        encoding: str | None = ...,
+        errors: str = ...,
+    ) -> Iterator[str]: ...
+
+    def iter_lines(
+        self,
+        *,
+        encoding: str | None = ...,
+        errors: str = ...,
+        max_line_chars: int | None = ...,
+    ) -> Iterator[str]: ...
+
+
+class AsyncStreamResponseProtocol(ResponseProtocol, Protocol):
+    """Stable asynchronous streaming-response behavior."""
+
+    def close(self) -> None: ...
+
+    async def aclose(self) -> None: ...
+
+    def aiter_bytes(self) -> AsyncIterator[bytes]: ...
+
+    def aiter_text(
+        self,
+        *,
+        encoding: str | None = ...,
+        errors: str = ...,
+    ) -> AsyncIterator[str]: ...
+
+    def aiter_lines(
+        self,
+        *,
+        encoding: str | None = ...,
+        errors: str = ...,
+        max_line_chars: int | None = ...,
+    ) -> AsyncIterator[str]: ...

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,7 +1,9 @@
 import foghttp
 import foghttp.methods
 import foghttp.models
+import foghttp.policy
 import foghttp.stats
+import foghttp.types
 
 
 def test_top_level_exports() -> None:
@@ -62,3 +64,24 @@ def test_query_method_is_exported() -> None:
     assert foghttp.methods.QUERY in foghttp.methods.HTTP_METHODS
     assert foghttp.methods.HTTP_METHODS.count(foghttp.methods.QUERY) == 1
     assert "QUERY" in foghttp.methods.__all__
+
+
+def test_public_typing_protocols_do_not_open_transport_adapters() -> None:
+    assert foghttp.types.RequestProtocol is not None
+    assert foghttp.types.ResponseProtocol is not None
+    assert foghttp.types.BufferedResponseProtocol is not None
+    assert foghttp.types.StreamResponseProtocol is not None
+    assert foghttp.types.AsyncStreamResponseProtocol is not None
+    assert not hasattr(foghttp, "SyncTransport")
+    assert not hasattr(foghttp, "AsyncTransport")
+    assert not hasattr(foghttp.types, "SyncTransport")
+    assert not hasattr(foghttp.types, "AsyncTransport")
+
+
+def test_policy_contracts_are_identical_at_the_package_root() -> None:
+    assert foghttp.TransportPolicyBodyState is foghttp.policy.TransportPolicyBodyState
+    assert foghttp.TransportPolicyHooks is foghttp.policy.TransportPolicyHooks
+    assert foghttp.TransportPolicyRequest is foghttp.policy.TransportPolicyRequest
+    assert foghttp.TransportPolicyRequestHook is foghttp.policy.TransportPolicyRequestHook
+    assert foghttp.TransportPolicyResponse is foghttp.policy.TransportPolicyResponse
+    assert foghttp.TransportPolicyResponseHook is foghttp.policy.TransportPolicyResponseHook

--- a/tests/types/test_policy_contracts.py
+++ b/tests/types/test_policy_contracts.py
@@ -1,41 +1,37 @@
-from collections.abc import Callable
 from typing import assert_type
 
 import foghttp
-from foghttp.policy import (
-    TransportPolicyHooks,
-    TransportPolicyRequest,
-    TransportPolicyResponse,
-)
 
 
-def observe_request(request: TransportPolicyRequest) -> None:
+def observe_request(request: foghttp.TransportPolicyRequest) -> None:
     assert request.method
     assert_type(request.extensions, foghttp.RequestExtensions)
 
 
-def observe_response(response: TransportPolicyResponse) -> None:
+def observe_response(response: foghttp.TransportPolicyResponse) -> None:
     assert response.status_code > 0
 
 
 def test_policy_hook_callable_contracts() -> None:
-    hooks = TransportPolicyHooks(
-        before_send=observe_request,
-        on_response_headers=observe_response,
-        after_response_body=observe_response,
+    request_hook: foghttp.TransportPolicyRequestHook = observe_request
+    response_hook: foghttp.TransportPolicyResponseHook = observe_response
+    hooks = foghttp.TransportPolicyHooks(
+        before_send=request_hook,
+        on_response_headers=response_hook,
+        after_response_body=response_hook,
     )
 
     assert_type(
         hooks.before_send,
-        Callable[[TransportPolicyRequest], None] | None,
+        foghttp.TransportPolicyRequestHook | None,
     )
     assert_type(
         hooks.on_response_headers,
-        Callable[[TransportPolicyResponse], None] | None,
+        foghttp.TransportPolicyResponseHook | None,
     )
     assert_type(
         hooks.after_response_body,
-        Callable[[TransportPolicyResponse], None] | None,
+        foghttp.TransportPolicyResponseHook | None,
     )
     assert hooks.enabled is True
 

--- a/tests/types/test_request_response_protocols.py
+++ b/tests/types/test_request_response_protocols.py
@@ -1,0 +1,72 @@
+from collections.abc import AsyncIterator, Iterator
+from typing import assert_type
+
+import foghttp
+from foghttp.types import (
+    AsyncStreamResponseProtocol,
+    BufferedResponseProtocol,
+    RequestProtocol,
+    ResponseProtocol,
+    StreamResponseProtocol,
+)
+
+
+def response_status(response: ResponseProtocol) -> tuple[int, str]:
+    return response.status_code, response.request.method
+
+
+def sync_stream_contract(response: foghttp.StreamResponse) -> StreamResponseProtocol:
+    stream: StreamResponseProtocol = response
+    assert_type(stream.iter_bytes(), Iterator[bytes])
+    return stream
+
+
+def async_stream_contract(response: foghttp.AsyncStreamResponse) -> AsyncStreamResponseProtocol:
+    stream: AsyncStreamResponseProtocol = response
+    assert_type(stream.aiter_bytes(), AsyncIterator[bytes])
+    return stream
+
+
+def test_prepared_and_completed_requests_share_public_metadata_contract() -> None:
+    prepared = foghttp.Request(
+        "GET",
+        "https://example.invalid/items",
+        extensions={"tests.request_id": "request-1"},
+    )
+    completed = foghttp.RequestInfo(
+        method=prepared.method,
+        url=prepared.url,
+        headers=prepared.headers,
+        extensions=prepared.extensions,
+    )
+
+    prepared_contract: RequestProtocol = prepared
+    completed_contract: RequestProtocol = completed
+
+    assert prepared_contract.method == completed_contract.method
+    assert prepared_contract.url == completed_contract.url
+    assert prepared_contract.extensions is completed_contract.extensions
+
+
+def test_buffered_response_satisfies_public_response_protocols() -> None:
+    request = foghttp.RequestInfo(
+        method="GET",
+        url="https://example.invalid/items",
+        headers=foghttp.Headers(),
+    )
+    response = foghttp.Response(
+        status_code=200,
+        headers=foghttp.Headers({"Content-Type": "application/json"}),
+        content=b'{"ok":true}',
+        url=request.url,
+        request=request,
+        http_version="HTTP/1.1",
+        elapsed=0.01,
+    )
+
+    response_contract: ResponseProtocol = response
+    buffered_contract: BufferedResponseProtocol = response
+
+    assert response_status(response_contract) == (200, "GET")
+    assert buffered_contract.json() == {"ok": True}
+    assert_type(buffered_contract.content, bytes)

--- a/tests/types/test_telemetry_contracts.py
+++ b/tests/types/test_telemetry_contracts.py
@@ -1,0 +1,23 @@
+import foghttp
+
+
+class RecordingTelemetrySink:
+    def __init__(self) -> None:
+        self.events: list[foghttp.TelemetryEvent] = []
+
+    def emit(self, event: foghttp.TelemetryEvent) -> None:
+        self.events.append(event)
+
+
+def test_telemetry_sink_is_a_structural_public_contract() -> None:
+    sink: foghttp.TelemetryEventSink = RecordingTelemetrySink()
+    event = foghttp.TelemetryEvent(
+        event_type=foghttp.TelemetryEventType.REQUEST_STARTED,
+        event_sequence=1,
+        observed_at_ns=1,
+    )
+
+    sink.emit(event)
+
+    assert isinstance(sink, RecordingTelemetrySink)
+    assert sink.events == [event]


### PR DESCRIPTION
Add stable structural protocols for request metadata and buffered, synchronous streaming, and asynchronous streaming responses. Expose typed policy hook contracts and document public typing boundaries.

Closes #105