### PR TITLE
ci(release): add example and benchmark smoke gates

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -53,3 +53,7 @@ per-file-ignores =
     # Explicit guard/mapping functions are clearer as direct raises than as indirection tables.
     foghttp/_client/options.py: WPS238
     foghttp/_client/raw/errors.py: WPS238
+    # Tests require descriptive names, rich scenario setup, repeated fixtures/data,
+    # exact-value assertions, local doubles and explicit cleanup. Ruff's ALL profile
+    # owns their general correctness checks; Wemake still enforces all other rules.
+    tests/**: WPS100, WPS114, WPS118, WPS122, WPS201, WPS202, WPS204, WPS210, WPS211, WPS212, WPS213, WPS214, WPS217, WPS218, WPS219, WPS220, WPS221, WPS222, WPS223, WPS226, WPS228, WPS229, WPS230, WPS231, WPS232, WPS235, WPS237, WPS243, WPS324, WPS328, WPS336, WPS338, WPS342, WPS353, WPS358, WPS362, WPS414, WPS420, WPS430, WPS431, WPS432, WPS435, WPS441, WPS459, WPS476, WPS478, WPS501, WPS504, WPS505, WPS516, WPS520, WPS527

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           path: dist
 
       - name: Smoke test wheel install
-        run: python scripts/install_wheel_smoke.py --dist-dir dist
+        run: python -I -S scripts/install_wheel_smoke.py --dist-dir dist
 
   tests:
     name: Tests (Python ${{ matrix.python-version }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           path: dist
 
       - name: Smoke test wheel install
-        run: python scripts/install_wheel_smoke.py --dist-dir dist
+        run: python -I -S scripts/install_wheel_smoke.py --dist-dir dist
 
   macos-wheels:
     name: Build macOS wheel (${{ matrix.platform.name }})
@@ -179,7 +179,7 @@ jobs:
           path: dist
 
       - name: Smoke test wheel install
-        run: python scripts/install_wheel_smoke.py --dist-dir dist
+        run: python -I -S scripts/install_wheel_smoke.py --dist-dir dist
 
   windows-wheels:
     name: Build Windows wheel (x64)
@@ -236,7 +236,7 @@ jobs:
           path: dist
 
       - name: Smoke test wheel install
-        run: python scripts/install_wheel_smoke.py --dist-dir dist
+        run: python -I -S scripts/install_wheel_smoke.py --dist-dir dist
 
   audit-wheels:
     name: Audit stable ABI wheels

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,9 +53,12 @@ repos:
     rev: "7.3.0"
     hooks:
       - id: flake8
+        name: wemake
         additional_dependencies:
           - wemake-python-styleguide==1.6.2
-        files: ^foghttp/.*\.py$
+        args: [foghttp, tests]
+        always_run: true
+        pass_filenames: false
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,13 @@ Run the project checks:
 uv run --extra dev pre-commit run --all-files --show-diff-on-failure
 ```
 
+Check that every top-level `examples/*.py` file still imports without running
+its network-dependent `main` block:
+
+```bash
+uv run --extra dev pytest -q tests/examples
+```
+
 When changing Rust code, also run the relevant Rust checks:
 
 ```bash
@@ -239,10 +246,13 @@ Before requesting review, please check:
 - Python tests pass
 - Rust tests pass when Rust code changed
 - pre-commit passes
+- every top-level `examples/*.py` file passes the import smoke check
 - public API changes update types, docs, and examples
 - security-sensitive behavior has regression tests
 - new errors and diagnostics avoid leaking secrets
 - limitations are documented honestly if the feature is partial
+- release pull requests complete every evidence field for the example and
+  benchmark smoke gates in [docs/benchmarks.md](./docs/benchmarks.md)
 
 The project is small on purpose. A contribution that preserves that clarity is
 usually easier to merge than a broad change that tries to solve several future

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -2,12 +2,102 @@
 
 Benchmark harness and full benchmark reports live in a separate repository:
 [github.com/AmberFog/FogHttpBenchmark](https://github.com/AmberFog/FogHttpBenchmark).
+Use the `README.md` from the exact recorded benchmark checkout as the canonical
+workflow for full-suite setup, execution, and report review.
 
 This page is a benchmark status snapshot, not a marketing scoreboard. Invalid
 rows, compatibility gaps, resource-limit errors, and weak spots stay visible
 because they are the inputs we use to improve FogHTTP.
 
-Last updated: `2026-07-02`.
+Benchmark snapshot last updated: `2026-07-02`.
+
+## Release Smoke Gate
+
+Normal pull-request CI does not use wall-clock benchmark thresholds. Shared CI
+hosts are too variable for a small timing delta to be a reliable pass/fail
+signal, and the full benchmark matrix is intentionally kept out of every PR.
+
+Before a release, start from a clean checkout of the separate benchmark
+repository at a recorded full commit SHA. Pin the exact FogHTTP release candidate
+by its full commit SHA and run this bounded local-server smoke from that checkout.
+For an unpublished candidate, update the benchmark checkout and verify its lock
+before running the smoke:
+
+```bash
+candidate_sha="<full-candidate-commit-sha>"
+uv add "foghttp @ git+https://github.com/AmberFog/foghttp.git" \
+  --rev "$candidate_sha"
+uv lock --check
+```
+
+After pinning, only the benchmark project manifest and lockfile may differ from
+the recorded clean checkout. Record SHA-256 digests of both exact files; any
+other harness change must be committed and become the new recorded benchmark
+repository SHA before the smoke runs.
+
+Then run:
+
+```bash
+candidate_sha="<full-candidate-commit-sha>"
+uv run --locked foghttp-benchmark \
+  --suite request-builder \
+  --clients foghttp \
+  --modes async,sync \
+  --iterations 100 \
+  --warmup 10 \
+  --repeats 3 \
+  --scenarios absolute-url,json-body,send-prepared-get \
+  --no-progress \
+  --output-dir "results/release-smoke-${candidate_sha}"
+```
+
+The smoke passes when the command exits successfully, the release tag, candidate,
+and FogHTTP lock entry all resolve to the same full commit SHA, the report's
+`metadata.package_versions.foghttp` value matches the candidate version, all
+FogHTTP rows are valid with no unexpected measured or warmup errors, and the
+report has no obvious regression against a same-host, same-Python, same-harness
+baseline produced with the same suite, clients, modes, iterations, warmup,
+repeats, scenarios, and progress settings. A timing change is reviewed as
+evidence, not rejected by a fixed percentage; a maintainer records the timing-
+review decision and rationale. Dependency-graph differences outside the
+intended FogHTTP baseline/candidate change must be explained there.
+Classify or rerun `warning`, `invalid`, and `needs-rerun` output before release.
+For changes to a specific hot path or resource lifecycle, run the corresponding
+full benchmark suite as described in the benchmark repository instead of
+expanding this smoke into the normal PR matrix.
+
+Record this evidence in the release-readiness issue or pull request before
+publishing:
+
+```text
+Candidate version and release-tag full commit SHA:
+Source examples smoke CI run URL and CPython 3.11-3.14 statuses:
+Installed-wheel smoke CI run URL and CPython 3.11-3.14 statuses:
+Benchmark smoke status:
+Benchmark repository full commit SHA and clean-start status:
+Benchmark project manifest and lockfile SHA-256:
+Candidate manifest/lock artifact URI or reproducible patch:
+Resolved FogHTTP lock full SHA:
+Report metadata FogHTTP version:
+Benchmark host, Python, and exact command:
+Candidate-specific report artifact URI and SHA-256:
+Baseline FogHTTP version and full commit SHA:
+Baseline benchmark repository full commit SHA and manifest/lockfile SHA-256:
+Baseline manifest/lock artifact URI or reproducible patch:
+Baseline host, Python, exact command, report artifact URI, and SHA-256:
+Timing-review decision, maintainer, and rationale:
+Warnings, reruns, or approved waiver with approver and rationale:
+```
+
+Release readiness requires both example smoke paths and either a valid benchmark
+report or a waiver approved by a maintainer. A waiver must identify why the
+benchmark is not applicable and record the approver; a missing or unknown status
+is not release-ready. Any candidate code change or release-tag move invalidates
+the record and requires evidence for the new full SHA. An unrecorded harness
+delta or manifest, lockfile, report, or baseline digest mismatch also invalidates
+the record. A baseline produced with a different harness identity or workload
+command is not comparable and cannot satisfy the gate. Local-only files that
+are not retained with the release evidence do not satisfy the artifact fields.
 
 ## Methodology
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -40,9 +40,15 @@ Pull-request CI builds one Linux `cp311-abi3` wheel, audits it with
 `abi3audit --strict`, and installs that exact artifact on CPython 3.11-3.14.
 The release workflow repeats the ABI audit for every platform wheel and runs
 the install smoke described above. The smoke exercises imports, URL handling,
-and real sync and async requests against a local HTTP server. Native builds use
+every top-level `examples/*.py` file under a non-`__main__` module name, and real
+sync and async requests against a local HTTP server. Example imports use the
+installed wheel and do not make outbound network requests. Native builds use
 `Cargo.lock` with `maturin --locked` so Rust dependency resolution cannot drift
 in CI or during a release.
+
+Before publishing, the release-readiness record also captures the installed-
+wheel example smoke runs and the bounded benchmark smoke evidence defined in
+[benchmarks.md](./benchmarks.md).
 
 Python versions newer than the currently tested 3.11-3.14 range may be ABI
 compatible, but they are not part of the release compatibility claim until

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,22 @@ uv run examples/ssrf_policy.py
 uv run examples/telemetry_hooks.py
 ```
 
+## Smoke Check
+
+All current examples are external-service examples when their `main` blocks
+run. Normal pull-request CI therefore imports every top-level `examples/*.py`
+file under a non-`__main__` module name instead of making outbound requests.
+This catches syntax errors, missing imports, and public API references evaluated
+at module import time without relying on `httpbin.org`:
+
+```bash
+uv run --extra dev pytest -q tests/examples
+```
+
+The release wheel-smoke jobs repeat the same import check against the installed
+wheel before exercising the sync and async clients against their local HTTP
+server. Full example execution remains a manual, network-dependent check.
+
 ## Good Examples
 
 - [sync_json_api.py](./sync_json_api.py): sync JSON request/response flow.

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,6 +4,7 @@ output-format = "grouped"
 target-version = "py311"
 
 [lint]
+external = ["WPS"]
 fixable = ["ALL"]
 select = ["ALL"]
 ignore = [
@@ -25,8 +26,7 @@ ignore = [
 "docs/**/*.py" = ["T201"]
 "examples/**/*.py" = ["T201"]
 "scripts/**/*.py" = ["INP001"]
