### PR TITLE
perf(url): reduce origin formatting allocations

### DIFF
--- a/src/core/url/constants.rs
+++ b/src/core/url/constants.rs
@@ -1,9 +1,6 @@
 pub(super) const HTTP_SCHEME: &str = "http";
 pub(super) const HTTPS_SCHEME: &str = "https";
 
-pub(super) const HTTP_DEFAULT_PORT: u16 = 80;
-pub(super) const HTTPS_DEFAULT_PORT: u16 = 443;
-
 pub(super) const INVALID_SCHEME_ERROR: &str = "URL scheme must be http or https";
 pub(super) const MISSING_HOST_ERROR: &str = "URL must include a host";
 
@@ -11,5 +8,3 @@ pub(super) const VALIDATED_URL_HOST_EXPECTATION: &str =
     "validated HTTP URL should always include host";
 pub(super) const VALIDATED_URL_PORT_EXPECTATION: &str =
     "validated HTTP URL should always include port";
-pub(super) const VALIDATED_URL_SCHEME_EXPECTATION: &str =
-    "validated HTTP URL should only use http or https";

--- a/src/core/url/mod.rs
+++ b/src/core/url/mod.rs
@@ -2,7 +2,7 @@ mod constants;
 mod origin;
 mod scheme;
 
-use url::Url;
+use url::{Position, Url};
 
 #[derive(Clone, Debug)]
 pub struct HttpUrl {
@@ -68,7 +68,11 @@ impl HttpUrl {
     }
 
     pub fn origin(&self) -> String {
-        origin::format_origin(self.scheme(), &self.host(), self.port())
+        format!(
+            "{}://{}",
+            self.scheme(),
+            &self.inner[Position::BeforeHost..Position::AfterPort],
+        )
     }
 
     pub fn join(&self, location: &str) -> Result<Self, String> {

--- a/src/core/url/origin.rs
+++ b/src/core/url/origin.rs
@@ -1,5 +1,3 @@
-use super::scheme;
-
 #[derive(Clone, Copy)]
 pub(super) struct OriginRef<'a> {
     scheme: &'a str,
@@ -15,19 +13,4 @@ impl<'a> OriginRef<'a> {
     pub(super) fn is_same(self, other: Self) -> bool {
         self.scheme == other.scheme && self.host == other.host && self.port == other.port
     }
-}
-
-pub(super) fn format_origin(scheme: &str, host: &str, port: u16) -> String {
-    let mut netloc = host_netloc(host);
-    if port != scheme::default_port(scheme) {
-        netloc = format!("{netloc}:{port}");
-    }
-    format!("{scheme}://{netloc}")
-}
-
-fn host_netloc(host: &str) -> String {
-    if host.contains(':') && !host.starts_with('[') {
-        return format!("[{host}]");
-    }
-    host.to_owned()
 }

--- a/src/core/url/scheme.rs
+++ b/src/core/url/scheme.rs
@@ -1,16 +1,5 @@
-use super::constants::{
-    HTTPS_DEFAULT_PORT, HTTPS_SCHEME, HTTP_DEFAULT_PORT, HTTP_SCHEME,
-    VALIDATED_URL_SCHEME_EXPECTATION,
-};
+use super::constants::{HTTPS_SCHEME, HTTP_SCHEME};
 
 pub(super) fn is_supported(scheme: &str) -> bool {
     matches!(scheme, HTTP_SCHEME | HTTPS_SCHEME)
-}
-
-pub(super) fn default_port(scheme: &str) -> u16 {
-    match scheme {
-        HTTP_SCHEME => HTTP_DEFAULT_PORT,
-        HTTPS_SCHEME => HTTPS_DEFAULT_PORT,
-        _ => unreachable!("{}", VALIDATED_URL_SCHEME_EXPECTATION),
-    }
 }

--- a/src/core/url/tests.rs
+++ b/src/core/url/tests.rs
@@ -14,6 +14,39 @@ fn parses_and_normalizes_http_url() {
 }
 
 #[test]
+fn origin_preserves_normalization_without_url_secrets() {
+    let cases = [
+        (
+            "HTTPS://Example.COM:443/path?q=1#part",
+            "https://example.com",
+        ),
+        (
+            "http://user:p%40ss@Example.COM:80/private?token=value#part", // pragma: allowlist secret
+            "http://example.com",
+        ),
+        (
+            "https://user:pass@Example.COM:8443/private", // pragma: allowlist secret
+            "https://example.com:8443",
+        ),
+        ("http://127.0.0.1:8080/path", "http://127.0.0.1:8080"),
+        ("http://[::1]:80/path", "http://[::1]"),
+        (
+            "https://user:pass@[2001:0DB8::1]:8443/private?token=value", // pragma: allowlist secret
+            "https://[2001:db8::1]:8443",
+        ),
+        (
+            "https://b\u{00fc}cher.example/path",
+            "https://xn--bcher-kva.example",
+        ),
+        ("http://example.com:0/path", "http://example.com:0"),
+    ];
+
+    for (input, expected) in cases {
+        assert_eq!(HttpUrl::parse(input).unwrap().origin(), expected);
+    }
+}
+
+#[test]
 fn joins_relative_locations() {
     let url = HttpUrl::parse("https://example.com/users/current/profile").unwrap();
 


### PR DESCRIPTION
- reuse normalized host and port slices from url::Url
- remove redundant formatting helpers and constants
- test origin normalization and exclusion of URL secrets