### PR TITLE
chore(security): configure dependency monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Zero disables routine version PRs, not repository-level security updates.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - "--autofix"
       - id: check-json
       - id: check-yaml
-        exclude: ^\.github/
+        exclude: ^\.github/workflows/
       - id: check-toml
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -99,6 +99,23 @@ FogHTTP currently makes several conservative choices:
 
 Security reports that weaken any of these guarantees are high priority.
 
+## Dependency Monitoring
+
+GitHub's dependency graph and Dependabot alerts monitor the Cargo and Python
+dependencies on `main`. Dependabot security updates are enabled for both
+ecosystems. The repository configuration uses `cargo` for `Cargo.toml` and
+`Cargo.lock`, and `uv` for `pyproject.toml` and `uv.lock`.
+
+Routine Dependabot version-update pull requests are intentionally disabled by
+setting `open-pull-requests-limit: 0` in `.github/dependabot.yml`. This does not
+disable security updates. A separate maintenance decision must define the
+cadence and triage policy before routine version updates are enabled.
+
+The project does not run `cargo audit` or `pip-audit` as mandatory pull-request
+checks. Any future repository audit starts as a scheduled or manually triggered
+workflow, with a triage and allowlist policy defined before it can block pull
+requests.
+
 ## Coordinated Disclosure
 
 The maintainer will make a best-effort attempt to:


### PR DESCRIPTION
Configure Dependabot security updates for Cargo and uv while keeping routine version-update pull requests disabled.

Validate the Dependabot YAML and document dependency monitoring and future audit-gate policy.

Closes #116