### PR TITLE
feat(errors): add ConfigurationError for client setup

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -146,6 +146,14 @@ Wait before using FogHTTP when:
 
 ## Error Surface
 
+Python-side option validation still raises `TypeError` or `ValueError` eagerly
+when the client configuration object is built. Failures discovered during lazy Rust
+transport setup, including unreadable or invalid CA certificates and native
+runtime/configuration rejection, raise `ConfigurationError` on the first
+request. `ConfigurationError` is both a `FogHTTPError` and a `ValueError`, so
+existing `except ValueError` handlers remain compatible; callers should branch
+on the exception type instead of parsing its diagnostic message.
+
 Pre-header transport failures map to `NetworkError`, a `RequestError` subtype;
 local request-provider and other request failures remain `RequestError`. Pool acquire timeout and
 queue-full conditions map to `PoolTimeout`. Response body progress timeout maps

--- a/foghttp/__init__.py
+++ b/foghttp/__init__.py
@@ -13,6 +13,7 @@ __all__ = (
     "AuthRequest",
     "Client",
     "ClientClosedError",
+    "ConfigurationError",
     "ConnectTimeout",
     "FogHTTPError",
     "HTTPStatusError",
@@ -79,6 +80,7 @@ from .errors.base import (
     NetworkError,
     RequestError,
 )
+from .errors.configuration import ConfigurationError
 from .errors.lifecycle import (
     ClientClosedError,
     LifecycleError,

--- a/foghttp/_client/raw/lifecycle.py
+++ b/foghttp/_client/raw/lifecycle.py
@@ -4,12 +4,15 @@ from dataclasses import dataclass
 
 import foghttp._foghttp as _foghttp  # noqa: PLR0402
 
-from ...errors import NetworkError
+from ...errors import ConfigurationError, NetworkError
 from ...retry import RetryPolicy
 from ...ssrf import SSRFPolicy
 from ..config import ClientConfig
 from ..proxy.auth import basic_proxy_authorization
 from ..tls import ca_certificate_bytes, trust_webpki_roots
+
+
+_RAW_CLIENT_SETUP_ERRORS = (TypeError, ValueError, OverflowError, _foghttp.FogHttpError)
 
 
 def close_raw_client(raw_client: _foghttp.RawClient) -> None:
@@ -61,8 +64,8 @@ def create_raw_client(
             ssrf_allowed_domains=ssrf_options.domains,
             telemetry_enabled=config.telemetry is not None and config.telemetry.enabled,
         )
-    except _foghttp.FogHttpError as exc:
-        raise ValueError(str(exc)) from exc
+    except _RAW_CLIENT_SETUP_ERRORS as exc:
+        raise ConfigurationError(str(exc)) from exc
 
 
 @dataclass(frozen=True, slots=True)

--- a/foghttp/errors/__init__.py
+++ b/foghttp/errors/__init__.py
@@ -2,6 +2,7 @@
 
 __all__ = (
     "ClientClosedError",
+    "ConfigurationError",
     "ConnectTimeout",
     "FogHTTPError",
     "HTTPStatusError",
@@ -21,6 +22,7 @@ __all__ = (
 )
 
 from .base import FogHTTPError, NetworkError, RequestError
+from .configuration import ConfigurationError
 from .lifecycle import ClientClosedError, LifecycleError, UnclosedClientError
 from .response import (
     HTTPStatusError,

--- a/foghttp/errors/configuration.py
+++ b/foghttp/errors/configuration.py
@@ -1,0 +1,7 @@
+__all__ = ("ConfigurationError",)
+
+from .base import FogHTTPError
+
+
+class ConfigurationError(FogHTTPError, ValueError):
+    """Raised when lazy client transport setup fails."""

--- a/foghttp/prometheus/labels.py
+++ b/foghttp/prometheus/labels.py
@@ -25,6 +25,7 @@ _STABLE_ERROR_CLASSES = frozenset(
     (
         "CancelledError",
         "ClientClosedError",
+        "ConfigurationError",
         "ConnectTimeout",
         "FogHTTPError",
         "HTTPStatusError",

--- a/tests/client_tls/test_tls_config.py
+++ b/tests/client_tls/test_tls_config.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -10,7 +9,7 @@ from .constants import TLS_INVALID_CA_BODY, TLS_OK_BODY, TLS_PATH
 from .models import TLSServer
 
 
-class _FailingCertificatePath(os.PathLike[str]):
+class _FailingCertificatePath:
     def __fspath__(self) -> str:
         raise TypeError
 

--- a/tests/client_tls/test_tls_config.py
+++ b/tests/client_tls/test_tls_config.py
@@ -1,3 +1,4 @@
+from os import PathLike
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,11 @@ import foghttp
 from .certificates import TLSCertificateBundle
 from .constants import TLS_INVALID_CA_BODY, TLS_OK_BODY, TLS_PATH
 from .models import TLSServer
+
+
+class _FailingCertificatePath(PathLike[str]):
+    def __fspath__(self) -> str:
+        raise TypeError
 
 
 def test_client_accepts_single_ca_certificate_path(
@@ -88,9 +94,20 @@ def test_client_rejects_missing_ca_certificate_file(
 
     with (
         foghttp.Client(tls=tls) as client,
-        pytest.raises(ValueError, match="failed to read CA certificate"),
+        pytest.raises(foghttp.ConfigurationError, match="failed to read CA certificate"),
     ):
         client.get(sync_http_server)
+
+
+def test_client_maps_lazy_certificate_path_type_error_to_configuration_error(
+    sync_http_server: str,
+) -> None:
+    tls = foghttp.TLSConfig(ca_certificates=_FailingCertificatePath())
+
+    with foghttp.Client(tls=tls) as client, pytest.raises(foghttp.ConfigurationError) as exc_info:
+        client.get(sync_http_server)
+
+    assert isinstance(exc_info.value.__cause__, TypeError)
 
 
 def test_client_rejects_invalid_ca_certificate_pem(
@@ -103,6 +120,6 @@ def test_client_rejects_invalid_ca_certificate_pem(
 
     with (
         foghttp.Client(tls=tls) as client,
-        pytest.raises(ValueError, match="CA certificate PEM did not contain certificates"),
+        pytest.raises(foghttp.ConfigurationError, match="CA certificate PEM did not contain certificates"),
     ):
         client.get(sync_http_server)

--- a/tests/client_tls/test_tls_config.py
+++ b/tests/client_tls/test_tls_config.py
@@ -1,4 +1,4 @@
-from os import PathLike
+import os
 from pathlib import Path
 
 import pytest
@@ -10,7 +10,7 @@ from .constants import TLS_INVALID_CA_BODY, TLS_OK_BODY, TLS_PATH
 from .models import TLSServer
 
 
-class _FailingCertificatePath(PathLike[str]):
+class _FailingCertificatePath(os.PathLike[str]):
     def __fspath__(self) -> str:
         raise TypeError
 

--- a/tests/prometheus/test_telemetry_sink.py
+++ b/tests/prometheus/test_telemetry_sink.py
@@ -183,6 +183,33 @@ def test_terminal_request_maps_stable_labels_and_duration() -> None:
     )
 
 
+def test_configuration_error_keeps_stable_failure_label() -> None:
+    registry = CollectorRegistry()
+    sink = PrometheusTelemetrySink(registry=registry)
+
+    sink.emit(
+        _request_event(
+            status_code=None,
+            outcome=foghttp.TelemetryRequestOutcome.ERROR,
+            error_type=foghttp.ConfigurationError.__name__,
+        ),
+    )
+
+    assert (
+        _metric_value(
+            registry,
+            "foghttp_request_failures_total",
+            {
+                "method": "GET",
+                "origin": "all",
+                "status_class": "none",
+                "error_class": "ConfigurationError",
+            },
+        )
+        == 1
+    )
+
+
 def test_body_and_pool_histograms_use_seconds() -> None:
     registry = CollectorRegistry()
     sink = PrometheusTelemetrySink(registry=registry)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,4 +1,5 @@
 import foghttp
+import foghttp.errors
 import foghttp.methods
 import foghttp.models
 import foghttp.policy
@@ -8,6 +9,7 @@ import foghttp.types
 
 def test_top_level_exports() -> None:
     assert foghttp.Client is not None
+    assert foghttp.ConfigurationError is foghttp.errors.ConfigurationError
     assert foghttp.AsyncLifecycleDebugConfig is not None
     assert foghttp.AsyncLifecycleDebugRequest is not None
     assert foghttp.AsyncLifecycleDebugRequestMode is not None
@@ -35,6 +37,8 @@ def test_top_level_exports() -> None:
     assert foghttp.TransportState is not None
     assert foghttp.OriginPressureState is not None
     assert foghttp.URL is not None
+    assert issubclass(foghttp.ConfigurationError, foghttp.FogHTTPError)
+    assert issubclass(foghttp.ConfigurationError, ValueError)
     assert issubclass(foghttp.NetworkError, foghttp.RequestError)
     assert issubclass(foghttp.SSRFError, foghttp.RequestError)
 

--- a/tests/test_raw_client_errors.py
+++ b/tests/test_raw_client_errors.py
@@ -5,7 +5,6 @@ from faker import Faker
 import pytest
 
 import foghttp
-from foghttp import _foghttp
 from foghttp._client.config import ClientConfig
 from foghttp._client.constants import DEFAULT_MAX_REDIRECTS
 from foghttp._client.options import ClientOptions
@@ -13,6 +12,7 @@ from foghttp._client.proxy import ProxyTransportPolicy
 from foghttp._client.raw.errors import public_raw_error
 from foghttp._client.raw.lifecycle import create_raw_client
 from foghttp._client.raw.requests import RawRequestOptions, send_raw_request, send_raw_request_async
+import foghttp._foghttp as _foghttp  # noqa: PLR0402
 from foghttp._request_body import RequestBody
 from foghttp.errors import (
     ConfigurationError,

--- a/tests/test_raw_client_errors.py
+++ b/tests/test_raw_client_errors.py
@@ -4,6 +4,7 @@ import pickle
 from faker import Faker
 import pytest
 
+import foghttp
 from foghttp import _foghttp
 from foghttp._client.config import ClientConfig
 from foghttp._client.constants import DEFAULT_MAX_REDIRECTS
@@ -14,6 +15,7 @@ from foghttp._client.raw.lifecycle import create_raw_client
 from foghttp._client.raw.requests import RawRequestOptions, send_raw_request, send_raw_request_async
 from foghttp._request_body import RequestBody
 from foghttp.errors import (
+    ConfigurationError,
     PoolTimeout,
     ReadTimeout,
     ResponseBodyBudgetExceededError,
@@ -83,6 +85,7 @@ BYTEARRAY_REDIRECT_HOP_RAW_ARGS = (
     "https://example.com",
     bytearray(b"not-an-int"),
 )
+RAW_CLIENT_SETUP_FAILURE = "runtime setup failed"
 
 
 def _default_client_config() -> ClientConfig:
@@ -200,17 +203,56 @@ class BodyBudgetExceededRawClient:
         raise _foghttp.FogHttpResponseBodyBudgetExceededError(msg)
 
 
-def test_raw_client_constructor_error_maps_to_value_error(
+def _fail_raw_client_setup(**_kwargs: object) -> object:
+    raise _foghttp.FogHttpError(RAW_CLIENT_SETUP_FAILURE)
+
+
+def test_raw_client_constructor_error_maps_to_configuration_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fail_raw_client(**_kwargs: object) -> object:
-        msg = "runtime failed"
-        raise _foghttp.FogHttpError(msg)
+    monkeypatch.setattr(_foghttp, "RawClient", _fail_raw_client_setup)
 
-    monkeypatch.setattr(_foghttp, "RawClient", fail_raw_client)
-
-    with pytest.raises(ValueError, match="runtime failed"):
+    with pytest.raises(ConfigurationError) as exc_info:
         create_raw_client(config=_default_client_config())
+
+    assert RAW_CLIENT_SETUP_FAILURE in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, _foghttp.FogHttpError)
+
+
+def test_raw_client_numeric_overflow_maps_to_configuration_error(
+    faker: Faker,
+) -> None:
+    with (
+        foghttp.Client(max_redirects=2**64) as client,
+        pytest.raises(foghttp.ConfigurationError) as exc_info,
+    ):
+        client.get(faker.url())
+
+    assert isinstance(exc_info.value.__cause__, OverflowError)
+
+
+def test_sync_client_setup_error_uses_public_configuration_error(
+    monkeypatch: pytest.MonkeyPatch,
+    faker: Faker,
+) -> None:
+    monkeypatch.setattr(_foghttp, "RawClient", _fail_raw_client_setup)
+
+    with (
+        foghttp.Client() as client,
+        pytest.raises(foghttp.ConfigurationError),
+    ):
+        client.get(faker.url())
+
+
+async def test_async_client_setup_error_uses_public_configuration_error(
+    monkeypatch: pytest.MonkeyPatch,
+    faker: Faker,
+) -> None:
+    monkeypatch.setattr(_foghttp, "RawClient", _fail_raw_client_setup)
+
+    async with foghttp.AsyncClient() as client:
+        with pytest.raises(foghttp.ConfigurationError):
+            await client.get(faker.url())
 
 
 def test_sync_raw_timeout_maps_to_public_timeout(faker: Faker) -> None:


### PR DESCRIPTION
Expose a public ValueError-compatible configuration error and map lazy TLS, numeric, and native client setup failures while preserving causes.

Document and test the public API and Prometheus error label contract.

Closes #205