### PR TITLE
chore(release): complete 0.4.0 readiness audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,29 @@ jobs:
       - name: Run Rust tests
         run: cargo test --all-targets
 
+  rust-msrv:
+    name: Rust MSRV (1.88)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust MSRV
+        uses: dtolnay/rust-toolchain@1.88.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Show Rust version
+        run: rustc --version
+
+      - name: Run Rust tests at MSRV
+        run: cargo test --locked --all-targets
+
+      - name: Check release features at MSRV
+        run: cargo check --locked --all-targets --all-features
+
   abi3-wheel:
     name: Build and audit abi3 wheel
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 Thank you for taking the time to improve FogHTTP.
 
-FogHTTP is an early-stage HTTP client for Python with a Rust transport core. The
-project is intentionally focused: it is built for controlled service-to-service
-HTTP workloads where explicit lifecycle, predictable resource usage,
-cancellation, redirect safety, TLS trust boundaries, and request pressure
-visibility matter more than broad browser-like feature parity.
+FogHTTP is a focused pre-`0.5` HTTP client for Python with a Rust transport
+core. The project is intentionally focused: it is built for controlled
+service-to-service HTTP workloads where explicit lifecycle, predictable
+resource usage, cancellation, redirect safety, TLS trust boundaries, and
+request pressure visibility matter more than broad browser-like feature parity.
 
 The project values engineers who are interested in serious implementation work:
 debugging, measurement, API design, resource ownership, security boundaries, and

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   Rust-powered HTTP client for Python with sync and asyncio APIs.
 </p>
 
-FogHTTP is an early MVP HTTP client. The public API is Python-first, while the
-transport core is implemented in Rust on top of `hyper`.
+FogHTTP is a focused pre-`0.5` HTTP client. The public API is Python-first,
+while the transport core is implemented in Rust on top of `hyper`.
 
 FogHTTP is positioned as an observable, high-concurrency Rust-powered transport
 for Python services. It is built for controlled service-to-service HTTP

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -135,9 +135,9 @@ The following are usually out of scope unless they demonstrate a concrete
 FogHTTP vulnerability:
 
 - attacks that require arbitrary code execution in the caller process
-- reports about unsupported features such as proxy transport behavior, cookie
-  jar behavior, multipart uploads, or HTTP/2 unless the current code exposes
-  unsafe behavior
+- reports about unsupported features such as HTTP/2, SOCKS/PAC proxy routing,
+  TLS-to-proxy endpoints, browser-grade cookie policy, or streaming response
+  decompression unless the current code exposes unsafe behavior
 - denial-of-service reports that ignore documented response and request limits
 - issues caused only by intentionally disabling security in user application
   code outside FogHTTP

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -122,7 +122,7 @@ are not retained with the release evidence do not satisfy the artifact fields.
   used as strong all-client performance baselines until the reason is
   classified or rerun.
 
-## Current Source Snapshots
+## Latest Retained Source Snapshots
 
 Primary benchmark data source for this page:
 
@@ -132,13 +132,19 @@ Primary benchmark data source for this page:
   httpxyz `0.31.2`, zapros `0.13.0`.
 - Platform: `macOS-26.5.1-arm64-arm-64bit-Mach-O`.
 - Python: `3.14.0`.