-"tests/**/test_*.py" = ["ARG001", "S101", "S311"]
-"tests/**/conftest.py" = ["ARG001"]
+"tests/**/test_*.py" = ["S101"]
 "**/*_controller.py" = ["RUF012"]
 
 [lint.flake8-annotations]

--- a/scripts/install_wheel_smoke.py
+++ b/scripts/install_wheel_smoke.py
@@ -4,90 +4,61 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
-import textwrap
 
 
-SMOKE_SCRIPT = textwrap.dedent(
-    """
-    import asyncio
-    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-    from importlib.metadata import version
-    import threading
-
-    import foghttp
-
-
-    OK_BODY = b"OK"
-
-
-    class SmokeHandler(BaseHTTPRequestHandler):
-        protocol_version = "HTTP/1.1"
-
-        def do_GET(self):
-            self.send_response(200)
-            self.send_header("content-length", str(len(OK_BODY)))
-            self.send_header("connection", "close")
-            self.end_headers()
-            self.wfile.write(OK_BODY)
-
-        def log_message(self, _format, *_args):
-            return
-
-
-    server = ThreadingHTTPServer(("127.0.0.1", 0), SmokeHandler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    host, port = server.server_address
-    url = f"http://{host}:{port}/smoke"
-
-    try:
-        assert version("foghttp")
-        assert str(foghttp.URL("HTTPS://Example.COM:443/path?q=1")) == "https://example.com/path?q=1"
-
-        with foghttp.Client() as client:
-            response = client.get(url)
-            assert response.status_code == 200
-            assert response.content == OK_BODY
-            assert response.request.method == "GET"
-
-        async def smoke_async_client():
-            async with foghttp.AsyncClient() as client:
-                response = await client.get(url)
-                assert response.status_code == 200
-                assert response.content == OK_BODY
-                assert response.request.url == url
-
-        asyncio.run(smoke_async_client())
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=1)
-    """,
-)
+DEFAULT_EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+SMOKE_RUNTIME = Path(__file__).with_name("wheel_smoke_runtime.py").resolve()
 
 
 def main() -> int:
+    if not sys.flags.isolated or not sys.flags.no_site:
+        msg = "wheel smoke installer must run with python -I -S"
+        raise SystemExit(msg)
+
     args = parse_args()
     wheel_path = find_wheel(args.dist_dir)
+    examples_dir = args.examples_dir.resolve()
+    if not examples_dir.is_dir():
+        msg = f"examples directory does not exist: {examples_dir}"
+        raise SystemExit(msg)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         smoke_dir = Path(tmp_dir)
+        installer_dir = smoke_dir / "installer"
         target_dir = smoke_dir / "site-packages"
         target_dir.mkdir()
+        run(
+            [sys.executable, "-I", "-S", "-m", "venv", str(installer_dir)],
+            cwd=smoke_dir,
+        )
+        installer_python = installer_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
 
         run(
             [
-                sys.executable,
+                str(installer_python),
+                "-I",
                 "-m",
                 "pip",
                 "install",
+                "--isolated",
                 "--disable-pip-version-check",
                 "--target",
                 str(target_dir),
                 str(wheel_path),
             ],
+            cwd=smoke_dir,
         )
-        run([sys.executable, "-c", SMOKE_SCRIPT], cwd=smoke_dir, python_path=target_dir)
+        run(
+            [
+                sys.executable,
+                "-I",
+                "-S",
+                str(SMOKE_RUNTIME),
+                str(target_dir),
+                str(examples_dir),
+            ],
+            cwd=smoke_dir,
+        )
 
     return 0
 
