### PR TITLE
fix(pool): release idle connection capacity on timeout

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -570,11 +570,17 @@ but its pressure is reported through `connection_acquire_*` rather than
 handle and is released when Hyper drops that physical connection. Idle
 keep-alive connections therefore count against explicit connection caps until
 they are reused, closed, or removed by transport pool cleanup.
-`Limits.idle_timeout` configures idle pool expiry, but it should not be treated
-as a precise cross-origin release timer. Idle keep-alive capacity remains
-controlled separately by `Limits.max_idle_connections_per_host`; if the idle
-pool setting is larger than an explicit connection cap, the connection cap is
+For a positive finite `Limits.idle_timeout`, Hyper periodically removes expired
+idle connections even when no further request targets their origin. This also
+releases their physical connection permits for requests to other origins.
+Cleanup is periodic, not a precise cross-origin release timer; a shorter
+`Timeouts.pool` can still expire before capacity is released. Connection-cap
+pressure does not evict idle connections before their timeout. Idle keep-alive
+capacity remains controlled separately by `Limits.max_idle_connections_per_host`;
+if the idle pool setting is larger than an explicit connection cap, the connection cap is
 still the hard upper bound on tracked physical connections.
+With `Limits.idle_timeout=0`, completed connections are not retained in the idle
+pool, so releasing their permits does not require a later request or cleanup tick.
 
 The response body lifecycle counters describe FogHTTP's Rust-side body
 contract for buffered and streamed response bodies. Socket lifecycle counters

--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -33,6 +33,7 @@ use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::connect::dns::GaiResolver;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioTimer;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -132,11 +133,12 @@ where
     );
 
     let mut builder = Client::builder(executor);