+- Benchmark repository revision:
+  [`861e7cddf9134003c7079cb521def6892235c8d2`](https://github.com/AmberFog/FogHttpBenchmark/tree/861e7cddf9134003c7079cb521def6892235c8d2).
+
+This `0.3.5` snapshot is the latest retained full baseline, not evidence for a
+`0.4.0` release candidate. A `0.4.0` candidate must still satisfy the release
+smoke gate above at its own full commit SHA before publication.
 
 Historical comparison sources:
 
 | Role | Result directory | Use |
 | --- | --- | --- |
-| Current release run | `results/full-pypi-foghttp-0.3.5-settled-20260702-200414` | Primary FogHTTP `0.3.5` evidence after run-settling. |
-| Previous release baseline | `results/full-current-deps-foghttp-0.3.4-20260607-121844` | Matching-row comparison against FogHTTP `0.3.4` on the same primary host lineage. |
+| Latest retained full run | `results/full-pypi-foghttp-0.3.5-settled-20260702-200414` | Primary FogHTTP `0.3.5` evidence after run-settling. |
+| Matching comparison baseline | `results/full-current-deps-foghttp-0.3.4-20260607-121844` | Matching-row comparison against FogHTTP `0.3.4` on the same primary host lineage. |
 | Valid proxy/CONNECT baseline | `results/proxy-connect-0.3.4-isolated-full-20260607-213445` | Previous proxy/CONNECT baseline for stability comparison. |
 | Earlier 0.3.5 attempts | `results/full-pypi-foghttp-0.3.5-20260702-162612`, `results/full-pypi-foghttp-0.3.5-rerun-20260702-172113`, `results/full-pypi-foghttp-0.3.5-settled-20260702-183136` | Diagnostic evidence that run settling removed false FogHTTP error contamination in request-style suites. |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,15 +13,15 @@ features:
   - title: "Sync and async"
     details: "Use Client in scripts and workers, or AsyncClient for high-concurrency asyncio workloads."
 
-  - title: "Focused MVP"
+  - title: "Focused service client"
     details: "FogHTTP is intentionally small today: buffered responses with gzip/deflate/br decoding, sync and async bytes/text/line streaming, JSON, form-urlencoded data, streaming and multipart uploads, base URL clients, redirects, async cancellation, bounded request queues, explicit HTTP/1.1 connection caps, and transport diagnostics."
 ---
 
 # FogHTTP Documentation
 
-FogHTTP is currently an MVP. It is already useful for controlled HTTP workloads
-that use buffered request/response bodies, JSON and form APIs, streaming or
-multipart uploads, explicit client lifecycle, and predictable redirect behavior.
+FogHTTP is a focused pre-`0.5` client for controlled HTTP workloads that use
+buffered request/response bodies, JSON and form APIs, streaming or multipart
+uploads, explicit client lifecycle, and predictable redirect behavior.
 
 ## Positioning
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,7 +1,7 @@
 # Limitations
 
-FogHTTP is an MVP. It can already be useful, but it is not trying to be a full
-`httpx` replacement yet.
+FogHTTP is a focused pre-`0.5` client. It is not trying to be a full `httpx`
+replacement yet.
 
 For request-parameter compatibility with common Python HTTP clients, see
 [Request builder compatibility](./request-builder.md).
@@ -96,7 +96,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | Authentication | Basic credentials and synchronous callable header refresh are available through client-level `auth=`; async hooks, OAuth flows, and provider SDKs are not built in |
 | Disabling TLS verification | Not available by design; use `TLSConfig` with explicit CA certificates |
 | OS trust store integration | Not available; FogHTTP uses bundled WebPKI roots unless `trust_webpki_roots=False` is set |
-| HTTP/2 | Not available |
+| HTTP version selection | HTTP/1.1 is the only supported version. Omit `http_versions` or pass `http_versions=["HTTP/1.1"]`; any other non-empty selection raises `NotImplementedError`. HTTP/2 is not available. |
 | automatic `Accept-Encoding` negotiation | Not implemented; send `Accept-Encoding` manually when you want compressed responses |
 | transport-managed request headers | Safe API rejects manual `Host`, `Content-Length`, `Transfer-Encoding`, `TE`, `Trailer`, `Connection`, `Upgrade`, `Keep-Alive`, `Proxy-Connection`, and `Proxy-Authorization` |
 | request body source conflicts | Use one body source among `json=`, `data=`, `content=`, and `files=`; `files=` can include form fields from mapping or repeated-pair `data=` |
@@ -105,7 +105,7 @@ try to keep public interfaces stable and avoid unnecessary breaking changes.
 | per-request connect timeout changes | `Timeouts.connect` configures the Rust connector from client-level settings when transport state is created; per-request `timeout.connect` does not reconfigure the connector |
 | separate read/write timeout semantics | `Timeouts.read` is implemented as a buffered and streamed response body progress timeout; `Timeouts.write` is implemented for buffered request body write progress and streaming upload chunk/write progress |
 | socket lifecycle telemetry granularity | `TransportStats` and `dump_transport_state()["origins"]` expose opened, open-failed, closed, reused, aborted, idle-timeout eviction, active, and idle tracked connection counters for the current HTTP/1 path; dedicated failed-reuse and close-reason taxonomy are not exposed yet because current connector hooks do not provide a stable reason signal |
-| telemetry hook granularity | `TelemetryConfig` currently dispatches Python-level request/response lifecycle events; lower-level Rust pool acquire and connection lifecycle event delivery is planned before Prometheus/OpenTelemetry exporters |
+| telemetry hook granularity | `TelemetryConfig` dispatches request/response events plus lower-level Rust pool-acquire and HTTP/1 connection lifecycle events from a bounded best-effort native journal. Prometheus/OpenMetrics adapters are available; OpenTelemetry integration is not built in. |
 | transport policy hook execution | `TransportPolicyHooks` callbacks are synchronous, inline, non-reentrant, and may run on Rust transport worker threads; `after_response_body` observes only redirect bodies consumed internally, not the final response body returned to the caller |
 | retry scope | Retry is client-level and opt-in. It covers configured response statuses and pre-header `NetworkError` only; response-body errors, FogHTTP timeouts, local upload-provider failures, auth-hook failures, hedging, and circuit breaking are not retried. Auth headers are refreshed before a retry selected for a supported transport outcome. |
 | SSRF protection scope | `SSRFPolicy` is client-level and opt-in. It validates initial and redirected destinations plus every resolved address, but it is not a replacement for network egress policy. Proxy routes fail closed because a remote proxy can resolve the target independently. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -147,6 +147,20 @@ Absolute request URLs ignore `base_url`.
 `base_url` must not include query parameters or a fragment. Use client-level or
 per-request `params=` for query parameters.
 
+## HTTP Version Selection
+
+Both clients use HTTP/1.1. Omit `http_versions` for the default behavior, or
+pass the only supported explicit selection:
+
+```python
+with foghttp.Client(http_versions=["HTTP/1.1"]) as client:
+    response = client.get("https://httpbin.org/get")
+```
+
+Any other non-empty selection raises `NotImplementedError`; HTTP/2 is not
+implemented. The public `HttpVersion` and `HttpVersions` aliases are available
+from `foghttp.types` for wrappers that expose this option.
+
 ## Default Headers
 
 Use client-level `headers=` for values that should be sent with every request
@@ -636,6 +650,7 @@ limits = foghttp.Limits(
     max_response_body_size=10 * 1024 * 1024,
     max_buffered_response_bytes=100 * 1024 * 1024,
     idle_timeout=30.0,
+    keepalive=True,
 )
 
 timeouts = foghttp.Timeouts(
@@ -659,9 +674,10 @@ response and raises `ReadTimeout` when body progress stalls.
 Timeout exceptions include a safe `diagnostic` object when FogHTTP can identify
 the phase, elapsed time, configured budget, normalized origin, and redirect hop.
 
-`Limits.max_active_requests` caps active buffered requests for the whole client.
+`Limits.max_active_requests` caps active transport requests for the whole
+client. A streaming request holds its slot until clean EOF or close.
 `Limits.max_active_requests_per_origin` defaults to `None`; set it to cap active
-buffered requests for one normalized origin. `Limits.max_pending_requests` caps
+transport requests for one normalized origin. `Limits.max_pending_requests` caps
 requests waiting in the Rust-side FIFO acquire queue. `Limits.max_response_body_size`
 defaults to `10 * 1024 * 1024` bytes and protects one response.
 `Limits.max_connections` defaults to `None`; set it to add an explicit global
@@ -683,6 +699,8 @@ under concurrency.
 `Limits.max_idle_connections_per_host` controls idle keep-alive pool capacity;
 it is not an active connection cap and is separate from request-slot and
 connection-slot backpressure.
+`Limits.keepalive` defaults to `True`; set it to `False` to prevent completed
+HTTP/1.1 connections from returning to the idle pool for reuse.
 
 `TransportStats.buffered_response_bytes` reports currently reserved in-flight
 buffered body bytes. `TransportStats.buffered_response_budget_rejections`

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -72,10 +72,10 @@ except foghttp.TimeoutError as exc:
 ```
 
 Current diagnostic phases are `pool_acquire`, `connection_acquire`,
-`response_headers`, `response_body`, and `request_body`; the exported
-`TimeoutPhase` type matches this current emitted set. The `origin` field is
-normalized and never includes path, query, userinfo, headers, or body data.
-`elapsed` and `timeout` are seconds, and `redirect_hop` is zero-based.
+`request_body`, `retry_backoff`, `response_headers`, and `response_body`; the
+exported `TimeoutPhase` type matches this current emitted set. The `origin`
+field is normalized and never includes path, query, userinfo, headers, or body
+data. `elapsed` and `timeout` are seconds, and `redirect_hop` is zero-based.
 
 ## Client Defaults And Request Overrides
 

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -16,6 +16,11 @@ Concrete `Request`, `RequestInfo`, `Response`, `StreamResponse`, and
 `AsyncStreamResponse` objects satisfy the applicable protocols without
 inheriting from them.
 
+Client wrappers can also import `HttpVersion` and `HttpVersions` from
+`foghttp.types`. The current literal domain contains only `"HTTP/1.1"`, matching
+the explicit `Client` and `AsyncClient` `http_versions=` option; HTTP/2 is not
+implemented.
+
 ## Request And Response Protocols
 
 | Protocol | Stable surface |

--- a/examples/http_proxy.py
+++ b/examples/http_proxy.py
@@ -22,12 +22,13 @@ def main() -> None:
 
     with foghttp.Client(proxy=proxy) as client:
         response = client.get(target_url)
-        response.raise_for_status()
 
-        print("proxy:", proxy or "direct")
-        print("target:", target_url)
+        print("proxy:", "configured" if proxy is not None else "direct")
+        print("target origin:", foghttp.URL(response.request.url).origin)
         print("status:", response.status_code)
-        print("request:", response.request.method, response.request.url)
+        print("request method:", response.request.method)
+        if response.is_error:
+            raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/foghttp/messages.py
+++ b/foghttp/messages.py
@@ -45,7 +45,7 @@ BODY_PARAMETER_CONFLICT = (
 )
 CLIENT_CLOSED = "FogHTTP client is closed"
 CONNECTION_ACQUIRE_TIMEOUT = "connection acquire timeout expired"
-HTTP_VERSION_UNSUPPORTED = "only HTTP/1.1 is supported in the MVP"
+HTTP_VERSION_UNSUPPORTED = "only HTTP/1.1 is currently supported"
 MAX_REDIRECTS_INVALID = "max_redirects must be greater than or equal to 0"
 MULTIPART_DATA_UNSUPPORTED = "files can only be combined with mapping or repeated-pair form data"
 MULTIPART_FILE_FACTORY_MIX_UNSUPPORTED = (

--- a/tests/examples/test_imports.py
+++ b/tests/examples/test_imports.py
@@ -4,9 +4,11 @@ import py_compile
 import sys
 from types import ModuleType
 import unittest
+from unittest.mock import create_autospec
 
 import pytest
 
+import foghttp
 from scripts.wheel_smoke_runtime import discover_examples, loopback_server_url, run_example
 
 
@@ -216,3 +218,77 @@ def test_example_imports_without_running_main(example_path: Path) -> None:
     assert module.__name__ != "__main__"
     assert module.__spec__ is not None
     assert module.__spec__.name == module.__name__
+
+
+@pytest.mark.parametrize(
+    ("status_code", "exit_code"),
+    [
+        pytest.param(200, None, id="success"),
+        pytest.param(404, 1, id="error"),
+    ],
+)
+def test_http_proxy_example_redacts_output(
+    status_code: int,
+    exit_code: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    proxy_sentinel = "proxy-password-sentinel"
+    userinfo_sentinel = "target-userinfo-sentinel"
+    path_sentinel = "target-path-sentinel"
+    query_sentinel = "target-query-sentinel"
+    proxy = f"http://user:{proxy_sentinel}@proxy.example:8080"
+    target = f"https://user:{userinfo_sentinel}@example.com/{path_sentinel}?code={query_sentinel}"
+    module = run_example(EXAMPLES_DIR / "http_proxy.py")
+    response = foghttp.Response(
+        status_code=status_code,
+        headers=foghttp.Headers(),
+        content=b"",
+        url=target,
+        request=foghttp.RequestInfo(
+            method="GET",
+            url=target,
+            headers=foghttp.Headers(),
+        ),
+        http_version="HTTP/1.1",
+        elapsed=0.0,
+    )
+    client = create_autospec(foghttp.Client, instance=True, spec_set=True)
+    client.__enter__.return_value = client
+    client.__exit__.return_value = False
+    client.get.return_value = response
+    client_factory = create_autospec(foghttp.Client, return_value=client)
+    monkeypatch.setattr(module.foghttp, "Client", client_factory)
+    monkeypatch.setenv("FOGHTTP_HTTP_PROXY", proxy)
+    monkeypatch.setenv("FOGHTTP_PROXY_TARGET_URL", target)
+
+    if exit_code is None:
+        module.main()
+    else:
+        with pytest.raises(SystemExit) as error_info:
+            module.main()
+        assert error_info.value.code == exit_code
+
+    captured = capsys.readouterr()
+    output = captured.out
+    assert proxy_sentinel not in output
+    assert userinfo_sentinel not in output
+    assert path_sentinel not in output
+    assert query_sentinel not in output
+    assert "proxy: configured" in output
+    assert "target origin: https://example.com" in output
+    assert f"status: {status_code}" in output
+    assert "request method: GET" in output
+    assert captured.err == ""
+    client_factory.assert_called_once_with(proxy=proxy)
+    client.get.assert_called_once_with(target)
+    client.__enter__.assert_called_once_with()
+    client.__exit__.assert_called_once()
+    if exit_code is None:
+        client.__exit__.assert_called_once_with(None, None, None)
+    else:
+        exit_type, exit_value, exit_traceback = client.__exit__.call_args.args
+        assert exit_type is SystemExit
+        assert isinstance(exit_value, SystemExit)
+        assert exit_value.code == exit_code
+        assert exit_traceback is not None

--- a/tests/test_client_options.py
+++ b/tests/test_client_options.py
@@ -35,7 +35,7 @@ def test_client_accepts_opt_in_cookies() -> None:
 
 
 def test_client_rejects_unsupported_http_versions() -> None:
-    with pytest.raises(NotImplementedError, match=r"only HTTP/1\.1 is supported in the MVP"):
+    with pytest.raises(NotImplementedError, match=r"only HTTP/1\.1 is currently supported"):
         foghttp.Client(http_versions=["HTTP/2"])
 
 


### PR DESCRIPTION
- align public documentation with the current API and limitations
- prevent credential and target URL leakage in the proxy example
- add Rust 1.88 MSRV and release-feature CI checks
- clarify benchmark and release evidence boundaries

Refs #192