@@ -95,6 +66,7 @@ def main() -> int:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Install a built FogHTTP wheel and run a smoke test.")
     parser.add_argument("--dist-dir", type=Path, required=True)
+    parser.add_argument("--examples-dir", type=Path, default=DEFAULT_EXAMPLES_DIR)
     return parser.parse_args()
 
 
@@ -106,13 +78,10 @@ def find_wheel(dist_dir: Path) -> Path:
     return wheel_paths[0].resolve()
 
 
-def run(command: list[str], *, cwd: Path | None = None, python_path: Path | None = None) -> None:
+def run(command: list[str], *, cwd: Path | None = None) -> None:
     env = os.environ.copy()
     env.pop("PYTHONHOME", None)
-    if python_path is None:
-        env.pop("PYTHONPATH", None)
-    else:
-        env["PYTHONPATH"] = str(python_path)
+    env.pop("PYTHONPATH", None)
     subprocess.run(command, check=True, cwd=cwd, env=env)  # noqa: S603
 
 

--- a/scripts/wheel_smoke_runtime.py
+++ b/scripts/wheel_smoke_runtime.py
@@ -1,0 +1,161 @@
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib import import_module
+from importlib.metadata import version
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+import threading
+from types import ModuleType
+from typing import cast
+from unittest import SkipTest
+
+
+OK_BODY = b"OK"
+OK_STATUS = 200
+_MISSING_MODULE = object()
+
+
+def require(condition: object, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def discover_examples(examples_dir: Path) -> tuple[Path, ...]:
+    paths = tuple(path for path in sorted(examples_dir.glob("*.py")) if path.is_file())
+    if not paths:
+        message = f"no Python examples found in {examples_dir}"
+        raise RuntimeError(message)
+    return paths
+
+
+def run_example(example_path: Path) -> ModuleType:
+    run_name = f"_foghttp_example_{example_path.stem}"
+    previous_module = sys.modules.get(run_name, _MISSING_MODULE)
+    spec = spec_from_file_location(run_name, example_path)
+    if spec is None or spec.loader is None:
+        message = f"cannot create an import spec for Python example: {example_path}"
+        raise RuntimeError(message)
+
+    module = module_from_spec(spec)
+    sys.modules[run_name] = module
+    try:
+        try:
+            # Compile current bytes so timestamp-based bytecode cannot hide an edited example.
+            code = compile(
+                example_path.read_bytes(),
+                str(example_path),
+                "exec",
+                dont_inherit=True,
+            )
+            exec(code, module.__dict__)  # noqa: S102
+        except SystemExit as error:
+            message = f"Python example attempted to exit during import: {example_path}"
+            raise RuntimeError(message) from error
+        except SkipTest as error:
+            message = f"Python example attempted to skip during import: {example_path}"
+            raise RuntimeError(message) from error
+        except Exception:
+            raise
+        except KeyboardInterrupt:
+            raise
+        except BaseException as error:
+            message = f"Python example raised a control-flow exception during import: {example_path}"
+            raise RuntimeError(message) from error
+    finally:
+        if previous_module is _MISSING_MODULE:
+            sys.modules.pop(run_name, None)
+        else:
+            sys.modules[run_name] = cast("ModuleType", previous_module)
+    return module
+
+
+def run_examples(examples_dir: Path) -> None:
+    for example_path in discover_examples(examples_dir):
+        run_example(example_path)
+
+
+class SmokeHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:
+        self.send_response(OK_STATUS)
+        self.send_header("content-length", str(len(OK_BODY)))
+        self.send_header("connection", "close")
+        self.end_headers()
+        self.wfile.write(OK_BODY)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+@contextmanager
+def loopback_server_url() -> Iterator[str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), SmokeHandler)
+    try:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+    except BaseException:
+        server.server_close()
+        raise
+
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}/smoke"
+    finally:
+        try:
+            server.shutdown()
+        finally:
+            try:
+                server.server_close()
+            finally:
+                thread.join(timeout=1)
+                if thread.is_alive():
+                    message = "loopback HTTP server thread did not stop"
+                    raise RuntimeError(message)
+
+
+def main() -> int:
+    _, target_arg, examples_arg = sys.argv
+    target_dir = Path(target_arg).resolve()
+    examples_dir = Path(examples_arg).resolve()
+    sys.path.insert(0, str(target_dir))
+    foghttp = import_module("foghttp")
+
+    package_file = getattr(foghttp, "__file__", None)
+    require(package_file is not None, "installed foghttp package has no file location")
+    require(
+        Path(package_file).resolve().is_relative_to(target_dir),
+        "foghttp was not imported from the installed wheel target",
+    )
+    run_examples(examples_dir)
+
+    with loopback_server_url() as url:
+        require(bool(version("foghttp")), "installed distribution version is empty")
+        require(
+            str(foghttp.URL("HTTPS://Example.COM:443/path?q=1")) == "https://example.com/path?q=1",
+            "URL normalization smoke failed",
+        )
+
+        with foghttp.Client() as client:
+            response = client.get(url)
+            require(response.status_code == OK_STATUS, "sync response status smoke failed")
+            require(response.content == OK_BODY, "sync response body smoke failed")
+            require(response.request.method == "GET", "sync request method smoke failed")
+
+        async def smoke_async_client() -> None:
+            async with foghttp.AsyncClient() as client:
+                response = await client.get(url)
+                require(response.status_code == OK_STATUS, "async response status smoke failed")
+                require(response.content == OK_BODY, "async response body smoke failed")
+                require(response.request.url == url, "async request URL smoke failed")
+
+        asyncio.run(smoke_async_client())
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/client_cancellation/lifecycle_debug_data.py
+++ b/tests/client_cancellation/lifecycle_debug_data.py
@@ -21,7 +21,8 @@ SENSITIVE_USERNAME = "debug-user"
 VISIBLE_QUERY_VALUE = "visible-value"
 
 
-class ContextBodyError(Exception): ...
+class ContextBodyError(Exception):
+    """Represent an application error raised inside a client context."""
 
 
 def sensitive_url(base_url: str, path: str) -> str:

--- a/tests/client_lifecycle/test_async_client_lifecycle.py
+++ b/tests/client_lifecycle/test_async_client_lifecycle.py
@@ -60,9 +60,9 @@ async def test_async_lifecycle_debug_snapshot_without_debug_does_not_create_raw_
     assert raw_client_factory.calls == 0
 
 