-    builder.pool_max_idle_per_host(if options.keepalive {
+    builder.pool_max_idle_per_host(if options.keepalive && !idle_timeout.is_zero() {
         options.max_idle_connections_per_host
     } else {
         0
     });
     builder.pool_idle_timeout(idle_timeout);
+    builder.pool_timer(TokioTimer::new());
     Ok(builder.build(connector))
 }

--- a/tests/client_keepalive/conftest.py
+++ b/tests/client_keepalive/conftest.py
@@ -12,6 +12,13 @@ def keepalive_http_server() -> Iterator[KeepAliveServer]:
 
 
 @pytest.fixture
+def idle_timeout_http_server() -> Iterator[KeepAliveServer]:
+    # A server-side timeout must not satisfy client-side pool expiry tests.
+    with start_keepalive_server(socket_timeout=None) as server:
+        yield server
+
+
+@pytest.fixture
 def early_close_keepalive_http_server() -> Iterator[KeepAliveServer]:
     with start_keepalive_server(disconnect_after_response=True) as server:
         yield server

--- a/tests/client_keepalive/server.py
+++ b/tests/client_keepalive/server.py
@@ -62,10 +62,15 @@ class KeepAliveServer:
         self.close()
 
 
-def start_keepalive_server(*, disconnect_after_response: bool = False) -> KeepAliveServer:
+def start_keepalive_server(
+    *,
+    disconnect_after_response: bool = False,
+    socket_timeout: float | None = SOCKET_TIMEOUT,
+) -> KeepAliveServer:
     state = KeepAliveState()
     server = KeepAliveTCPServer((SERVER_HOST, 0), KeepAliveHTTPHandler)
     server.disconnect_after_response = disconnect_after_response
+    server.socket_timeout = socket_timeout
     server.state = state
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -76,14 +81,15 @@ class KeepAliveTCPServer(ThreadingTCPServer):
     allow_reuse_address = True
     daemon_threads = True
     disconnect_after_response: bool
+    socket_timeout: float | None
     state: "KeepAliveState"
 
 
 class KeepAliveHTTPHandler(BaseRequestHandler):
     def handle(self) -> None:
         connection = cast("socket", self.request)
-        connection.settimeout(SOCKET_TIMEOUT)
         server = cast("KeepAliveTCPServer", self.server)
+        connection.settimeout(server.socket_timeout)
         connection_id = server.state.register_connection()
         pending = b""
 

--- a/tests/client_keepalive/test_async_keepalive.py
+++ b/tests/client_keepalive/test_async_keepalive.py
@@ -2,6 +2,7 @@ from collections.abc import AsyncIterator
 from functools import partial
 from io import BytesIO
 import json
+from typing import Literal
 
 import pytest
 
@@ -15,6 +16,8 @@ from tests.client_multipart.sources import (
     FailsWhenReadPastExactLengthFile,
     TrackedFactory,
 )
+from tests.client_streaming.constants import FIRST_CHUNK, GATED_STREAM_PATH, SECOND_CHUNK
+from tests.client_streaming.server import start_async_streaming_server
 from tests.client_upload.helpers import DelayedCloseEmptyFile, MisreportedLengthFile
 from tests.support.transport_state import wait_for_async_transport_state
 from tests.support.transport_stats import wait_for_async_transport_stats
@@ -339,7 +342,7 @@ async def test_async_transport_state_reports_idle_connection_detail(
 
 
 async def test_async_idle_timeout_eviction_is_reported(
-    keepalive_http_server: KeepAliveServer,
+    idle_timeout_http_server: KeepAliveServer,
 ) -> None:
     limits = foghttp.Limits(
         keepalive=True,
@@ -348,12 +351,7 @@ async def test_async_idle_timeout_eviction_is_reported(
     )
 
     async with foghttp.AsyncClient(limits=limits) as client:
-        response = await client.get(keepalive_http_server.url + KEEPALIVE_PATH)
-        await wait_for_async_transport_stats(
-            client,
-            lambda stats: stats.idle_connections == 1,
-            message="expected reusable connection to enter the idle pool",
-        )
+        response = await client.get(idle_timeout_http_server.url + KEEPALIVE_PATH)
         await wait_for_async_transport_stats(
             client,
             is_idle_timeout_eviction_reported,
@@ -362,13 +360,64 @@ async def test_async_idle_timeout_eviction_is_reported(
         stats = client.stats()
         state = client.dump_transport_state()
 
-    origin_state = state["origins"][keepalive_http_server.url]
+    origin_state = state["origins"][idle_timeout_http_server.url]
 
     assert response.status_code == OK
     assert stats.connections_closed == 1
     assert stats.idle_timeout_evictions == 1
     assert origin_state["connections_closed"] == 1
     assert origin_state["idle_timeout_evictions"] == 1
+
+
+@pytest.mark.parametrize("idle_timeout", [0.0, IDLE_TIMEOUT_SECONDS])
+@pytest.mark.parametrize("runtime", ["shared", "dedicated"])
+async def test_async_idle_timeout_releases_connection_cap_for_another_origin(
+    idle_timeout_http_server: KeepAliveServer,
+    keepalive_http_server: KeepAliveServer,
+    idle_timeout: float,
+    runtime: Literal["shared", "dedicated"],
+) -> None:
+    limits = foghttp.Limits(
+        max_connections=1,
+        max_connections_per_host=1,
+        max_idle_connections_per_host=1,
+        idle_timeout=idle_timeout,
+    )
+    timeouts = foghttp.Timeouts(pool=2.0, total=3.0)
+
+    async with foghttp.AsyncClient(limits=limits, timeouts=timeouts, runtime=runtime, trust_env=False) as client:
+        first = await client.get(idle_timeout_http_server.url + KEEPALIVE_PATH)
+        second = await client.get(keepalive_http_server.url + KEEPALIVE_PATH)
+        stats = client.stats()
+        origin = client.dump_transport_state()["origins"][idle_timeout_http_server.url]
+
+    assert first.status_code == OK
+    assert second.status_code == OK
+    assert stats.connections_opened == EXPECTED_DISTINCT_CONNECTIONS
+    assert stats.connection_acquire_timeouts == 0
+    assert origin["connections_closed"] == 1
+    assert idle_timeout_http_server.snapshot().request_count == 1
+
+
+async def test_async_idle_cleanup_preserves_active_stream(
+    idle_timeout_http_server: KeepAliveServer,
+) -> None:
+    limits = foghttp.Limits(idle_timeout=IDLE_TIMEOUT_SECONDS)
+
+    async with start_async_streaming_server() as server, foghttp.AsyncClient(limits=limits, trust_env=False) as client:
+        async with client.stream(GET, server.base_url + GATED_STREAM_PATH) as stream:
+            assert (await client.get(idle_timeout_http_server.url + KEEPALIVE_PATH)).status_code == OK
+            await wait_for_async_transport_stats(
+                client,
+                lambda stats: stats.idle_timeout_evictions == 1,
+                message="expected idle cleanup while the stream is active",
+            )
+            assert client.stats().active_requests == 1
+            assert client.stats().active_connections == 1
+            server.release_tail.set()
+            assert b"".join([chunk async for chunk in stream.aiter_bytes()]) == FIRST_CHUNK + SECOND_CHUNK
+
+        assert client.stats().failed_requests == 0
 
 
 async def test_async_early_remote_idle_close_is_not_idle_timeout_eviction(

--- a/tests/client_keepalive/test_sync_keepalive.py
+++ b/tests/client_keepalive/test_sync_keepalive.py
@@ -1,9 +1,11 @@
 from functools import partial
 from io import BytesIO
+from typing import Literal
 
 import pytest
 
 import foghttp
+from foghttp.methods import GET
 from foghttp.status_codes.redirect import PERMANENT_REDIRECT, TEMPORARY_REDIRECT
 from foghttp.status_codes.success import OK
 from tests.client_multipart.sources import (
@@ -12,6 +14,8 @@ from tests.client_multipart.sources import (
     SyncChunks,
     TrackedFactory,
 )
+from tests.client_streaming.constants import FIRST_CHUNK, GATED_STREAM_PATH, SECOND_CHUNK
+from tests.client_streaming.server import start_sync_streaming_server
 from tests.client_upload.helpers import DelayedCloseEmptyFile, MisreportedLengthFile
 from tests.support.transport_state import wait_for_sync_transport_state
 from tests.support.transport_stats import wait_for_sync_transport_stats
@@ -310,7 +314,7 @@ def test_sync_transport_state_reports_idle_connection_detail(
 
 
 def test_sync_idle_timeout_eviction_is_reported(
-    keepalive_http_server: KeepAliveServer,
+    idle_timeout_http_server: KeepAliveServer,
 ) -> None:
     limits = foghttp.Limits(
         keepalive=True,
@@ -319,12 +323,7 @@ def test_sync_idle_timeout_eviction_is_reported(
     )
 
     with foghttp.Client(limits=limits) as client:
-        response = client.get(keepalive_http_server.url + KEEPALIVE_PATH)
-        wait_for_sync_transport_stats(
-            client,
-            lambda stats: stats.idle_connections == 1,
-            message="expected reusable connection to enter the idle pool",
-        )
+        response = client.get(idle_timeout_http_server.url + KEEPALIVE_PATH)
         wait_for_sync_transport_stats(
             client,
             is_idle_timeout_eviction_reported,
@@ -333,13 +332,64 @@ def test_sync_idle_timeout_eviction_is_reported(
         stats = client.stats()
         state = client.dump_transport_state()
 
-    origin_state = state["origins"][keepalive_http_server.url]
+    origin_state = state["origins"][idle_timeout_http_server.url]
 
     assert response.status_code == OK
     assert stats.connections_closed == 1
     assert stats.idle_timeout_evictions == 1
     assert origin_state["connections_closed"] == 1
     assert origin_state["idle_timeout_evictions"] == 1
+
+
+@pytest.mark.parametrize("idle_timeout", [0.0, IDLE_TIMEOUT_SECONDS])
+@pytest.mark.parametrize("runtime", ["shared", "dedicated"])
+def test_sync_idle_timeout_releases_connection_cap_for_another_origin(
+    idle_timeout_http_server: KeepAliveServer,
+    keepalive_http_server: KeepAliveServer,
+    idle_timeout: float,
+    runtime: Literal["shared", "dedicated"],
+) -> None:
+    limits = foghttp.Limits(
+        max_connections=1,
+        max_connections_per_host=1,
+        max_idle_connections_per_host=1,
+        idle_timeout=idle_timeout,
+    )
+    timeouts = foghttp.Timeouts(pool=2.0, total=3.0)
+
+    with foghttp.Client(limits=limits, timeouts=timeouts, runtime=runtime, trust_env=False) as client:
+        first = client.get(idle_timeout_http_server.url + KEEPALIVE_PATH)
+        second = client.get(keepalive_http_server.url + KEEPALIVE_PATH)
+        stats = client.stats()
+        origin = client.dump_transport_state()["origins"][idle_timeout_http_server.url]
+
+    assert first.status_code == OK
+    assert second.status_code == OK
+    assert stats.connections_opened == EXPECTED_DISTINCT_CONNECTIONS
+    assert stats.connection_acquire_timeouts == 0
+    assert origin["connections_closed"] == 1
+    assert idle_timeout_http_server.snapshot().request_count == 1
+
+
+def test_sync_idle_cleanup_preserves_active_stream(
+    idle_timeout_http_server: KeepAliveServer,
+) -> None:
+    limits = foghttp.Limits(idle_timeout=IDLE_TIMEOUT_SECONDS)
+
+    with start_sync_streaming_server() as server, foghttp.Client(limits=limits, trust_env=False) as client:
+        with client.stream(GET, server.base_url + GATED_STREAM_PATH) as stream:
+            assert client.get(idle_timeout_http_server.url + KEEPALIVE_PATH).status_code == OK
+            wait_for_sync_transport_stats(
+                client,
+                lambda stats: stats.idle_timeout_evictions == 1,
+                message="expected idle cleanup while the stream is active",
+            )
+            assert client.stats().active_requests == 1
+            assert client.stats().active_connections == 1
+            server.release_tail.set()
+            assert b"".join(stream.iter_bytes()) == FIRST_CHUNK + SECOND_CHUNK
+
+        assert client.stats().failed_requests == 0
 
 
 def test_sync_early_remote_idle_close_is_not_idle_timeout_eviction(


### PR DESCRIPTION
- Enable periodic idle cleanup using Hyper's Tokio timer
- Disable idle connection retention when idle_timeout is zero
- Cover cross-origin cap release and active stream safety in sync/async tests
- Document periodic cleanup and zero-timeout behavior