### PR TITLE
refactor(core): separate Rust errors from PyO3 bindings

### DIFF
--- a/docs/pyo3-boundary.md
+++ b/docs/pyo3-boundary.md
@@ -27,6 +27,24 @@ runtime shutdown, close/aclose, or asyncio future integration.
 - If raw close ever becomes blocking, `AsyncClient.aclose()` needs an
   async-safe shutdown path instead of doing blocking teardown on the event loop.
 
+## Core Error Boundary
+
+`src/core` does not construct or carry Python exceptions. Request/header
+validation returns the existing `hyper::http::Error`, retaining its concrete
+parser error through `get_ref()`. Buffered collection, memory reservations and
+decompression return `ResponseBodyError`; decoding errors retain their I/O
+source and resource errors retain their category and configured limit.
+
+The transport binding maps these errors to the existing native exceptions.
+Do not use a generic I/O-to-Python conversion: decoding failures are request
+errors, not retryable network errors. Size and aggregate-budget failures keep
+their distinct exception classes. This conversion does not change reservation
+rollback, connection completion, or the read-error-only raw-deflate fallback.
+
+Core error-path tests must not initialize or attach to Python. Binding tests
+verify the native and public exception mapping separately. This separation
+does not make the extension crate's build/link toolchain Python-independent.
+
 ## Streaming Rules
 
 Streaming adds repeated Python/Rust handoff, so it needs stricter review than

--- a/src/core/headers/request.rs
+++ b/src/core/headers/request.rs
@@ -1,17 +1,14 @@
 use super::HeaderPairs;
-use crate::errors::FogHttpError;
 use hyper::header::{HeaderMap, HeaderName, HeaderValue};
-use pyo3::prelude::*;
+use hyper::http::Error;
 use std::str::FromStr;
 