+@pytest.mark.usefixtures("async_noop_transport")
 async def test_async_lifecycle_debug_maps_raw_lifecycle_errors(
     lifecycle_error_async_client_factory: type[foghttp.AsyncClient],
-    async_noop_transport: None,
     faker: Faker,
 ) -> None:
     client = lifecycle_error_async_client_factory(
@@ -77,9 +77,9 @@ async def test_async_lifecycle_debug_maps_raw_lifecycle_errors(
         await client.aclose()
 
 
+@pytest.mark.usefixtures("async_noop_transport")
 async def test_async_client_rejects_stale_process_owner_without_closing_raw_parent_copy(
     async_client_factory: type[foghttp.AsyncClient],
-    async_noop_transport: None,
     raw_client: CloseTrackingRawClient,
     faker: Faker,
 ) -> None:
@@ -179,11 +179,11 @@ async def test_async_dump_transport_state_before_first_request_do_not_create_raw
     assert raw_client_factory.calls == 0
 
 
+@pytest.mark.usefixtures("async_noop_transport")
 async def test_async_close_closes_opened_raw_client_once(
     async_client_factory: type[foghttp.AsyncClient],
     raw_client: CloseTrackingRawClient,
     raw_client_factory: RawClientFactory,
-    async_noop_transport: None,
     faker: Faker,
 ) -> None:
     client = async_client_factory()
@@ -223,10 +223,10 @@ async def test_async_short_lived_clients_without_requests_do_not_create_raw_clie
     assert raw_client.close_calls == 0
 
 
+@pytest.mark.usefixtures("async_noop_transport")
 async def test_async_reuses_lazy_raw_client(
     async_client_factory: type[foghttp.AsyncClient],
     raw_client_factory: RawClientFactory,
-    async_noop_transport: None,
     faker: Faker,
 ) -> None:
     urls = [faker.url(), faker.url()]
@@ -238,10 +238,10 @@ async def test_async_reuses_lazy_raw_client(
     assert raw_client_factory.calls == 1
 
 
+@pytest.mark.usefixtures("async_noop_transport")
 async def test_async_concurrent_first_requests_share_lazy_raw_client(
     async_client_factory: type[foghttp.AsyncClient],
     raw_client_factory: RawClientFactory,
-    async_noop_transport: None,
     faker: Faker,
 ) -> None:
     urls = [faker.url(), faker.url()]
@@ -255,11 +255,11 @@ async def test_async_concurrent_first_requests_share_lazy_raw_client(
     assert raw_client_factory.calls == 1
 
 
+@pytest.mark.usefixtures("async_noop_transport")
 async def test_async_context_manager_closes_opened_raw_client(
     async_client_factory: type[foghttp.AsyncClient],
     raw_client: CloseTrackingRawClient,
     raw_client_factory: RawClientFactory,
-    async_noop_transport: None,
     faker: Faker,
 ) -> None:
     async with async_client_factory() as client:

--- a/tests/client_lifecycle/test_sync_client_lifecycle.py
+++ b/tests/client_lifecycle/test_sync_client_lifecycle.py
@@ -58,18 +58,17 @@ def test_sync_closed_client_rejects_stats(
 
 
 @pytest.mark.parametrize(
-    ("action_name", "action"),
+    "action",
     [
-        pytest.param("stats", foghttp.Client.stats, id="stats"),
-        pytest.param("transport state", foghttp.Client.dump_transport_state, id="transport-state"),
-        pytest.param("pool diagnostics", foghttp.Client.dump_pool_diagnostics, id="pool-diagnostics"),
+        pytest.param(foghttp.Client.stats, id="stats"),
+        pytest.param(foghttp.Client.dump_transport_state, id="transport-state"),
+        pytest.param(foghttp.Client.dump_pool_diagnostics, id="pool-diagnostics"),
     ],
 )
+@pytest.mark.usefixtures("sync_noop_transport")
 def test_sync_client_maps_raw_lifecycle_errors(
     lifecycle_error_sync_client_factory: type[foghttp.Client],
-    sync_noop_transport: None,
     faker: Faker,
-    action_name: str,
     action: Callable[[foghttp.Client], object],
 ) -> None:
     client = lifecycle_error_sync_client_factory()
@@ -82,9 +81,9 @@ def test_sync_client_maps_raw_lifecycle_errors(
         client.close()
 
 
+@pytest.mark.usefixtures("sync_noop_transport")
 def test_sync_client_rejects_stale_process_owner_without_closing_raw_parent_copy(
     sync_client_factory: type[foghttp.Client],
-    sync_noop_transport: None,
     raw_client: CloseTrackingRawClient,
     faker: Faker,
 ) -> None:
@@ -111,7 +110,7 @@ def test_inherited_client_copy_does_not_warn_about_parent_owned_resources() -> N
         warnings.simplefilter("always")
         collect_unclosed_client(inherited_client_factory)
 
-    assert not [item for item in caught if issubclass(item.category, foghttp.UnclosedClientError)]
+    assert not any(issubclass(item.category, foghttp.UnclosedClientError) for item in caught)
 
 
 def test_sync_stream_context_rechecks_process_owner_on_enter(faker: Faker) -> None:
@@ -187,11 +186,11 @@ def test_sync_dump_transport_state_before_first_request_do_not_create_raw_client
     assert raw_client_factory.calls == 0
 
 
+@pytest.mark.usefixtures("sync_noop_transport")
 def test_sync_close_closes_opened_raw_client_once(
     sync_client_factory: type[foghttp.Client],
     raw_client: CloseTrackingRawClient,
     raw_client_factory: RawClientFactory,
-    sync_noop_transport: None,
     faker: Faker,
 ) -> None:
     client = sync_client_factory()
@@ -231,10 +230,10 @@ def test_sync_short_lived_clients_without_requests_do_not_create_raw_client(
     assert raw_client.close_calls == 0
 
 
+@pytest.mark.usefixtures("sync_noop_transport")
 def test_sync_reuses_lazy_raw_client(
     sync_client_factory: type[foghttp.Client],
     raw_client_factory: RawClientFactory,
-    sync_noop_transport: None,
     faker: Faker,
 ) -> None:
     urls = [faker.url(), faker.url()]
@@ -246,10 +245,10 @@ def test_sync_reuses_lazy_raw_client(
     assert raw_client_factory.calls == 1
 
 
+@pytest.mark.usefixtures("sync_noop_transport")
 def test_sync_concurrent_first_requests_share_lazy_raw_client(
     sync_client_factory: type[foghttp.Client],
     raw_client_factory: RawClientFactory,
-    sync_noop_transport: None,
     faker: Faker,
 ) -> None:
     raw_client_factory.delay = 0.01
@@ -271,11 +270,11 @@ def test_sync_concurrent_first_requests_share_lazy_raw_client(
     assert raw_client_factory.calls == 1
 
 
+@pytest.mark.usefixtures("sync_noop_transport")
 def test_sync_context_manager_closes_opened_raw_client(
     sync_client_factory: type[foghttp.Client],
     raw_client: CloseTrackingRawClient,
     raw_client_factory: RawClientFactory,
-    sync_noop_transport: None,
     faker: Faker,
 ) -> None:
     with sync_client_factory() as client:

--- a/tests/client_lifecycle/test_sync_close_race.py
+++ b/tests/client_lifecycle/test_sync_close_race.py
@@ -19,8 +19,8 @@ from .helpers import (
 )
 
 
-class SyntheticBaseException(BaseException):
-    pass
+class SyntheticBaseException(BaseException):  # noqa: WPS418
+    """Represent non-Exception control flow during lifecycle admission."""
 
 
 def test_sync_close_waits_for_send_in_validation_window(

--- a/tests/examples/test_imports.py
+++ b/tests/examples/test_imports.py
@@ -95,7 +95,8 @@ def test_loopback_server_closes_when_thread_setup_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class FakeServer:
-        closed = False
+        def __init__(self) -> None:
+            self.closed = False
 
         def serve_forever(self) -> None:
             pytest.fail("server thread must not run")

--- a/tests/examples/test_imports.py
+++ b/tests/examples/test_imports.py
@@ -1,0 +1,217 @@
+import os
+from pathlib import Path
+import py_compile
+import sys
+from types import ModuleType
+import unittest
+
+import pytest
+
+from scripts.wheel_smoke_runtime import discover_examples, loopback_server_url, run_example
+
+
+EXAMPLES_DIR = Path(__file__).parents[2] / "examples"
+EXAMPLE_PATHS = discover_examples(EXAMPLES_DIR)
+
+
+def test_example_paths_select_sorted_top_level_python_files(tmp_path: Path) -> None:
+    first_path = tmp_path / "a.py"
+    second_path = tmp_path / "b.py"
+    first_path.touch()
+    second_path.touch()
+    (tmp_path / "ignored.txt").touch()
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "ignored.py").touch()
+    python_dir = tmp_path / "ignored.py"
+    python_dir.mkdir()
+    (python_dir / "__main__.py").touch()
+
+    assert discover_examples(tmp_path) == (first_path, second_path)
+
+
+def test_discover_examples_rejects_empty_inventory(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="no Python examples found"):
+        discover_examples(tmp_path)
+
+
+def test_run_example_uses_import_semantics(tmp_path: Path) -> None:
+    example_path = tmp_path / "import_semantics.py"
+    example_path.write_text(
+        "import sys\n"
+        "if __spec__ is None:\n"
+        "    raise RuntimeError('missing module spec')\n"
+        "if __name__ not in sys.modules:\n"
+        "    raise RuntimeError('module is not registered')\n",
+        encoding="utf-8",
+    )
+
+    module = run_example(example_path)
+
+    assert module.__spec__ is not None
+    assert module.__name__ not in sys.modules
+
+
+def test_run_example_rejects_system_exit(tmp_path: Path) -> None:
+    example_path = tmp_path / "exit.py"
+    example_path.write_text("raise SystemExit(0)\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="attempted to exit during import"):
+        run_example(example_path)
+
+
+def test_run_example_rejects_skip_control_flow(tmp_path: Path) -> None:
+    example_path = tmp_path / "skip.py"
+    example_path.write_text(
+        "from unittest import SkipTest\nraise SkipTest('not a smoke pass')\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="attempted to skip") as error_info:
+        run_example(example_path)
+
+    assert isinstance(error_info.value.__cause__, unittest.SkipTest)
+
+
+def test_run_example_preserves_ordinary_exception(tmp_path: Path) -> None:
+    example_path = tmp_path / "failure.py"
+    example_path.write_text("raise LookupError('import failed')\n", encoding="utf-8")
+
+    with pytest.raises(LookupError, match="import failed"):
+        run_example(example_path)
+
+
+def test_run_example_preserves_keyboard_interrupt(tmp_path: Path) -> None:
+    example_path = tmp_path / "interrupt.py"
+    example_path.write_text("raise KeyboardInterrupt\n", encoding="utf-8")
+
+    with pytest.raises(KeyboardInterrupt):
+        run_example(example_path)
+
+
+@pytest.mark.parametrize("failure_point", ["construct", "start"])
+def test_loopback_server_closes_when_thread_setup_fails(
+    failure_point: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeServer:
+        closed = False
+
+        def serve_forever(self) -> None:
+            pytest.fail("server thread must not run")
+
+        def server_close(self) -> None:
+            self.closed = True
+
+    class FailingThread:
+        def start(self) -> None:
+            message = "thread start unavailable"
+            raise RuntimeError(message)
+
+    def create_thread(**_kwargs: object) -> FailingThread:
+        if failure_point == "construct":
+            message = "thread construct unavailable"
+            raise RuntimeError(message)
+        return FailingThread()
+
+    server = FakeServer()
+    monkeypatch.setattr("scripts.wheel_smoke_runtime.ThreadingHTTPServer", lambda *_args: server)
+    monkeypatch.setattr("scripts.wheel_smoke_runtime.threading.Thread", create_thread)
+
+    with pytest.raises(RuntimeError, match=f"thread {failure_point} unavailable"), loopback_server_url():
+        pytest.fail("context must not be entered")
+
+    assert server.closed
+
+
+@pytest.mark.parametrize("failure_method", ["shutdown", "server_close", "thread_alive"])
+def test_loopback_server_attempts_all_cleanup_after_failure(
+    failure_method: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class FakeServer:
+        server_address = ("127.0.0.1", 80)
+
+        def serve_forever(self) -> None:
+            pytest.fail("fake thread must not run")
+
+        def shutdown(self) -> None:
+            calls.append("shutdown")
+            if failure_method == "shutdown":
+                message = "shutdown failed"
+                raise RuntimeError(message)
+
+        def server_close(self) -> None:
+            calls.append("server_close")
+            if failure_method == "server_close":
+                message = "server close failed"
+                raise RuntimeError(message)
+
+    class FakeThread:
+        def start(self) -> None:
+            calls.append("start")
+
+        def join(self, *, timeout: int) -> None:
+            calls.append(f"join:{timeout}")
+
+        def is_alive(self) -> bool:
+            calls.append("is_alive")
+            return failure_method == "thread_alive"
+
+    server = FakeServer()
+    monkeypatch.setattr("scripts.wheel_smoke_runtime.ThreadingHTTPServer", lambda *_args: server)
+    monkeypatch.setattr("scripts.wheel_smoke_runtime.threading.Thread", lambda **_kwargs: FakeThread())
+
+    expected_error = "did not stop" if failure_method == "thread_alive" else "failed"
+    with pytest.raises(RuntimeError, match=expected_error), loopback_server_url():
+        pass
+
+    assert calls == ["start", "shutdown", "server_close", "join:1", "is_alive"]
+
+
+def test_run_example_restores_existing_registration_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    example_path = tmp_path / "registered.py"
+    example_path.write_text("", encoding="utf-8")
+    module_name = run_example(example_path).__name__
+    existing_module = ModuleType(module_name)
+    monkeypatch.setitem(sys.modules, module_name, existing_module)
+    example_path.write_text("raise SystemExit(0)\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="attempted to exit during import"):
+        run_example(example_path)
+
+    assert sys.modules[module_name] is existing_module
+
+
+def test_run_example_ignores_stale_timestamp_bytecode(tmp_path: Path) -> None:
+    example_path = tmp_path / "stale.py"
+    initial_source = b"pass\n##############\n"
+    changed_source = b"raise SystemExit(0)\n"
+    assert len(initial_source) == len(changed_source)
+    example_path.write_bytes(initial_source)
+    metadata = example_path.stat()
+    py_compile.compile(
+        str(example_path),
+        doraise=True,
+        invalidation_mode=py_compile.PycInvalidationMode.TIMESTAMP,
+    )
+    example_path.write_bytes(changed_source)
+    os.utime(example_path, ns=(metadata.st_atime_ns, metadata.st_mtime_ns))
+    assert example_path.stat().st_size == metadata.st_size
+
+    with pytest.raises(RuntimeError, match="attempted to exit during import"):
+        run_example(example_path)
+
+
+@pytest.mark.parametrize("example_path", EXAMPLE_PATHS, ids=lambda path: path.name)
+def test_example_imports_without_running_main(example_path: Path) -> None:
+    module = run_example(example_path)
+
+    assert module.__name__ != "__main__"
+    assert module.__spec__ is not None
+    assert module.__spec__.name == module.__name__

--- a/tests/prometheus/test_integration.py
+++ b/tests/prometheus/test_integration.py
@@ -72,7 +72,7 @@ def test_wsgi_exposition_app_scrapes_the_explicit_registry() -> None:
 
     def start_response(
         status: str,
-        headers: list[tuple[str, str]],
+        _headers: list[tuple[str, str]],
     ) -> None:
         response_status.append(status)
 

--- a/tests/redirect_helpers.py
+++ b/tests/redirect_helpers.py
@@ -7,38 +7,45 @@ __all__ = (
     "redirect_to_location_url",
 )
 
+from types import MappingProxyType
 from typing import Any, cast
 from urllib.parse import urlencode
 
 
 SECURITY_HEADERS_PATH = "/headers/security"
-REDIRECT_CONDITIONAL_HEADERS = {
-    "if-match": '"request-etag"',
-    "if-modified-since": "Mon, 01 Jan 2024 00:00:00 GMT",
-    "if-none-match": '"cached-etag"',
-    "if-range": '"range-etag"',
-    "if-unmodified-since": "Mon, 01 Jan 2024 00:00:00 GMT",
-}
-REDIRECT_CONTENT_HEADERS = {
-    "content-checksum": "custom-checksum",
-    "content-digest": "sha-256=:YWJj:",
-    "content-disposition": "attachment; filename=payload.txt",
-    "content-encoding": "identity",
-    "content-language": "en",
-    "content-location": "/source",
-    "content-range": "bytes 0-2/3",
-    "content-type": "text/plain",
-    "digest": "sha-256=Z2hp",
-    "last-modified": "Mon, 01 Jan 2024 00:00:00 GMT",
-    "repr-digest": "sha-256=:ZGVm:",
-}
-REDIRECT_SECURITY_HEADERS = {
-    "accept": "application/json",
-    "authorization": "Bearer secret",
-    "cookie": "session=secret",
-    "origin": "https://example.com",
-    "referer": "https://example.com/source",
-}
+REDIRECT_CONDITIONAL_HEADERS = MappingProxyType(
+    {
+        "if-match": '"request-etag"',
+        "if-modified-since": "Mon, 01 Jan 2024 00:00:00 GMT",
+        "if-none-match": '"cached-etag"',
+        "if-range": '"range-etag"',
+        "if-unmodified-since": "Mon, 01 Jan 2024 00:00:00 GMT",
+    },
+)
+REDIRECT_CONTENT_HEADERS = MappingProxyType(
+    {
+        "content-checksum": "custom-checksum",
+        "content-digest": "sha-256=:YWJj:",
+        "content-disposition": "attachment; filename=payload.txt",
+        "content-encoding": "identity",
+        "content-language": "en",
+        "content-location": "/source",
+        "content-range": "bytes 0-2/3",
+        "content-type": "text/plain",
+        "digest": "sha-256=Z2hp",
+        "last-modified": "Mon, 01 Jan 2024 00:00:00 GMT",
+        "repr-digest": "sha-256=:ZGVm:",
+    },
+)
+REDIRECT_SECURITY_HEADERS = MappingProxyType(
+    {
+        "accept": "application/json",
+        "authorization": "Bearer secret",
+        "cookie": "session=secret",
+        "origin": "https://example.com",
+        "referer": "https://example.com/source",
+    },
+)
 
 
 def redirect_to_location_url(base_url: str, *, status_code: int, location: str) -> str:

--- a/tests/request_builder/test_shortcuts.py
+++ b/tests/request_builder/test_shortcuts.py
@@ -5,7 +5,7 @@ import foghttp
 from foghttp.methods import DELETE, GET, HEAD, PATCH, POST, PUT, QUERY
 
 
-SHORTCUT_METHODS = [
+SHORTCUT_METHODS = (
     ("get", GET),
     ("head", HEAD),
     ("post", POST),
@@ -13,19 +13,19 @@ SHORTCUT_METHODS = [
     ("put", PUT),
     ("patch", PATCH),
     ("delete", DELETE),
-]
+)
 
-BODYLESS_SHORTCUT_NAMES = [
+BODYLESS_SHORTCUT_NAMES = (
     "get",
     "head",
-]
+)
 
-BODY_KWARGS = [
-    pytest.param({"content": b"body"}, id="content"),
-    pytest.param({"data": {"field": "value"}}, id="data"),
-    pytest.param({"files": {"file": b"body"}}, id="files"),
-    pytest.param({"json": {"field": "value"}}, id="json"),
-]
+BODY_KWARG_NAMES = (
+    "content",
+    "data",
+    "files",
+    "json",
+)
 
 
 @pytest.mark.parametrize(
@@ -49,6 +49,7 @@ def test_sync_shortcuts_use_request_builder_pipeline_without_transport(
         *,
         timeout: foghttp.Timeouts | None = None,
     ) -> foghttp.Response:
+        assert timeout is None
         captured_requests.append(request)
         return _response_for(request)
 
@@ -93,6 +94,7 @@ async def test_async_shortcuts_use_request_builder_pipeline_without_transport(
         *,
         timeout: foghttp.Timeouts | None = None,
     ) -> foghttp.Response:
+        assert timeout is None
         captured_requests.append(request)
         return _response_for(request)
 
@@ -117,12 +119,13 @@ async def test_async_shortcuts_use_request_builder_pipeline_without_transport(
 
 
 @pytest.mark.parametrize("shortcut_name", BODYLESS_SHORTCUT_NAMES)
-@pytest.mark.parametrize("body_kwargs", BODY_KWARGS)
+@pytest.mark.parametrize("body_kwarg_name", BODY_KWARG_NAMES)
 def test_sync_get_head_shortcuts_reject_body_parameters(
     shortcut_name: str,
-    body_kwargs: dict[str, object],
+    body_kwarg_name: str,
     faker: Faker,
 ) -> None:
+    body_kwargs = _body_kwargs(body_kwarg_name)
     with foghttp.Client() as client:
         shortcut = getattr(client, shortcut_name)
         with pytest.raises(TypeError, match="unexpected keyword argument"):
@@ -130,12 +133,13 @@ def test_sync_get_head_shortcuts_reject_body_parameters(
 
 
 @pytest.mark.parametrize("shortcut_name", BODYLESS_SHORTCUT_NAMES)
-@pytest.mark.parametrize("body_kwargs", BODY_KWARGS)
+@pytest.mark.parametrize("body_kwarg_name", BODY_KWARG_NAMES)
 async def test_async_get_head_shortcuts_reject_body_parameters(
     shortcut_name: str,
-    body_kwargs: dict[str, object],
+    body_kwarg_name: str,
     faker: Faker,
 ) -> None:
+    body_kwargs = _body_kwargs(body_kwarg_name)
     async with foghttp.AsyncClient() as client:
         shortcut = getattr(client, shortcut_name)
         with pytest.raises(TypeError, match="unexpected keyword argument"):
@@ -164,6 +168,7 @@ def test_sync_request_allows_explicit_get_head_body_without_transport(
         *,
         timeout: foghttp.Timeouts | None = None,
     ) -> foghttp.Response:
+        assert timeout is None
         captured_requests.append(request)
         return _response_for(request)
 
@@ -198,6 +203,7 @@ async def test_async_request_allows_explicit_get_head_body_without_transport(
         *,
         timeout: foghttp.Timeouts | None = None,
     ) -> foghttp.Response:
+        assert timeout is None
         captured_requests.append(request)
         return _response_for(request)
 
@@ -212,6 +218,14 @@ async def test_async_request_allows_explicit_get_head_body_without_transport(
 
 def _base_url(faker: Faker) -> str:
     return f"https://{faker.domain_name()}/{faker.uri_path(deep=1)}?debug=1"
+
+
+def _body_kwargs(name: str) -> dict[str, object]:
+    if name == "content":
+        return {name: b"body"}
+    if name == "files":
+        return {name: {"file": b"body"}}
+    return {name: {"field": "value"}}
 
 
 def _assert_shortcut_request(

--- a/tests/response_decompression/server.py
+++ b/tests/response_decompression/server.py
@@ -6,6 +6,7 @@ __all__ = (
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import threading
+from types import MappingProxyType
 from typing import Self, TypeAlias
 from urllib.parse import urlsplit
 
@@ -155,12 +156,14 @@ class ResponseDecompressionHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
 
-ENCODED_RESPONSE_ENCODINGS = {
-    BROTLI_ENCODING_PATH: "br",
-    GZIP_ENCODING_PATH: "gzip",
-    RAW_DEFLATE_ENCODING_PATH: "deflate",
-    ZLIB_DEFLATE_ENCODING_PATH: "deflate",
-}
+ENCODED_RESPONSE_ENCODINGS = MappingProxyType(
+    {
+        BROTLI_ENCODING_PATH: "br",
+        GZIP_ENCODING_PATH: "gzip",
+        RAW_DEFLATE_ENCODING_PATH: "deflate",
+        ZLIB_DEFLATE_ENCODING_PATH: "deflate",
+    },
+)
 ENCODED_PATHS = frozenset(ENCODED_RESPONSE_ENCODINGS)
 
 

--- a/tests/support/sync_http_server.py
+++ b/tests/support/sync_http_server.py
@@ -1,6 +1,7 @@
 __all__ = ("secondary_sync_http_server", "sync_http_server")
 
 from collections.abc import Iterator
+from functools import partial
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import threading
 from typing import Any, BinaryIO
@@ -74,17 +75,17 @@ class SyncHTTPHandler(BaseHTTPRequestHandler):
             for handler in (
                 self._write_cookie_response,
                 self._write_redirect_to_location,
-                lambda: self._write_redirect_to_status(path),
-                lambda: self._write_redirect(path),
-                lambda: self._write_status(path),
-                lambda: write_sync_body_safety_response(self, path),
-                lambda: self._write_bytes(path),
-                lambda: self._write_unknown_size_bytes(path),
-                lambda: self._write_text(path),
-                lambda: self._write_repeated_headers(path),
-                lambda: self._write_obs_text_headers(path),
-                lambda: self._write_echo_headers(path),
-                lambda: self._write_security_headers(path, body),
+                partial(self._write_redirect_to_status, path),
+                partial(self._write_redirect, path),
+                partial(self._write_status, path),
+                partial(write_sync_body_safety_response, self, path),
+                partial(self._write_bytes, path),
+                partial(self._write_unknown_size_bytes, path),
+                partial(self._write_text, path),
+                partial(self._write_repeated_headers, path),
+                partial(self._write_obs_text_headers, path),
+                partial(self._write_echo_headers, path),
+                partial(self._write_security_headers, path, body),
             )
         )
         if handled:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,15 +1,15 @@
 import foghttp
-import foghttp.errors
-import foghttp.methods
-import foghttp.models
-import foghttp.policy
-import foghttp.stats
-import foghttp.types
+import foghttp.errors as errors_module
+import foghttp.methods as methods_module
+import foghttp.models as models_module
+import foghttp.policy as policy_module
+import foghttp.stats as stats_module
+import foghttp.types as types_module
 
 
 def test_top_level_exports() -> None:
     assert foghttp.Client is not None
-    assert foghttp.ConfigurationError is foghttp.errors.ConfigurationError
+    assert foghttp.ConfigurationError is errors_module.ConfigurationError
     assert foghttp.AsyncLifecycleDebugConfig is not None
     assert foghttp.AsyncLifecycleDebugRequest is not None
     assert foghttp.AsyncLifecycleDebugRequestMode is not None
@@ -44,48 +44,48 @@ def test_top_level_exports() -> None:
 
 
 def test_compatibility_modules_reexport_models() -> None:
-    assert foghttp.models.Limits is foghttp.Limits
-    assert foghttp.models.AsyncLifecycleDebugConfig is foghttp.AsyncLifecycleDebugConfig
-    assert foghttp.models.AsyncLifecycleDebugRequest is foghttp.AsyncLifecycleDebugRequest
-    assert foghttp.models.AsyncLifecycleDebugRequestMode is foghttp.AsyncLifecycleDebugRequestMode
-    assert foghttp.models.AsyncLifecycleDebugSnapshot is foghttp.AsyncLifecycleDebugSnapshot
-    assert foghttp.models.Headers is foghttp.Headers
-    assert foghttp.models.Request is foghttp.Request
-    assert foghttp.models.RequestExtensions is foghttp.RequestExtensions
-    assert foghttp.models.Response is foghttp.Response
-    assert foghttp.models.AsyncStreamResponse is foghttp.AsyncStreamResponse
-    assert foghttp.models.StreamResponse is foghttp.StreamResponse
-    assert foghttp.models.TLSConfig is foghttp.TLSConfig
-    assert foghttp.models.TimeoutDiagnostic is foghttp.TimeoutDiagnostic
-    assert foghttp.models.TimeoutPhase is foghttp.TimeoutPhase
-    assert foghttp.models.Timeouts is foghttp.Timeouts
-    assert foghttp.models.URL is foghttp.URL
-    assert foghttp.stats.TransportStats is foghttp.TransportStats
+    assert models_module.Limits is foghttp.Limits
+    assert models_module.AsyncLifecycleDebugConfig is foghttp.AsyncLifecycleDebugConfig
+    assert models_module.AsyncLifecycleDebugRequest is foghttp.AsyncLifecycleDebugRequest
+    assert models_module.AsyncLifecycleDebugRequestMode is foghttp.AsyncLifecycleDebugRequestMode
+    assert models_module.AsyncLifecycleDebugSnapshot is foghttp.AsyncLifecycleDebugSnapshot
+    assert models_module.Headers is foghttp.Headers
+    assert models_module.Request is foghttp.Request
+    assert models_module.RequestExtensions is foghttp.RequestExtensions
+    assert models_module.Response is foghttp.Response
+    assert models_module.AsyncStreamResponse is foghttp.AsyncStreamResponse
+    assert models_module.StreamResponse is foghttp.StreamResponse
+    assert models_module.TLSConfig is foghttp.TLSConfig
+    assert models_module.TimeoutDiagnostic is foghttp.TimeoutDiagnostic
+    assert models_module.TimeoutPhase is foghttp.TimeoutPhase
+    assert models_module.Timeouts is foghttp.Timeouts
+    assert models_module.URL is foghttp.URL
+    assert stats_module.TransportStats is foghttp.TransportStats
 
 
 def test_query_method_is_exported() -> None:
-    assert foghttp.methods.QUERY == "QUERY"
-    assert foghttp.methods.QUERY in foghttp.methods.HTTP_METHODS
-    assert foghttp.methods.HTTP_METHODS.count(foghttp.methods.QUERY) == 1
-    assert "QUERY" in foghttp.methods.__all__
+    assert methods_module.QUERY == "QUERY"
+    assert methods_module.QUERY in methods_module.HTTP_METHODS
+    assert methods_module.HTTP_METHODS.count(methods_module.QUERY) == 1
+    assert "QUERY" in methods_module.__all__
 
 
 def test_public_typing_protocols_do_not_open_transport_adapters() -> None:
-    assert foghttp.types.RequestProtocol is not None
-    assert foghttp.types.ResponseProtocol is not None
-    assert foghttp.types.BufferedResponseProtocol is not None
-    assert foghttp.types.StreamResponseProtocol is not None
-    assert foghttp.types.AsyncStreamResponseProtocol is not None
+    assert types_module.RequestProtocol is not None
+    assert types_module.ResponseProtocol is not None
+    assert types_module.BufferedResponseProtocol is not None
+    assert types_module.StreamResponseProtocol is not None
+    assert types_module.AsyncStreamResponseProtocol is not None
     assert not hasattr(foghttp, "SyncTransport")
     assert not hasattr(foghttp, "AsyncTransport")
-    assert not hasattr(foghttp.types, "SyncTransport")
-    assert not hasattr(foghttp.types, "AsyncTransport")
+    assert not hasattr(types_module, "SyncTransport")
+    assert not hasattr(types_module, "AsyncTransport")
 
 
 def test_policy_contracts_are_identical_at_the_package_root() -> None:
-    assert foghttp.TransportPolicyBodyState is foghttp.policy.TransportPolicyBodyState
-    assert foghttp.TransportPolicyHooks is foghttp.policy.TransportPolicyHooks
-    assert foghttp.TransportPolicyRequest is foghttp.policy.TransportPolicyRequest
-    assert foghttp.TransportPolicyRequestHook is foghttp.policy.TransportPolicyRequestHook
-    assert foghttp.TransportPolicyResponse is foghttp.policy.TransportPolicyResponse
-    assert foghttp.TransportPolicyResponseHook is foghttp.policy.TransportPolicyResponseHook
+    assert foghttp.TransportPolicyBodyState is policy_module.TransportPolicyBodyState
+    assert foghttp.TransportPolicyHooks is policy_module.TransportPolicyHooks
+    assert foghttp.TransportPolicyRequest is policy_module.TransportPolicyRequest
+    assert foghttp.TransportPolicyRequestHook is policy_module.TransportPolicyRequestHook
+    assert foghttp.TransportPolicyResponse is policy_module.TransportPolicyResponse
+    assert foghttp.TransportPolicyResponseHook is policy_module.TransportPolicyResponseHook

--- a/tests/test_runtime_workers.py
+++ b/tests/test_runtime_workers.py
@@ -163,4 +163,4 @@ def test_client_rejects_invalid_env_runtime_workers(
     ):
         foghttp.Client()
 
-    assert not [item for item in caught if issubclass(item.category, foghttp.UnclosedClientError)]
+    assert not any(issubclass(item.category, foghttp.UnclosedClientError) for item in caught)

--- a/tests/test_transport_stats.py
+++ b/tests/test_transport_stats.py
@@ -1,46 +1,48 @@
 from dataclasses import fields
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 
 import foghttp
 from foghttp._client.stats import stats_from_raw
 
 
-RAW_STATS_VALUES = {
-    "active_requests": 1,
-    "pending_requests": 2,
-    "peak_pending_requests": 3,
-    "total_requests": 4,
-    "failed_requests": 5,
-    "pool_acquire_attempts": 6,
-    "pool_acquire_immediate": 7,
-    "pool_acquire_waited": 8,
-    "pool_acquire_timeouts": 9,
-    "pool_acquire_wait_time_total_ns": 10,
-    "pool_acquire_wait_time_max_ns": 11,
-    "pool_acquire_wait_time_last_ns": 12,
-    "connection_acquire_attempts": 13,
-    "connection_acquire_immediate": 14,
-    "connection_acquire_waited": 15,
-    "connection_acquire_timeouts": 16,
-    "connection_acquire_wait_time_total_ns": 17,
-    "connection_acquire_wait_time_max_ns": 18,
-    "connection_acquire_wait_time_last_ns": 19,
-    "response_body_reuse_eligible": 20,
-    "response_body_closed": 21,
-    "response_body_aborted": 22,
-    "active_connections": 23,
-    "idle_connections": 24,
-    "connections_opened": 25,
-    "connections_open_failed": 26,
-    "connections_closed": 27,
-    "connections_reused": 28,
-    "connections_aborted": 29,
-    "idle_timeout_evictions": 30,
-    "buffered_response_bytes": 31,
-    "buffered_response_budget_rejections": 32,
-    "schema_version": 33,
-    "snapshot_sequence": 34,
-}
+RAW_STATS_VALUES = MappingProxyType(
+    {
+        "active_requests": 1,
+        "pending_requests": 2,
+        "peak_pending_requests": 3,
+        "total_requests": 4,
+        "failed_requests": 5,
+        "pool_acquire_attempts": 6,
+        "pool_acquire_immediate": 7,
+        "pool_acquire_waited": 8,
+        "pool_acquire_timeouts": 9,
+        "pool_acquire_wait_time_total_ns": 10,
+        "pool_acquire_wait_time_max_ns": 11,
+        "pool_acquire_wait_time_last_ns": 12,
+        "connection_acquire_attempts": 13,
+        "connection_acquire_immediate": 14,
+        "connection_acquire_waited": 15,
+        "connection_acquire_timeouts": 16,
+        "connection_acquire_wait_time_total_ns": 17,
+        "connection_acquire_wait_time_max_ns": 18,
+        "connection_acquire_wait_time_last_ns": 19,
+        "response_body_reuse_eligible": 20,
+        "response_body_closed": 21,
+        "response_body_aborted": 22,
+        "active_connections": 23,
+        "idle_connections": 24,
+        "connections_opened": 25,
+        "connections_open_failed": 26,
+        "connections_closed": 27,
+        "connections_reused": 28,
+        "connections_aborted": 29,
+        "idle_timeout_evictions": 30,
+        "buffered_response_bytes": 31,
+        "buffered_response_budget_rejections": 32,
+        "schema_version": 33,
+        "snapshot_sequence": 34,
+    },
+)
 
 
 def test_raw_stats_values_cover_transport_stats_contract() -> None:


### PR DESCRIPTION
Add fail-closed source and installed-wheel smoke coverage for examples. Exercise sync and async clients against a loopback server across supported CPython versions.

Document reproducible benchmark evidence and release readiness requirements.

Closes #206