### PR TITLE
chore(release): prepare 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "brotli",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foghttp"
-version = "0.3.9"
+version = "0.4.0"
 description = "Observable Rust-powered HTTP client for Python services."
 edition = "2021"
 rust-version = "1.88"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "foghttp"
-version = "0.3.9"
+version = "0.4.0"
 description = "Observable Rust-powered HTTP client for Python services."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "foghttp"
-version = "0.3.9"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
Bump Python and Rust package versions to 0.4.0.
Synchronize Cargo and uv lockfile package metadata.

Refs #198