-pub fn request_headers(headers: HeaderPairs) -> PyResult<HeaderMap> {
+pub fn request_headers(headers: HeaderPairs) -> Result<HeaderMap, Error> {
     let mut header_map = HeaderMap::new();
 
     for (name, value) in headers {
-        let header_name =
-            HeaderName::from_str(&name).map_err(|err| FogHttpError::new_err(err.to_string()))?;
-        let header_value =
-            HeaderValue::from_str(&value).map_err(|err| FogHttpError::new_err(err.to_string()))?;
+        let header_name = HeaderName::from_str(&name)?;
+        let header_value = HeaderValue::from_str(&value)?;
         header_map.append(header_name, header_value);
     }
 

--- a/src/core/headers/tests.rs
+++ b/src/core/headers/tests.rs
@@ -2,6 +2,19 @@ use super::{request_headers, response_headers};
 use hyper::header::{HeaderMap, HeaderName, HeaderValue};
 
 #[test]
+fn request_headers_retain_invalid_name_and_value_errors() {
+    let name_error = request_headers(vec![("bad name".to_owned(), "value".to_owned())])
+        .expect_err("invalid header name");
+    assert!(name_error.is::<hyper::header::InvalidHeaderName>());
+    assert_eq!(name_error.to_string(), name_error.get_ref().to_string());
+
+    let value_error = request_headers(vec![("x-test".to_owned(), "bad\r\nvalue".to_owned())])
+        .expect_err("invalid header value");
+    assert!(value_error.is::<hyper::header::InvalidHeaderValue>());
+    assert_eq!(value_error.to_string(), value_error.get_ref().to_string());
+}
+
+#[test]
 fn request_headers_preserve_repeated_values() {
     let headers = request_headers(vec![
         ("x-repeat".to_owned(), "first".to_owned()),

--- a/src/core/request.rs
+++ b/src/core/request.rs
@@ -3,10 +3,9 @@ use crate::core::client::{
     RequestWriteTimeoutContext, UploadBodyReceiver,
 };
 use crate::core::headers::{request_headers, HeaderPairs};
-use crate::errors::FogHttpError;
 use hyper::header::{HeaderValue, PROXY_AUTHORIZATION};
+use hyper::http::Error;
 use hyper::{Method, Request, Uri};
-use pyo3::prelude::*;
 use std::str::FromStr;
 
 pub struct RequestParts {
@@ -28,10 +27,9 @@ pub enum RequestBodyParts {
 pub fn build_request(
     parts: RequestParts,
     write_timeout: Option<RequestWriteTimeoutContext>,
-) -> PyResult<(Request<RequestBody>, RequestBodyCompletion)> {
-    let method = Method::from_bytes(parts.method.as_bytes())
-        .map_err(|err| FogHttpError::new_err(err.to_string()))?;
-    let uri = Uri::from_str(&parts.url).map_err(|err| FogHttpError::new_err(err.to_string()))?;
+) -> Result<(Request<RequestBody>, RequestBodyCompletion), Error> {
+    let method = Method::from_bytes(parts.method.as_bytes())?;
+    let uri = Uri::from_str(&parts.url)?;
     let (body, body_completion) = match parts.body {
         RequestBodyParts::Buffered(content) => buffered_request_body(content),
         RequestBodyParts::Streaming {
@@ -39,17 +37,81 @@ pub fn build_request(
             content_length,
         } => streaming_request_body(receiver, content_length, write_timeout),
     };
-    let mut request = Request::builder()
-        .method(method)
-        .uri(uri)
-        .body(body)
-        .map_err(|err| FogHttpError::new_err(err.to_string()))?;
+    let mut request = Request::builder().method(method).uri(uri).body(body)?;
 
     *request.headers_mut() = request_headers(parts.headers)?;
     if let Some(proxy_authorization) = parts.proxy_authorization {
-        let value = HeaderValue::from_str(&proxy_authorization)
-            .map_err(|err| FogHttpError::new_err(err.to_string()))?;
+        let value = HeaderValue::from_str(&proxy_authorization)?;
         request.headers_mut().insert(PROXY_AUTHORIZATION, value);
     }
     Ok((request, body_completion))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_request, RequestBodyParts, RequestParts};
+    use hyper::header::{InvalidHeaderValue, PROXY_AUTHORIZATION};
+    use hyper::http::{method::InvalidMethod, uri::InvalidUri};
+
+    fn request_parts() -> RequestParts {
+        RequestParts {
+            method: "POST".to_owned(),
+            url: "http://example.com/echo".to_owned(),
+            headers: vec![("x-test".to_owned(), "value".to_owned())],
+            body: RequestBodyParts::Buffered(Some(vec![1, 2, 3])),
+            proxy_authorization: None,
+        }
+    }
+
+    #[test]
+    fn invalid_method_is_rejected_before_uri() {
+        let mut parts = request_parts();
+        parts.method = "NOT A METHOD".to_owned();
+        parts.url = "http://[".to_owned();
+        let error = build_request(parts, None).err().expect("invalid method");
+        assert!(error.is::<InvalidMethod>());
+        assert_eq!(error.to_string(), error.get_ref().to_string());
+    }
+
+    #[test]
+    fn invalid_uri_retains_parse_error() {
+        let mut parts = request_parts();
+        parts.url = "http://[".to_owned();
+        let error = build_request(parts, None).err().expect("invalid URI");
+        assert!(error.is::<InvalidUri>());
+        assert_eq!(error.to_string(), error.get_ref().to_string());
+    }
+
+    #[test]
+    fn invalid_proxy_authorization_retains_header_error() {
+        let mut parts = request_parts();
+        parts.proxy_authorization = Some("bad\r\nvalue".to_owned());
+        let error = build_request(parts, None)
+            .err()
+            .expect("invalid proxy header");
+        assert!(error.is::<InvalidHeaderValue>());
+    }
+
+    #[test]
+    fn valid_request_preserves_headers_body_and_completion() {
+        use http_body_util::BodyExt;
+
+        let mut parts = request_parts();
+        parts.proxy_authorization = Some("Basic dGVzdA==".to_owned());
+        let (request, completion) = build_request(parts, None).expect("valid request");
+        assert_eq!(request.method(), "POST");
+        assert_eq!(request.uri(), "http://example.com/echo");
+        assert_eq!(request.headers()["x-test"], "value");
+        assert_eq!(request.headers()[PROXY_AUTHORIZATION], "Basic dGVzdA==");
+        assert!(!completion.is_complete());
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let body = runtime.block_on(request.into_body().collect()).unwrap();
+        assert_eq!(body.to_bytes().as_ref(), &[1, 2, 3]);
+        assert!(!completion.is_complete());
+        completion.mark_transport_flushed();
+        assert!(completion.is_complete());
+    }
 }

--- a/src/core/response/body.rs
+++ b/src/core/response/body.rs
@@ -1,8 +1,6 @@
 use super::budget::{BufferedBodyBudget, BufferedBodyReservation};
-use crate::errors::FogHttpResponseBodyTooLargeError;
-use crate::messages::response_body_too_large;
+use super::ResponseBodyError;
 use hyper::body::{Body, Incoming};
-use pyo3::prelude::*;
 
 pub struct CollectedBody {
     pub content: Vec<u8>,
@@ -19,7 +17,7 @@ impl BufferedBodyCollector {
         body: &Incoming,
         max_response_body_size: Option<usize>,
         budget: &BufferedBodyBudget,
-    ) -> PyResult<Self> {
+    ) -> Result<Self, ResponseBodyError> {
         enforce_response_size_hint(body, max_response_body_size)?;
 
         Ok(Self {
@@ -31,7 +29,7 @@ impl BufferedBodyCollector {
         })
     }
 
-    pub fn push_data(&mut self, data: &[u8]) -> PyResult<()> {
+    pub fn push_data(&mut self, data: &[u8]) -> Result<(), ResponseBodyError> {
         enforce_response_body_limit(
             self.collected.content.len(),
             data.len(),
@@ -50,7 +48,7 @@ impl BufferedBodyCollector {
 fn enforce_response_size_hint(
     body: &Incoming,
     max_response_body_size: Option<usize>,
-) -> PyResult<()> {
+) -> Result<(), ResponseBodyError> {
     let Some(limit) = max_response_body_size else {
         return Ok(());
     };
@@ -59,7 +57,7 @@ fn enforce_response_size_hint(
     };
     let exceeds_limit = usize::try_from(upper_size_hint).map_or(true, |size| size > limit);
     if exceeds_limit {
-        return Err(response_body_limit_error(limit));
+        return Err(ResponseBodyError::TooLarge { limit });
     }
 
     Ok(())
@@ -69,21 +67,65 @@ pub(super) fn enforce_response_body_limit(
     current_size: usize,
     chunk_size: usize,
     max_response_body_size: Option<usize>,
-) -> PyResult<()> {
+) -> Result<(), ResponseBodyError> {
     let Some(limit) = max_response_body_size else {
         return Ok(());
     };
 
     let Some(next_size) = current_size.checked_add(chunk_size) else {
-        return Err(response_body_limit_error(limit));
+        return Err(ResponseBodyError::TooLarge { limit });
     };
     if next_size > limit {
-        return Err(response_body_limit_error(limit));
+        return Err(ResponseBodyError::TooLarge { limit });
     }
 
     Ok(())
 }
 
-fn response_body_limit_error(limit: usize) -> PyErr {
-    FogHttpResponseBodyTooLargeError::new_err(response_body_too_large(limit))
+#[cfg(test)]
+mod tests {
+    use super::{enforce_response_body_limit, BufferedBodyCollector, CollectedBody};
+    use crate::core::metrics::Metrics;
+    use crate::core::response::{BufferedBodyBudget, ResponseBodyError};
+    use std::sync::Arc;
+
+    #[test]
+    fn body_limit_handles_exact_zero_overflow_and_unbounded_sizes() {
+        assert!(enforce_response_body_limit(0, 0, Some(0)).is_ok());
+        assert!(enforce_response_body_limit(3, 5, Some(8)).is_ok());
+        assert!(enforce_response_body_limit(usize::MAX, 1, None).is_ok());
+        for (current, chunk, limit) in [(0, 1, 0), (3, 6, 8), (usize::MAX, 1, usize::MAX)] {
+            let error = enforce_response_body_limit(current, chunk, Some(limit)).unwrap_err();
+            assert!(
+                matches!(error, ResponseBodyError::TooLarge { limit: actual } if actual == limit)
+            );
+            assert_eq!(
+                error.to_string(),
+                crate::messages::response_body_too_large(limit)
+            );
+        }
+    }
+
+    #[test]
+    fn rejected_chunk_preserves_collected_bytes_until_drop_releases_reservation() {
+        let metrics = Arc::new(Metrics::default());
+        let budget = BufferedBodyBudget::new(Some(8), Arc::clone(&metrics));
+        let mut collector = BufferedBodyCollector {
+            collected: CollectedBody {
+                content: Vec::new(),
+                reservation: budget.start_response(),
+            },
+            max_response_body_size: Some(3),
+        };
+        collector.push_data(b"abc").unwrap();
+        assert!(matches!(
+            collector.push_data(b"d"),
+            Err(ResponseBodyError::TooLarge { limit: 3 })
+        ));
+        assert_eq!(collector.collected.content, b"abc");
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 3);
+        assert_eq!(metrics.snapshot().buffered_response_budget_rejections, 0);
+        drop(collector);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
+    }
 }

--- a/src/core/response/budget.rs
+++ b/src/core/response/budget.rs
@@ -1,7 +1,5 @@
+use super::ResponseBodyError;
 use crate::core::metrics::{BufferedByteReservationError, Metrics};
-use crate::errors::{FogHttpError, FogHttpResponseBodyBudgetExceededError};
-use crate::messages::buffered_response_body_budget_exceeded;
-use pyo3::prelude::*;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -30,7 +28,7 @@ impl BufferedBodyBudget {
         }
     }
 
-    fn reserve_bytes(&self, byte_count: usize) -> PyResult<()> {
+    fn reserve_bytes(&self, byte_count: usize) -> Result<(), ResponseBodyError> {
         match self
             .metrics
             .reserve_buffered_response_bytes(byte_count, self.max_buffered_response_bytes)
@@ -39,13 +37,11 @@ impl BufferedBodyBudget {
             Err(BufferedByteReservationError::LimitExceeded) => {
                 self.metrics.buffered_response_budget_rejected();
                 let limit = self.max_buffered_response_bytes.unwrap_or(0);
-                Err(FogHttpResponseBodyBudgetExceededError::new_err(
-                    buffered_response_body_budget_exceeded(limit),
-                ))
+                Err(ResponseBodyError::BudgetExceeded { limit })
             }
-            Err(BufferedByteReservationError::CounterOverflow) => Err(FogHttpError::new_err(
-                "buffered response byte counter overflow",
-            )),
+            Err(BufferedByteReservationError::CounterOverflow) => {
+                Err(ResponseBodyError::CounterOverflow)
+            }
         }
     }
 
@@ -55,11 +51,9 @@ impl BufferedBodyBudget {
 }
 
 impl BufferedBodyReservation {
-    pub fn reserve_chunk(&mut self, chunk_size: usize) -> PyResult<()> {
+    pub fn reserve_chunk(&mut self, chunk_size: usize) -> Result<(), ResponseBodyError> {
         let Some(next_reserved_bytes) = self.reserved_bytes.checked_add(chunk_size) else {
-            return Err(FogHttpError::new_err(
-                "buffered response byte reservation overflow",
-            ));
+            return Err(ResponseBodyError::ReservationOverflow);
         };
 
         self.budget.reserve_bytes(chunk_size)?;
@@ -67,15 +61,13 @@ impl BufferedBodyReservation {
         Ok(())
     }
 
-    pub fn release_chunk(&mut self, chunk_size: usize) -> PyResult<()> {
+    pub fn release_chunk(&mut self, chunk_size: usize) -> Result<(), ResponseBodyError> {
         if chunk_size == 0 {
             return Ok(());
         }
 
         let Some(next_reserved_bytes) = self.reserved_bytes.checked_sub(chunk_size) else {
-            return Err(FogHttpError::new_err(
-                "buffered response byte reservation underflow",
-            ));
+            return Err(ResponseBodyError::ReservationUnderflow);
         };
 
         self.budget.release_bytes(chunk_size);
@@ -94,6 +86,7 @@ impl Drop for BufferedBodyReservation {
 mod tests {
     use super::BufferedBodyBudget;
     use crate::core::metrics::Metrics;
+    use crate::core::response::ResponseBodyError;
     use std::sync::Arc;
 
     #[test]
@@ -115,10 +108,76 @@ mod tests {
         let mut reservation = budget.start_response();
 
         reservation.reserve_chunk(8).unwrap();
-        assert!(reservation.release_chunk(9).is_err());
+        assert!(matches!(
+            reservation.release_chunk(9),
+            Err(ResponseBodyError::ReservationUnderflow)
+        ));
         assert_eq!(metrics.snapshot().buffered_response_bytes, 8);
 
         drop(reservation);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
+    }
+
+    #[test]
+    fn rejected_budget_reservation_does_not_change_owned_bytes() {
+        let metrics = Arc::new(Metrics::default());
+        let budget = BufferedBodyBudget::new(Some(8), Arc::clone(&metrics));
+        let mut first = budget.start_response();
+        let mut second = budget.start_response();
+        first.reserve_chunk(5).unwrap();
+        second.reserve_chunk(3).unwrap();
+        assert!(matches!(
+            second.reserve_chunk(1),
+            Err(ResponseBodyError::BudgetExceeded { limit: 8 })
+        ));
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 8);
+        assert_eq!(metrics.snapshot().buffered_response_budget_rejections, 1);
+        drop(second);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 5);
+        drop(first);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
+        let mut next = budget.start_response();
+        next.reserve_chunk(8).unwrap();
+        drop(next);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
+    }
+
+    #[test]
+    fn zero_budget_accepts_empty_chunk_only() {
+        let metrics = Arc::new(Metrics::default());
+        let budget = BufferedBodyBudget::new(Some(0), Arc::clone(&metrics));
+        let mut reservation = budget.start_response();
+        reservation.reserve_chunk(0).unwrap();
+        reservation.release_chunk(0).unwrap();
+        assert!(matches!(
+            reservation.reserve_chunk(1),
+            Err(ResponseBodyError::BudgetExceeded { limit: 0 })
+        ));
+        drop(reservation);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
+        assert_eq!(metrics.snapshot().buffered_response_budget_rejections, 1);
+    }
+
+    #[test]
+    fn reservation_and_aggregate_overflows_leave_accounting_unchanged() {
+        let metrics = Arc::new(Metrics::default());
+        let budget = BufferedBodyBudget::new(None, Arc::clone(&metrics));
+        let mut first = budget.start_response();
+        let mut second = budget.start_response();
+        first.reserve_chunk(usize::MAX).unwrap();
+        assert!(matches!(
+            first.reserve_chunk(1),
+            Err(ResponseBodyError::ReservationOverflow)
+        ));
+        assert!(matches!(
+            second.reserve_chunk(1),
+            Err(ResponseBodyError::CounterOverflow)
+        ));
+        assert_eq!(metrics.snapshot().buffered_response_bytes, usize::MAX);
+        assert_eq!(metrics.snapshot().buffered_response_budget_rejections, 0);
+        drop(second);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, usize::MAX);
+        drop(first);
         assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
     }
 }

--- a/src/core/response/decompression.rs
+++ b/src/core/response/decompression.rs
@@ -1,11 +1,10 @@
 use super::body::{enforce_response_body_limit, CollectedBody};
+use super::ResponseBodyError;
 use crate::core::headers::HeaderPairs;
-use crate::errors::FogHttpError;
 use brotli::Decompressor;
 use flate2::read::{DeflateDecoder, MultiGzDecoder, ZlibDecoder};
 use hyper::header::CONTENT_ENCODING;
 use hyper::HeaderMap;
-use pyo3::prelude::*;
 use std::io::{Cursor, Read};
 
 const DECODE_BUFFER_SIZE: usize = 8192;
@@ -45,7 +44,7 @@ pub fn decode_body(
     collected: CollectedBody,
     decoding_plan: ResponseBodyDecodingPlan,
     max_response_body_size: Option<usize>,
-) -> PyResult<ResponseBody> {
+) -> Result<ResponseBody, ResponseBodyError> {
     match decoding_plan.plan {
         ContentCodingPlan::Decode(codings) => {
             decode_supported_body(collected, codings.as_slice(), max_response_body_size)
@@ -107,7 +106,7 @@ fn decode_supported_body(
     mut body: CollectedBody,
     codings: &[ContentCoding],
     max_response_body_size: Option<usize>,
-) -> PyResult<ResponseBody> {
+) -> Result<ResponseBody, ResponseBodyError> {
     let mut content = std::mem::take(&mut body.content);
     for coding in codings.iter().rev().copied() {
         let encoded_size = content.len();
@@ -132,7 +131,7 @@ fn decode_content_coding(
     content: &[u8],
     max_response_body_size: Option<usize>,
     reservation: &mut super::BufferedBodyReservation,
-) -> PyResult<Vec<u8>> {
+) -> Result<Vec<u8>, ResponseBodyError> {
     match coding {
         ContentCoding::Gzip => decode_reader(
             coding,
@@ -154,7 +153,7 @@ fn decode_deflate(
     content: &[u8],
     max_response_body_size: Option<usize>,
     reservation: &mut super::BufferedBodyReservation,
-) -> PyResult<Vec<u8>> {
+) -> Result<Vec<u8>, ResponseBodyError> {
     match decode_reader_result(
         ZlibDecoder::new(Cursor::new(content)),
         max_response_body_size,
@@ -176,14 +175,14 @@ fn decode_reader<R: Read>(
     reader: R,
     max_response_body_size: Option<usize>,
     reservation: &mut super::BufferedBodyReservation,
-) -> PyResult<Vec<u8>> {
+) -> Result<Vec<u8>, ResponseBodyError> {
     decode_reader_result(reader, max_response_body_size, reservation)
         .map_err(|err| decode_attempt_error(coding, err))
 }
 
 enum DecodeAttemptError {
     Read(std::io::Error),
-    Runtime(PyErr),
+    Runtime(ResponseBodyError),
 }
 
 fn decode_reader_result<R: Read>(
@@ -225,21 +224,21 @@ fn decode_reader_result<R: Read>(
             if let Err(release_error) = reservation.release_chunk(attempt_reserved) {
                 return Err(DecodeAttemptError::Runtime(release_error));
             }
-            return Err(DecodeAttemptError::Runtime(FogHttpError::new_err(
-                "decoded response byte reservation overflow",
-            )));
+            return Err(DecodeAttemptError::Runtime(
+                ResponseBodyError::DecodeReservationOverflow,
+            ));
         };
         attempt_reserved = next_attempt_reserved;
         decoded.extend_from_slice(&buffer[..read]);
     }
 }
 
-fn decode_attempt_error(coding: ContentCoding, err: DecodeAttemptError) -> PyErr {
+fn decode_attempt_error(coding: ContentCoding, err: DecodeAttemptError) -> ResponseBodyError {
     match err {
-        DecodeAttemptError::Read(err) => FogHttpError::new_err(format!(
-            "failed to decode {} response body: {err}",
-            content_coding_name(coding),
-        )),
+        DecodeAttemptError::Read(source) => ResponseBodyError::Decode {
+            coding: content_coding_name(coding),
+            source,
+        },
         DecodeAttemptError::Runtime(err) => err,
     }
 }
@@ -260,8 +259,19 @@ fn decoded_body_header(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{content_coding_plan, decoded_response_headers, ContentCoding, ContentCodingPlan};
+    use super::{
+        decode_body, decode_content_coding, decode_deflate, decode_reader,
+        response_body_decoding_plan, CollectedBody,
+    };
+    use crate::core::metrics::Metrics;
+    use crate::core::response::{BufferedBodyBudget, ResponseBodyError};
+    use flate2::write::{DeflateEncoder, ZlibEncoder};
+    use flate2::Compression;
     use hyper::header::{HeaderValue, CONTENT_ENCODING};
     use hyper::HeaderMap;
+    use std::error::Error;
+    use std::io::{self, Cursor, Read, Write};
+    use std::sync::Arc;
 
     fn content_encoding_headers(values: &[&'static str]) -> HeaderMap {
         let mut headers = HeaderMap::new();
@@ -320,5 +330,124 @@ mod tests {
                 ("x-trace".to_owned(), "abc".to_owned()),
             ],
         );
+    }
+
+    #[test]
+    fn invalid_codings_retain_io_source_and_release_reserved_bytes() {
+        for coding in [
+            ContentCoding::Gzip,
+            ContentCoding::Deflate,
+            ContentCoding::Brotli,
+        ] {
+            let metrics = Arc::new(Metrics::default());
+            let budget = BufferedBodyBudget::new(None, Arc::clone(&metrics));
+            let mut reservation = budget.start_response();
+            reservation.reserve_chunk(16).unwrap();
+            let error = decode_content_coding(coding, &[0xff; 16], None, &mut reservation)
+                .expect_err("invalid compressed body");
+            assert!(
+                matches!(&error, ResponseBodyError::Decode { coding: name, .. } if *name == super::content_coding_name(coding))
+            );
+            assert!(error.source().unwrap().is::<io::Error>());
+            assert_eq!(metrics.snapshot().buffered_response_bytes, 16);
+            drop(reservation);
+            assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
+        }
+    }
+
+    #[test]
+    fn raw_deflate_fallback_keeps_only_decoded_reservation() {
+        let content = b"raw deflate response";
+        let mut compressor = DeflateEncoder::new(Vec::new(), Compression::default());
+        compressor.write_all(content).unwrap();
+        let encoded = compressor.finish().unwrap();
+        let metrics = Arc::new(Metrics::default());
+        let budget = BufferedBodyBudget::new(None, Arc::clone(&metrics));
+        let mut reservation = budget.start_response();
+        reservation.reserve_chunk(encoded.len()).unwrap();
+        let response = decode_body(
+            CollectedBody {
+                content: encoded,
+                reservation,
+            },
+            response_body_decoding_plan(&content_encoding_headers(&["deflate"])),
+            None,
+        )
+        .expect("raw deflate fallback");
+        assert_eq!(response.content, content);
+        assert!(response.decoded);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, content.len());
+        drop(response);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
+    }
+
+    #[test]
+    fn deflate_limits_do_not_fall_back_or_leak_attempt_bytes() {
+        let content = vec![b'x'; super::DECODE_BUFFER_SIZE + 1];
+        let mut compressor = ZlibEncoder::new(Vec::new(), Compression::default());
+        compressor.write_all(&content).unwrap();
+        let encoded = compressor.finish().unwrap();
+        for size_limited in [true, false] {
+            let metrics = Arc::new(Metrics::default());
+            let budget_limit = encoded.len() + super::DECODE_BUFFER_SIZE;
+            let budget = BufferedBodyBudget::new(
+                (!size_limited).then_some(budget_limit),
+                Arc::clone(&metrics),
+            );
+            let mut reservation = budget.start_response();
+            reservation.reserve_chunk(encoded.len()).unwrap();
+            let error = decode_deflate(
+                &encoded,
+                size_limited.then_some(super::DECODE_BUFFER_SIZE),
+                &mut reservation,
+            )
+            .expect_err("decoded limit");
+            if size_limited {
+                assert!(
+                    matches!(error, ResponseBodyError::TooLarge { limit } if limit == super::DECODE_BUFFER_SIZE)
+                );
+                assert_eq!(metrics.snapshot().buffered_response_budget_rejections, 0);
+            } else {
+                assert!(
+                    matches!(error, ResponseBodyError::BudgetExceeded { limit } if limit == budget_limit)
+                );
+                assert_eq!(metrics.snapshot().buffered_response_budget_rejections, 1);
+            }
+            assert_eq!(metrics.snapshot().buffered_response_bytes, encoded.len());
+            drop(reservation);
+            assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
+        }
+    }
+
+    struct FailedRead;
+
+    impl Read for FailedRead {
+        fn read(&mut self, _buffer: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::InvalidData, "broken payload"))
+        }
+    }
+
+    #[test]
+    fn decode_read_error_rolls_back_partial_output_and_preserves_source() {
+        let metrics = Arc::new(Metrics::default());
+        let budget = BufferedBodyBudget::new(None, Arc::clone(&metrics));
+        let mut reservation = budget.start_response();
+        reservation.reserve_chunk(7).unwrap();
+        let error = decode_reader(
+            ContentCoding::Gzip,
+            Cursor::new(b"partial").chain(FailedRead),
+            None,
+            &mut reservation,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "failed to decode gzip response body: broken payload"
+        );
+        let source = error.source().unwrap().downcast_ref::<io::Error>().unwrap();
+        assert_eq!(source.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 7);
+        drop(reservation);
+        assert_eq!(metrics.snapshot().buffered_response_bytes, 0);
     }
 }

--- a/src/core/response/error.rs
+++ b/src/core/response/error.rs
@@ -1,0 +1,58 @@
+use crate::messages::{buffered_response_body_budget_exceeded, response_body_too_large};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::io;
+
+#[derive(Debug)]
+pub enum ResponseBodyError {
+    TooLarge {
+        limit: usize,
+    },
+    BudgetExceeded {
+        limit: usize,
+    },
+    CounterOverflow,
+    ReservationOverflow,
+    ReservationUnderflow,
+    DecodeReservationOverflow,
+    Decode {
+        coding: &'static str,
+        source: io::Error,
+    },
+}
+
+impl Display for ResponseBodyError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooLarge { limit } => formatter.write_str(&response_body_too_large(*limit)),
+            Self::BudgetExceeded { limit } => {
+                formatter.write_str(&buffered_response_body_budget_exceeded(*limit))
+            }
+            Self::CounterOverflow => formatter.write_str("buffered response byte counter overflow"),
+            Self::ReservationOverflow => {
+                formatter.write_str("buffered response byte reservation overflow")
+            }
+            Self::ReservationUnderflow => {
+                formatter.write_str("buffered response byte reservation underflow")
+            }
+            Self::DecodeReservationOverflow => {
+                formatter.write_str("decoded response byte reservation overflow")
+            }
+            Self::Decode { coding, source } => {
+                write!(
+                    formatter,
+                    "failed to decode {coding} response body: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for ResponseBodyError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Decode { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}

--- a/src/core/response/mod.rs
+++ b/src/core/response/mod.rs
@@ -1,7 +1,9 @@
 mod body;
 mod budget;
 mod decompression;
+mod error;
 
 pub use body::{BufferedBodyCollector, CollectedBody};
 pub use budget::{BufferedBodyBudget, BufferedBodyReservation};
 pub use decompression::{decode_body, decoded_response_headers, response_body_decoding_plan};
+pub use error::ResponseBodyError;

--- a/src/py/client/transport/body.rs
+++ b/src/py/client/transport/body.rs
@@ -1,4 +1,5 @@
 use super::context::RawResponseContext;
+use super::errors::response_body_error;
 use crate::core::client::RequestBodyCompletion;
 use crate::core::response::{BufferedBodyCollector, CollectedBody};
 use crate::messages::{REQUEST_TOTAL_TIMEOUT, RESPONSE_BODY_READ_TIMEOUT};
@@ -32,7 +33,8 @@ pub(super) async fn collect_response_body(
         &body,
         context.max_response_body_size,
         &context.buffered_body_budget,
-    )?;
+    )
+    .map_err(|error| response_body_error(&error))?;
 
     while let Some(frame) = next_response_body_frame(&mut body, context, read_timeout).await? {
         let frame = frame.map_err(|error| {
@@ -47,7 +49,9 @@ pub(super) async fn collect_response_body(
             continue;
         };
 
-        collector.push_data(&data)?;
+        collector
+            .push_data(&data)
+            .map_err(|error| response_body_error(&error))?;
     }
 
     Ok(collector.finish())

--- a/src/py/client/transport/errors.rs
+++ b/src/py/client/transport/errors.rs
@@ -2,8 +2,12 @@ use crate::core::client::{
     connection_acquire_timeout_from_error, request_write_timeout_from_error,
 };
 use crate::core::policy::{PolicyError, SsrfViolation};
+use crate::core::response::ResponseBodyError;
 use crate::core::telemetry::TelemetryErrorType;
-use crate::errors::{transport_error_message, FogHttpError, FogHttpNetworkError, FogHttpSsrfError};
+use crate::errors::{
+    transport_error_message, FogHttpError, FogHttpNetworkError,
+    FogHttpResponseBodyBudgetExceededError, FogHttpResponseBodyTooLargeError, FogHttpSsrfError,
+};
 use crate::messages::CONNECTION_ACQUIRE_TIMEOUT;
 use crate::py::client::timeout_diagnostics::{
     connection_acquire_timeout_error, write_timeout_error,
@@ -17,6 +21,22 @@ pub(super) fn policy_error(error: &PolicyError) -> PyErr {
         return ssrf_error(violation);
     }
     FogHttpError::new_err(error.to_string())
+}
+
+pub(super) fn response_body_error(error: &ResponseBodyError) -> PyErr {
+    match error {
+        ResponseBodyError::TooLarge { .. } => {
+            FogHttpResponseBodyTooLargeError::new_err(error.to_string())
+        }
+        ResponseBodyError::BudgetExceeded { .. } => {
+            FogHttpResponseBodyBudgetExceededError::new_err(error.to_string())
+        }
+        ResponseBodyError::CounterOverflow
+        | ResponseBodyError::ReservationOverflow
+        | ResponseBodyError::ReservationUnderflow
+        | ResponseBodyError::DecodeReservationOverflow
+        | ResponseBodyError::Decode { .. } => FogHttpError::new_err(error.to_string()),
+    }
 }
 
 pub(super) fn transport_error(error: &(dyn Error + 'static)) -> PyErr {

--- a/src/py/client/transport/request.rs
+++ b/src/py/client/transport/request.rs
@@ -725,7 +725,8 @@ pub(super) async fn send_current_hop(
     let (mut request, request_body_completion) = build_request(
         state.take_request_parts(route)?,
         write_timeout_context.clone(),
-    )?;
+    )
+    .map_err(|error| FogHttpError::new_err(error.to_string()))?;
     let request_telemetry = current_request_telemetry();
     let mut captured_connection = Some(CapturedConnectionUse::new(
         capture_connection(&mut request),

--- a/src/py/client/transport/response.rs
+++ b/src/py/client/transport/response.rs
@@ -1,5 +1,6 @@
 use super::body::{collect_response_body, drain_response_body, response_body_can_be_decoded};
 use super::context::{RawResponseContext, RawStreamResponseContext};
+use super::errors::response_body_error;
 use crate::core::client::{ConnectionAbortReason, ConnectionUseGuard};
 use crate::core::headers::HeaderPairs;
 use crate::core::metrics::{Metrics, OriginMetrics, ResponseBodyLifecycleOutcome};
@@ -119,7 +120,8 @@ pub(super) async fn raw_response(
     };
     lifecycle.finish_connection();
     let (headers, response_content, body_reservation) = if let Some(decoding_plan) = decoding_plan {
-        let body = decode_body(collected, decoding_plan, context.max_response_body_size)?;
+        let body = decode_body(collected, decoding_plan, context.max_response_body_size)
+            .map_err(|error| response_body_error(&error))?;
         (
             decoded_response_headers(headers, body.decoded),
             body.content,

--- a/src/py/client/transport/tests.rs
+++ b/src/py/client/transport/tests.rs
@@ -1,14 +1,18 @@
+use super::errors::response_body_error;
 use super::request::{PendingResponsePolicyAction, RequestState, TransportRequest};
 use crate::core::headers::HeaderPairs;
 use crate::core::method::{GET, POST};
 use crate::core::metrics::Metrics;
 use crate::core::policy::TransportRoute;
-use crate::core::response::BufferedBodyBudget;
+use crate::core::response::{BufferedBodyBudget, ResponseBodyError};
+use crate::errors::{
+    FogHttpError, FogHttpResponseBodyBudgetExceededError, FogHttpResponseBodyTooLargeError,
+};
 use crate::messages::{
     NON_REPLAYABLE_REQUEST_BODY_REDIRECT, PROXY_REDIRECT_POLICY_RECOMPUTE_UNSUPPORTED,
 };
 use hyper::StatusCode;
-use pyo3::Python;
+use pyo3::prelude::*;
 use std::sync::{Arc, Once};
 use tokio::runtime::Builder;
 
@@ -20,6 +24,60 @@ const WRITE_TIMEOUT: f64 = 2.0;
 fn initialize_python() {
     static PYTHON: Once = Once::new();
     PYTHON.call_once(Python::initialize);
+}
+
+#[test]
+fn response_body_errors_keep_native_exception_types_and_arguments() {
+    initialize_python();
+    Python::attach(|py| {
+        let cases = [
+            (
+                ResponseBodyError::TooLarge { limit: 8 },
+                py.get_type::<FogHttpResponseBodyTooLargeError>(),
+                "response body exceeded max_response_body_size of 8 bytes",
+            ),
+            (
+                ResponseBodyError::BudgetExceeded { limit: 9 },
+                py.get_type::<FogHttpResponseBodyBudgetExceededError>(),
+                "buffered response bodies exceeded max_buffered_response_bytes of 9 bytes",
+            ),
+            (
+                ResponseBodyError::CounterOverflow,
+                py.get_type::<FogHttpError>(),
+                "buffered response byte counter overflow",
+            ),
+            (
+                ResponseBodyError::ReservationOverflow,
+                py.get_type::<FogHttpError>(),
+                "buffered response byte reservation overflow",
+            ),
+            (
+                ResponseBodyError::ReservationUnderflow,
+                py.get_type::<FogHttpError>(),
+                "buffered response byte reservation underflow",
+            ),
+            (
+                ResponseBodyError::DecodeReservationOverflow,
+                py.get_type::<FogHttpError>(),
+                "decoded response byte reservation overflow",
+            ),
+            (
+                ResponseBodyError::Decode {
+                    coding: "gzip",
+                    source: std::io::Error::new(std::io::ErrorKind::InvalidData, "broken payload"),
+                },
+                py.get_type::<FogHttpError>(),
+                "failed to decode gzip response body: broken payload",
+            ),
+        ];
+        for (error, expected_type, message) in cases {
+            let mapped = response_body_error(&error);
+            assert!(mapped.get_type(py).is(&expected_type));
+            assert!(mapped.is_instance_of::<FogHttpError>(py));
+            let args: (String,) = mapped.value(py).getattr("args").unwrap().extract().unwrap();
+            assert_eq!(args, (message.to_owned(),));
+        }
+    });
 }
 
 #[test]

--- a/tests/client_options/test_raw_numeric_boundary.py
+++ b/tests/client_options/test_raw_numeric_boundary.py
@@ -1,3 +1,4 @@
+from contextlib import closing
 import math
 from types import SimpleNamespace
 
@@ -7,6 +8,7 @@ import pytest
 from foghttp import _foghttp
 from foghttp._client.proxy import ProxyTransportPolicy
 from foghttp.methods import GET
+from foghttp.status_codes.success import OK
 
 from .raw_options import raw_client_options
 
@@ -16,6 +18,11 @@ REQUEST_BODY_REPLAYABLE = True
 BODY_STREAM = None
 USE_PROXY_TRANSPORT = False
 PROXY_TRANSPORT_POLICY = ProxyTransportPolicy.DIRECT.value
+INVALID_REQUEST_CASES = (
+    pytest.param({"method": "NOT A METHOD"}, "invalid HTTP method", id="method"),
+    pytest.param({"headers": [("bad name", "value")]}, "invalid HTTP header name", id="header-name"),
+    pytest.param({"headers": [("x-test", "bad\r\nvalue")]}, "failed to parse header value", id="header-value"),
+)
 
 
 def test_raw_client_rejects_positional_constructor_arguments() -> None:
@@ -225,6 +232,46 @@ async def test_raw_client_async_request_rejects_invalid_timeout_without_panic(
             raw_client.request_async(**_raw_request_options(url=faker.url(), total_timeout=math.inf))
     finally:
         raw_client.close()
+
+
+@pytest.mark.parametrize(("overrides", "message"), INVALID_REQUEST_CASES)
+@pytest.mark.parametrize("request_method", ["request", "request_stream"])
+def test_raw_sync_request_errors_preserve_type_and_release_slot(
+    sync_http_server: str,
+    request_method: str,
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with closing(_raw_client()) as raw_client:
+        options = _raw_request_options(url=sync_http_server)
+        options.update(overrides)
+        with pytest.raises(_foghttp.FogHttpError, match=message) as exc_info:
+            getattr(raw_client, request_method)(**options)
+        assert type(exc_info.value) is _foghttp.FogHttpError
+        assert exc_info.value.args == (message,)
+        assert raw_client.stats().active_requests == 0
+        response = raw_client.request(**_raw_request_options(url=sync_http_server))
+        assert response.status_code == OK
+
+
+@pytest.mark.parametrize(("overrides", "message"), INVALID_REQUEST_CASES)
+@pytest.mark.parametrize("request_method", ["request_async", "request_stream_async"])
+async def test_raw_async_request_errors_preserve_type_and_release_slot(
+    sync_http_server: str,
+    request_method: str,
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with closing(_raw_client()) as raw_client:
+        options = _raw_request_options(url=sync_http_server)
+        options.update(overrides)
+        with pytest.raises(_foghttp.FogHttpError, match=message) as exc_info:
+            await getattr(raw_client, request_method)(**options)
+        assert type(exc_info.value) is _foghttp.FogHttpError
+        assert exc_info.value.args == (message,)
+        assert raw_client.stats().active_requests == 0
+        response = await raw_client.request_async(**_raw_request_options(url=sync_http_server))
+        assert response.status_code == OK
 
 
 def _raw_client() -> _foghttp.RawClient:

--- a/tests/response_decompression/test_async_response_decompression.py
+++ b/tests/response_decompression/test_async_response_decompression.py
@@ -1,6 +1,13 @@
 import pytest
 
-import foghttp
+from foghttp import (
+    AsyncClient,
+    Limits,
+    RequestError,
+    ResponseBodyBudgetExceededError,
+    ResponseBodyTooLargeError,
+    _foghttp,
+)
 from foghttp.status_codes.success import OK, RESET_CONTENT
 
 from .constants import (
@@ -31,7 +38,7 @@ async def test_async_buffered_response_decodes_supported_content_encoding(
     response_decompression_server: ResponseDecompressionServer,
     path: str,
 ) -> None:
-    async with foghttp.AsyncClient() as client:
+    async with AsyncClient() as client:
         response = await client.get(f"{response_decompression_server.url}{path}")
         stats = client.stats()
 
@@ -48,7 +55,7 @@ async def test_async_buffered_response_decodes_supported_content_encoding(
 async def test_async_buffered_response_leaves_unsupported_content_encoding_encoded(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    async with foghttp.AsyncClient() as client:
+    async with AsyncClient() as client:
         response = await client.get(
             f"{response_decompression_server.url}{UNSUPPORTED_ENCODING_PATH}",
         )
@@ -62,7 +69,7 @@ async def test_async_buffered_response_leaves_unsupported_content_encoding_encod
 async def test_async_buffered_response_decodes_multiple_content_encoding_fields(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    async with foghttp.AsyncClient() as client:
+    async with AsyncClient() as client:
         response = await client.get(
             f"{response_decompression_server.url}{MULTIPLE_ENCODING_FIELDS_PATH}",
         )
@@ -81,7 +88,7 @@ async def test_async_head_response_preserves_encoded_body_metadata(
 ) -> None:
     encoded_body = compressed_body(GZIP_ENCODING_PATH)
 
-    async with foghttp.AsyncClient() as client:
+    async with AsyncClient() as client:
         response = await client.head(f"{response_decompression_server.url}{GZIP_ENCODING_PATH}")
         stats = client.stats()
 
@@ -96,7 +103,7 @@ async def test_async_head_response_preserves_encoded_body_metadata(
 async def test_async_reset_content_response_preserves_encoded_body_metadata(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    async with foghttp.AsyncClient() as client:
+    async with AsyncClient() as client:
         response = await client.get(f"{response_decompression_server.url}{RESET_CONTENT_PATH}")
         stats = client.stats()
 
@@ -111,14 +118,20 @@ async def test_async_reset_content_response_preserves_encoded_body_metadata(
 async def test_async_buffered_response_rejects_invalid_encoded_body(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    async with foghttp.AsyncClient() as client:
-        with pytest.raises(foghttp.RequestError, match="failed to decode gzip response body"):
+    async with AsyncClient() as client:
+        with pytest.raises(RequestError, match="failed to decode gzip response body") as exc_info:
             await client.get(f"{response_decompression_server.url}{INVALID_GZIP_PATH}")
 
         stats = client.stats()
+        response = await client.get(f"{response_decompression_server.url}{UNSUPPORTED_ENCODING_PATH}")
+        assert response.content == UNSUPPORTED_ENCODED_BODY
+        assert client.stats().buffered_response_bytes == 0
+        assert client.stats().active_requests == 0
 
     assert stats.total_requests == 1
     assert stats.failed_requests == 1
+    assert type(exc_info.value.__cause__) is _foghttp.FogHttpError
+    assert exc_info.value.__cause__.args == (str(exc_info.value),)
     assert stats.response_body_aborted == 1
     assert stats.active_connections == 0
     assert stats.idle_connections == 0
@@ -131,16 +144,23 @@ async def test_async_buffered_response_rejects_invalid_encoded_body(
 async def test_async_buffered_response_limit_applies_to_decoded_body(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    limits = foghttp.Limits(max_response_body_size=DECODED_BODY_LIMIT)
+    limits = Limits(max_response_body_size=DECODED_BODY_LIMIT)
 
-    async with foghttp.AsyncClient(limits=limits) as client:
+    async with AsyncClient(limits=limits) as client:
         with pytest.raises(
-            foghttp.ResponseBodyTooLargeError,
+            ResponseBodyTooLargeError,
             match="response body exceeded max_response_body_size",
-        ):
+        ) as exc_info:
             await client.get(f"{response_decompression_server.url}{DECODED_TOO_LARGE_PATH}")
 
+        assert type(exc_info.value.__cause__) is _foghttp.FogHttpResponseBodyTooLargeError
+        assert exc_info.value.__cause__.args == (str(exc_info.value),)
+
         stats = client.stats()
+        response = await client.get(f"{response_decompression_server.url}{UNSUPPORTED_ENCODING_PATH}")
+        assert response.content == UNSUPPORTED_ENCODED_BODY
+        assert client.stats().buffered_response_bytes == 0
+        assert client.stats().active_requests == 0
 
     assert stats.total_requests == 1
     assert stats.failed_requests == 1
@@ -150,19 +170,26 @@ async def test_async_buffered_response_limit_applies_to_decoded_body(
 async def test_async_buffered_response_budget_applies_while_decoding(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    limits = foghttp.Limits(
+    limits = Limits(
         max_response_body_size=len(DECODED_TOO_LARGE_BODY),
         max_buffered_response_bytes=budget_below_decoding_transient_size(),
     )
 
-    async with foghttp.AsyncClient(limits=limits) as client:
+    async with AsyncClient(limits=limits) as client:
         with pytest.raises(
-            foghttp.ResponseBodyBudgetExceededError,
+            ResponseBodyBudgetExceededError,
             match="buffered response bodies exceeded max_buffered_response_bytes",
-        ):
+        ) as exc_info:
             await client.get(f"{response_decompression_server.url}{DECODED_TOO_LARGE_PATH}")
 
+        assert type(exc_info.value.__cause__) is _foghttp.FogHttpResponseBodyBudgetExceededError
+        assert exc_info.value.__cause__.args == (str(exc_info.value),)
+
         stats = client.stats()
+        response = await client.get(f"{response_decompression_server.url}{UNSUPPORTED_ENCODING_PATH}")
+        assert response.content == UNSUPPORTED_ENCODED_BODY
+        assert client.stats().buffered_response_bytes == 0
+        assert client.stats().active_requests == 0
 
     assert stats.total_requests == 1
     assert stats.failed_requests == 1

--- a/tests/response_decompression/test_sync_response_decompression.py
+++ b/tests/response_decompression/test_sync_response_decompression.py
@@ -1,6 +1,13 @@
 import pytest
 
-import foghttp
+from foghttp import (
+    Client,
+    Limits,
+    RequestError,
+    ResponseBodyBudgetExceededError,
+    ResponseBodyTooLargeError,
+    _foghttp,
+)
 from foghttp.status_codes.success import OK, RESET_CONTENT
 
 from .constants import (
@@ -31,7 +38,7 @@ def test_sync_buffered_response_decodes_supported_content_encoding(
     response_decompression_server: ResponseDecompressionServer,
     path: str,
 ) -> None:
-    with foghttp.Client() as client:
+    with Client() as client:
         response = client.get(f"{response_decompression_server.url}{path}")
         stats = client.stats()
 
@@ -48,7 +55,7 @@ def test_sync_buffered_response_decodes_supported_content_encoding(
 def test_sync_buffered_response_leaves_unsupported_content_encoding_encoded(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    with foghttp.Client() as client:
+    with Client() as client:
         response = client.get(
             f"{response_decompression_server.url}{UNSUPPORTED_ENCODING_PATH}",
         )
@@ -62,7 +69,7 @@ def test_sync_buffered_response_leaves_unsupported_content_encoding_encoded(
 def test_sync_buffered_response_decodes_multiple_content_encoding_fields(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    with foghttp.Client() as client:
+    with Client() as client:
         response = client.get(
             f"{response_decompression_server.url}{MULTIPLE_ENCODING_FIELDS_PATH}",
         )
@@ -81,7 +88,7 @@ def test_sync_head_response_preserves_encoded_body_metadata(
 ) -> None:
     encoded_body = compressed_body(GZIP_ENCODING_PATH)
 
-    with foghttp.Client() as client:
+    with Client() as client:
         response = client.head(f"{response_decompression_server.url}{GZIP_ENCODING_PATH}")
         stats = client.stats()
 
@@ -96,7 +103,7 @@ def test_sync_head_response_preserves_encoded_body_metadata(
 def test_sync_reset_content_response_preserves_encoded_body_metadata(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    with foghttp.Client() as client:
+    with Client() as client:
         response = client.get(f"{response_decompression_server.url}{RESET_CONTENT_PATH}")
         stats = client.stats()
 
@@ -111,14 +118,20 @@ def test_sync_reset_content_response_preserves_encoded_body_metadata(
 def test_sync_buffered_response_rejects_invalid_encoded_body(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    with foghttp.Client() as client:
-        with pytest.raises(foghttp.RequestError, match="failed to decode gzip response body"):
+    with Client() as client:
+        with pytest.raises(RequestError, match="failed to decode gzip response body") as exc_info:
             client.get(f"{response_decompression_server.url}{INVALID_GZIP_PATH}")
 
         stats = client.stats()
+        response = client.get(f"{response_decompression_server.url}{UNSUPPORTED_ENCODING_PATH}")
+        assert response.content == UNSUPPORTED_ENCODED_BODY
+        assert client.stats().buffered_response_bytes == 0
+        assert client.stats().active_requests == 0
 
     assert stats.total_requests == 1
     assert stats.failed_requests == 1
+    assert type(exc_info.value.__cause__) is _foghttp.FogHttpError
+    assert exc_info.value.__cause__.args == (str(exc_info.value),)
     assert stats.response_body_aborted == 1
     assert stats.active_connections == 0
     assert stats.idle_connections == 0
@@ -131,16 +144,23 @@ def test_sync_buffered_response_rejects_invalid_encoded_body(
 def test_sync_buffered_response_limit_applies_to_decoded_body(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    limits = foghttp.Limits(max_response_body_size=DECODED_BODY_LIMIT)
+    limits = Limits(max_response_body_size=DECODED_BODY_LIMIT)
 
-    with foghttp.Client(limits=limits) as client:
+    with Client(limits=limits) as client:
         with pytest.raises(
-            foghttp.ResponseBodyTooLargeError,
+            ResponseBodyTooLargeError,
             match="response body exceeded max_response_body_size",
-        ):
+        ) as exc_info:
             client.get(f"{response_decompression_server.url}{DECODED_TOO_LARGE_PATH}")
 
+        assert type(exc_info.value.__cause__) is _foghttp.FogHttpResponseBodyTooLargeError
+        assert exc_info.value.__cause__.args == (str(exc_info.value),)
+
         stats = client.stats()
+        response = client.get(f"{response_decompression_server.url}{UNSUPPORTED_ENCODING_PATH}")
+        assert response.content == UNSUPPORTED_ENCODED_BODY
+        assert client.stats().buffered_response_bytes == 0
+        assert client.stats().active_requests == 0
 
     assert stats.total_requests == 1
     assert stats.failed_requests == 1
@@ -150,19 +170,26 @@ def test_sync_buffered_response_limit_applies_to_decoded_body(
 def test_sync_buffered_response_budget_applies_while_decoding(
     response_decompression_server: ResponseDecompressionServer,
 ) -> None:
-    limits = foghttp.Limits(
+    limits = Limits(
         max_response_body_size=len(DECODED_TOO_LARGE_BODY),
         max_buffered_response_bytes=budget_below_decoding_transient_size(),
     )
 
-    with foghttp.Client(limits=limits) as client:
+    with Client(limits=limits) as client:
         with pytest.raises(
-            foghttp.ResponseBodyBudgetExceededError,
+            ResponseBodyBudgetExceededError,
             match="buffered response bodies exceeded max_buffered_response_bytes",
-        ):
+        ) as exc_info:
             client.get(f"{response_decompression_server.url}{DECODED_TOO_LARGE_PATH}")
 
+        assert type(exc_info.value.__cause__) is _foghttp.FogHttpResponseBodyBudgetExceededError
+        assert exc_info.value.__cause__.args == (str(exc_info.value),)
+
         stats = client.stats()
+        response = client.get(f"{response_decompression_server.url}{UNSUPPORTED_ENCODING_PATH}")
+        assert response.content == UNSUPPORTED_ENCODED_BODY
+        assert client.stats().buffered_response_bytes == 0
+        assert client.stats().active_requests == 0
 
     assert stats.total_requests == 1
     assert stats.failed_requests == 1


### PR DESCRIPTION
- return native Rust errors from request and response core
- preserve Python exception mapping and resource lifecycle semantics
- add Rust and sync/async boundary regression tests
- document error ownership at the PyO3 boundary

Refs #4